### PR TITLE
[TECHNICAL-SUPPORT] LPS-42109 Use localized title instead of name

### DIFF
--- a/portal-web/docroot/html/portlet/search/init.jsp
+++ b/portal-web/docroot/html/portlet/search/init.jsp
@@ -112,7 +112,7 @@ private String _buildAssetCategoryPath(AssetCategory assetCategory, Locale local
 	List<AssetCategory> assetCategories = assetCategory.getAncestors();
 
 	if (assetCategories.isEmpty()) {
-		return HtmlUtil.escape(assetCategory.getName());
+		return HtmlUtil.escape(assetCategory.getTitle(locale));
 	}
 
 	Collections.reverse(assetCategories);
@@ -124,7 +124,7 @@ private String _buildAssetCategoryPath(AssetCategory assetCategory, Locale local
 		sb.append(" &raquo; ");
 	}
 
-	sb.append(HtmlUtil.escape(assetCategory.getName()));
+	sb.append(HtmlUtil.escape(assetCategory.getTitle(locale)));
 
 	return sb.toString();
 }


### PR DESCRIPTION
Hi Eudaldo,

this small fix is about category localization in the Search portlet.
I checked the asset_vocabulary.jsp, where a very similar issue can occur, however I saw that we don't have the option on the UI to enable it. I managed to enable the vocabulary facet through the Search portlet advanced configuration, but I doubt that any our customer will do that, so I'm not sure whether it is worth to deal with this situation in the current issue. 

Could you please review the changes?

Thanks,
Tamás
