### PR TITLE
[Regression] LPS-44511 Possible XSS in search results if "index.search.highlight.enabled=false"

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/search/Summary.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Summary.java
@@ -131,9 +131,11 @@ public class Summary {
 			text = SearchUtil.highlight(
 				text, _queryTerms, ESCAPE_SAFE_HIGHLIGHT_1,
 				ESCAPE_SAFE_HIGHLIGHT_2);
+		}
 
-			text = HtmlUtil.escape(text);
+		text = HtmlUtil.escape(text);
 
+		if (_highlight) {
 			text = StringUtil.replace(
 				text,
 				new String[] {ESCAPE_SAFE_HIGHLIGHT_1, ESCAPE_SAFE_HIGHLIGHT_2},


### PR DESCRIPTION
Hey Eudaldo,

https://issues.liferay.com/browse/LPS-44511

We always have to do escape in Summary#_escapeAndHighlight, otherwise we make XSS possible in the search results.

I prefer to have one "return" statement only (if possible), plus this way we avoid having 2 "escape" calls.

Regards,
Tibor
