### PR TITLE
LPS-44122 Slight SF in SearchUtil & Summary. Consistency with ee-6.2.x

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/search/Summary.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Summary.java
@@ -130,20 +130,17 @@ public class Summary {
 		}
 
 		text = SearchUtil.highlight(
-			text, _queryTerms, ESCAPE_SAFE_HIGHLIGHT_1,
-			ESCAPE_SAFE_HIGHLIGHT_2);
+			text, _queryTerms, ESCAPE_SAFE_HIGHLIGHTS[0],
+			ESCAPE_SAFE_HIGHLIGHTS[1]);
 
 		text = HtmlUtil.escape(text);
 
 		return StringUtil.replace(
-			text,
-			new String[] {ESCAPE_SAFE_HIGHLIGHT_1, ESCAPE_SAFE_HIGHLIGHT_2},
-			new String[] {SearchUtil.HIGHLIGHT_1, SearchUtil.HIGHLIGHT_2});
+			text, ESCAPE_SAFE_HIGHLIGHTS, SearchUtil.HIGHLIGHTS);
 	}
 
-	private static final String ESCAPE_SAFE_HIGHLIGHT_1 = "[@HIGHLIGHT1@]";
-
-	private static final String ESCAPE_SAFE_HIGHLIGHT_2 = "[@HIGHLIGHT2@]";
+	private static final String[] ESCAPE_SAFE_HIGHLIGHTS = {
+		"[@HIGHLIGHT1@]", "[@HIGHLIGHT2@]"};
 
 	private String _content;
 	private boolean _highlight;

--- a/portal-service/src/com/liferay/portal/kernel/search/util/SearchUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/util/SearchUtil.java
@@ -28,12 +28,11 @@ import java.util.regex.Pattern;
  */
 public class SearchUtil {
 
-	public static final String HIGHLIGHT_1 = "<span class=\"highlight\">";
-
-	public static final String HIGHLIGHT_2 = "</span>";
+	public static final String[] HIGHLIGHTS = {
+		"<span class=\"highlight\">", "</span>"};
 
 	public static String highlight(String s, String[] queryTerms) {
-		return highlight(s, queryTerms, HIGHLIGHT_1, HIGHLIGHT_2);
+		return highlight(s, queryTerms, HIGHLIGHTS[0], HIGHLIGHTS[1]);
 	}
 
 	public static String highlight(

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -660,8 +660,7 @@ public class StringUtil {
 	 */
 	@Deprecated
 	public static String highlight(String s, String[] queryTerms) {
-		return SearchUtil.highlight(
-			s, queryTerms, SearchUtil.HIGHLIGHT_1, SearchUtil.HIGHLIGHT_2);
+		return SearchUtil.highlight(s, queryTerms);
 	}
 
 	/**

--- a/portal-service/test/unit/com/liferay/portal/kernel/search/util/SearchUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/search/util/SearchUtilTest.java
@@ -28,13 +28,13 @@ public class SearchUtilTest {
 	public void testHighlight() throws Exception {
 		StringBundler sb = new StringBundler(7);
 
-		sb.append(SearchUtil.HIGHLIGHT_1);
+		sb.append(SearchUtil.HIGHLIGHTS[0]);
 		sb.append("Hello");
-		sb.append(SearchUtil.HIGHLIGHT_2);
+		sb.append(SearchUtil.HIGHLIGHTS[1]);
 		sb.append(" World ");
-		sb.append(SearchUtil.HIGHLIGHT_1);
+		sb.append(SearchUtil.HIGHLIGHTS[0]);
 		sb.append("Liferay");
-		sb.append(SearchUtil.HIGHLIGHT_2);
+		sb.append(SearchUtil.HIGHLIGHTS[1]);
 
 		Assert.assertEquals(
 			sb.toString(),


### PR DESCRIPTION
Hey Eudaldo,

Yesterday LPS-44122 & LPS-44123 finally got merged to ee-6.2.x in a simplified way. One of the simplification was to use arrays instead of 2 variables in SearchUtil & Summary.

I'm sending this pull with a commit to keep master in sync with 6.2.x

Regads,
Tibor
