### PR TITLE
LPS-47324 search portlet Search button disabled when selecting date range in IE8

### DIFF
--- a/portal-web/docroot/html/portlet/search/facets/modified.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/modified.jsp
@@ -215,6 +215,8 @@ int firstDayOfWeek = localeCal.getFirstDayOfWeek() - 1;
 <aui:script use="aui-datepicker-deprecated,aui-form-validator">
 	var Util = Liferay.Util;
 
+	var DATE_FORMAT = '%Y-%m-%d';
+
 	var DEFAULTS_FORM_VALIDATOR = A.config.FormValidator;
 
 	var REGEX_DATE = /^\d{4}(-)(0[1-9]|1[012])\1(0[1-9]|[12][0-9]|3[01])$/;
@@ -245,7 +247,7 @@ int firstDayOfWeek = localeCal.getFirstDayOfWeek() - 1;
 				var dateValue = null;
 
 				if (validDate) {
-					dateValue = A.Date.parse(val);
+					dateValue = A.Date.parse(DATE_FORMAT, val);
 				}
 
 				if (fieldNode === customRangeFrom) {
@@ -306,7 +308,7 @@ int firstDayOfWeek = localeCal.getFirstDayOfWeek() - 1;
 				}
 			},
 			calendar: {
-				dateFormat: '%Y-%m-%d',
+				dateFormat: DATE_FORMAT,
 				firstDayOfWeek: <%= firstDayOfWeek %>,
 				locale: '<%= locale %>',
 
@@ -342,7 +344,7 @@ int firstDayOfWeek = localeCal.getFirstDayOfWeek() - 1;
 				}
 			},
 			calendar: {
-				dateFormat: '%Y-%m-%d',
+				dateFormat: DATE_FORMAT,
 				firstDayOfWeek: <%= firstDayOfWeek %>,
 				locale: '<%= locale %>',
 


### PR DESCRIPTION
Hi @ealonso,

I think it's a bit more like UI issue, but it related to search portlet, so I send the PR for you. If you think the UI team should review it please let me know, or forward it to them.

The issue happens only in IE8.

Please see @peterborkuti's comment from the original pull request:

> The true fix would be fixing YUI, but that would be far more complicated.
> Alloy fallbacks YUI, see here:
> https://github.com/liferay/alloy-ui/blob/master/src/aui-datatype/js/aui-datatype-date-parse.js, line 832:
> "If only one argument is passed, the YUI parser will be called for backwards compatibility."
> 
> Here in YUI:
> https://github.com/yui/yui3/blob/master/src/date/js/date-parse.js
> "var val = new Date(+data || data);"
> So it is too simple to fix this IE8 issue.

Regards,
Vilmos
