### PR TITLE
LPS-48749 Add fallback if request attribute results in null

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/context/LayoutsAdminDisplayContext.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/context/LayoutsAdminDisplayContext.java
@@ -29,6 +29,7 @@ import com.liferay.portal.model.Organization;
 import com.liferay.portal.model.RoleConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.model.UserGroup;
+import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.service.OrganizationLocalServiceUtil;
@@ -329,6 +330,14 @@ public class LayoutsAdminDisplayContext {
 		}
 
 		_selGroup = (Group)_request.getAttribute(WebKeys.GROUP);
+
+		if (_selGroup != null) {
+			return _selGroup;
+		}
+
+		long groupId = ParamUtil.getLong(_request, "groupId");
+
+		_selGroup = GroupLocalServiceUtil.fetchGroup(groupId);
 
 		return _selGroup;
 	}


### PR DESCRIPTION
Hey Eudaldo,

I have created a very quick fix for the LayoutsAdminDisplayContext. When the WebKeys.GROUP request attribute does not return with anything it is falling back to the groupId attribute.

I've already emailed you about the more robust fix, I'm going to implement that later, I just wanted to solve this NPE quickly because we cannot even use staging while it is broken.

cc @juliocamarero

Thanks,

Máté
