### PR TITLE
[TECHNICAL-SUPPORT] LPS-51357 UserLocalService.updateAsset() does not trigger reindex

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -4138,8 +4138,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			user.getUuid(), 0, assetCategoryIds, assetTagNames, false, null,
 			null, null, null, user.getFullName(), null, null, null, null, 0, 0,
 			null, false);
-
-		reindex(user);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -673,56 +673,59 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		// Synchronize
 
-		if (!sync) {
-			return entry;
+		if (sync) {
+			if (className.equals(BlogsEntry.class.getName())) {
+				BlogsEntry blogsEntry = blogsEntryPersistence.findByPrimaryKey(
+					classPK);
+
+				blogsEntry.setTitle(title);
+
+				blogsEntryPersistence.update(blogsEntry);
+			}
+			else if (className.equals(DLFileEntry.class.getName())) {
+				DLFileEntry dlFileEntry =
+					dlFileEntryPersistence.findByPrimaryKey(classPK);
+
+				String fileName = DLUtil.getSanitizedFileName(
+					title, dlFileEntry.getExtension());
+
+				dlFileEntry.setFileName(fileName);
+
+				dlFileEntry.setTitle(title);
+				dlFileEntry.setDescription(description);
+
+				dlFileEntryPersistence.update(dlFileEntry);
+			}
+			else if (className.equals(JournalArticle.class.getName())) {
+				JournalArticle journalArticle =
+					journalArticlePersistence.findByPrimaryKey(classPK);
+
+				journalArticle.setTitle(title);
+				journalArticle.setDescription(description);
+
+				journalArticlePersistence.update(journalArticle);
+			}
+			else if (className.equals(MBMessage.class.getName())) {
+				MBMessage mbMessage = mbMessagePersistence.findByPrimaryKey(
+					classPK);
+
+				mbMessage.setSubject(title);
+
+				mbMessagePersistence.update(mbMessage);
+			}
+			else if (className.equals(WikiPage.class.getName())) {
+				WikiPage wikiPage = wikiPagePersistence.findByPrimaryKey(
+					classPK);
+
+				wikiPage.setTitle(title);
+
+				wikiPagePersistence.update(wikiPage);
+			}
 		}
 
-		if (className.equals(BlogsEntry.class.getName())) {
-			BlogsEntry blogsEntry = blogsEntryPersistence.findByPrimaryKey(
-				classPK);
+		// Indexer
 
-			blogsEntry.setTitle(title);
-
-			blogsEntryPersistence.update(blogsEntry);
-		}
-		else if (className.equals(DLFileEntry.class.getName())) {
-			DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
-				classPK);
-
-			String fileName = DLUtil.getSanitizedFileName(
-				title, dlFileEntry.getExtension());
-
-			dlFileEntry.setFileName(fileName);
-
-			dlFileEntry.setTitle(title);
-			dlFileEntry.setDescription(description);
-
-			dlFileEntryPersistence.update(dlFileEntry);
-		}
-		else if (className.equals(JournalArticle.class.getName())) {
-			JournalArticle journalArticle =
-				journalArticlePersistence.findByPrimaryKey(classPK);
-
-			journalArticle.setTitle(title);
-			journalArticle.setDescription(description);
-
-			journalArticlePersistence.update(journalArticle);
-		}
-		else if (className.equals(MBMessage.class.getName())) {
-			MBMessage mbMessage = mbMessagePersistence.findByPrimaryKey(
-				classPK);
-
-			mbMessage.setSubject(title);
-
-			mbMessagePersistence.update(mbMessage);
-		}
-		else if (className.equals(WikiPage.class.getName())) {
-			WikiPage wikiPage = wikiPagePersistence.findByPrimaryKey(classPK);
-
-			wikiPage.setTitle(title);
-
-			wikiPagePersistence.update(wikiPage);
-		}
+		reindex(entry);
 
 		return entry;
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-51357

Hi Eudaldo,

We know this change causes one additional reindex in some cases (add/update entity), but this problem (multiple re-indexation of an entity for a simple service call) is beyond the scope of the current issue and needs more attention from the developers of the core infrastructure, so we chose this way.

I was wondering if you had a better idea.

Cheers,
Tibor

/cc @akosthurzo
