### PR TITLE
[TECHNICAL-SUPPORT] LPS-53432 (fix + test) Asset Publisher sorts entries incorrectly by Title on non-default locales

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/blogs/search/BlogsEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/search/BlogsEntrySearchTest.java
@@ -14,10 +14,19 @@
 
 package com.liferay.portlet.blogs.search;
 
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.search.test.BaseSearchTestCase;
 import com.liferay.portal.service.ServiceContext;
@@ -27,6 +36,7 @@ import com.liferay.portlet.blogs.model.BlogsEntry;
 import com.liferay.portlet.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.portlet.blogs.util.test.BlogsTestUtil;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -49,6 +59,94 @@ public class BlogsEntrySearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testLocalizedSearch() throws Exception {
+	}
+
+	@Override
+	@Test
+	public void testLocalizedSortByTitle() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		BaseModel<?> parentBaseModel = getParentBaseModel(
+			group, serviceContext);
+
+		BaseModel<BlogsEntry> basemodel1 = (BlogsEntry)addBaseModelWithWorkflow(
+			parentBaseModel, true, "bblog", serviceContext);
+		BaseModel<BlogsEntry> basemodel2 = (BlogsEntry)addBaseModelWithWorkflow(
+			parentBaseModel, true, "ablog", serviceContext);
+		BaseModel<BlogsEntry> basemodel3 = (BlogsEntry)addBaseModelWithWorkflow(
+			parentBaseModel, true, "cblog", serviceContext);
+
+		// Test sort on default locale ("en_US")
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			group.getGroupId());
+
+		searchContext.setAttribute(Field.TITLE, "*blog");
+		searchContext.setKeywords("*blog");
+		searchContext.setLocale(LocaleUtil.getDefault());
+
+		String sortField = "localized_title_" + LocaleUtil.toLanguageId(
+			LocaleUtil.getDefault()) + "_sortable";
+
+		Sort sort = new Sort(sortField, Sort.STRING_TYPE, true);
+
+		searchContext.setSorts(sort);
+
+		Hits results = searchBaseModels(
+			getBaseModelClass(), group.getGroupId(), searchContext);
+
+		Assert.assertEquals(3, results.getLength());
+
+		BlogsEntry entry1 = (BlogsEntry)basemodel1;
+		BlogsEntry entry2 = (BlogsEntry)basemodel2;
+		BlogsEntry entry3 = (BlogsEntry)basemodel3;
+
+		Document document1 = results.doc(0);
+		Document document2 = results.doc(1);
+		Document document3 = results.doc(2);
+
+		Assert.assertEquals(
+			GetterUtil.getLong(document1.get(Field.ENTRY_CLASS_PK)),
+			entry3.getPrimaryKey());
+		Assert.assertEquals(
+			GetterUtil.getLong(document2.get(Field.ENTRY_CLASS_PK)),
+			entry1.getPrimaryKey());
+		Assert.assertEquals(
+			GetterUtil.getLong(document3.get(Field.ENTRY_CLASS_PK)),
+			entry2.getPrimaryKey());
+
+		// Test sort on a non-default locale.
+
+		// Since the title is not localizable for blog entries currently, the
+		// order should be the same regardless of the search locale.
+
+		searchContext.setLocale(LocaleUtil.FRENCH);
+
+		sortField = "localized_title_fr_FR_sortable";
+
+		sort.setFieldName(sortField);
+
+		searchContext.setSorts(sort);
+
+		results = searchBaseModels(
+			getBaseModelClass(), group.getGroupId(), searchContext);
+
+		Assert.assertEquals(3, results.getLength());
+
+		document1 = results.doc(0);
+		document2 = results.doc(1);
+		document3 = results.doc(2);
+
+		Assert.assertEquals(
+			GetterUtil.getLong(document1.get(Field.ENTRY_CLASS_PK)),
+			entry3.getPrimaryKey());
+		Assert.assertEquals(
+			GetterUtil.getLong(document2.get(Field.ENTRY_CLASS_PK)),
+			entry1.getPrimaryKey());
+		Assert.assertEquals(
+			GetterUtil.getLong(document3.get(Field.ENTRY_CLASS_PK)),
+			entry2.getPrimaryKey());
 	}
 
 	@Ignore()

--- a/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -683,8 +684,27 @@ public abstract class BaseIndexer implements Indexer {
 
 		document.addNumber(Field.VIEW_COUNT, assetEntry.getViewCount());
 
-		document.addLocalizedKeyword(
-			"localized_title", assetEntry.getTitleMap(), true, true);
+		Map<Locale, String> titleMap = assetEntry.getTitleMap();
+
+		Locale[] availableLocales = LanguageUtil.getAvailableLocales(
+			assetEntry.getGroupId());
+
+		String defaultTitle = titleMap.get(
+			LocaleUtil.fromLanguageId(assetEntry.getDefaultLanguageId()));
+
+		Map<Locale, String> missingTitleMap = new HashMap<>();
+
+		for (Locale availableLocale : availableLocales) {
+			if (!titleMap.containsKey(availableLocale) ||
+				Validator.isNull(titleMap.get(availableLocale))) {
+
+				missingTitleMap.put(availableLocale, defaultTitle);
+			}
+		}
+
+		MapUtil.merge(missingTitleMap, titleMap);
+
+		document.addLocalizedKeyword("localized_title", titleMap, true, true);
 		document.addKeyword("visible", assetEntry.isVisible());
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -684,6 +684,8 @@ public abstract class BaseIndexer implements Indexer {
 
 		document.addNumber(Field.VIEW_COUNT, assetEntry.getViewCount());
 
+		// Use a complete title map in order to sort properly on each locale
+
 		Map<Locale, String> titleMap = assetEntry.getTitleMap();
 
 		Locale[] availableLocales = LanguageUtil.getAvailableLocales(

--- a/portal-test-internal/src/com/liferay/portal/search/test/BaseSearchTestCase.java
+++ b/portal-test-internal/src/com/liferay/portal/search/test/BaseSearchTestCase.java
@@ -107,6 +107,10 @@ public abstract class BaseSearchTestCase {
 	}
 
 	@Test
+	public void testLocalizedSortByTitle() throws Exception {
+	}
+
+	@Test
 	public void testParentBaseModelUserPermissions() throws Exception {
 		testUserPermissions(true, false);
 	}

--- a/portal-test-internal/src/com/liferay/portal/search/test/BaseSearchTestCase.java
+++ b/portal-test-internal/src/com/liferay/portal/search/test/BaseSearchTestCase.java
@@ -383,7 +383,7 @@ public abstract class BaseSearchTestCase {
 				getBaseModelClass(), group.getGroupId(), searchContext));
 	}
 
-	protected int searchBaseModelsCount(
+	protected Hits searchBaseModels(
 			Class<?> clazz, long groupId, SearchContext searchContext)
 		throws Exception {
 
@@ -391,7 +391,14 @@ public abstract class BaseSearchTestCase {
 
 		searchContext.setGroupIds(new long[] {groupId});
 
-		Hits results = indexer.search(searchContext);
+		return indexer.search(searchContext);
+	}
+
+	protected int searchBaseModelsCount(
+			Class<?> clazz, long groupId, SearchContext searchContext)
+		throws Exception {
+
+		Hits results = searchBaseModels(clazz, groupId, searchContext);
 
 		return results.getLength();
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-53432

Hey Eudaldo,

Hope you're doing well.
Please, see the LPS for description and screenshots.

I'd like to ask you to also read my additional comments on the ticket, to get a detailed context about the issue and a possible alternative solution that could be used only by/in Elasticsearch. I decided not to follow that approach, since users shall switch from ES to Solr in 7.0 as well, and the behavior should remain consistent across different engines.

I'm also sending you a fix-only pull in case you'd like to rethink the integration test, so you can proceed and push forward the fix if you agree with my solution.

Best,
-tibor