### PR TITLE
[Technical Support] LPS-54110 Using "Select Box" template type on Language portlet causes js...

### DIFF
--- a/portal-web/docroot/html/taglib/ui/language/display_style_select_box.jsp
+++ b/portal-web/docroot/html/taglib/ui/language/display_style_select_box.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/html/taglib/ui/language/init.jsp" %>
 
-<aui:form action="<%= formAction %>" method="post" name="<%= formName %>" useNamespace="<%= false %>">
+<aui:form action="<%= formAction %>" method="post" name="<%= formName %>">
 	<aui:select changesContext="<%= true %>" label="" name="<%= name %>" onChange='<%= "submitForm(document." + namespace + formName + ");" %>' title="language">
 
 		<%


### PR DESCRIPTION
... error and brokes dockbar

Hi Eudaldo,

Nate asked me to forward this pull to you.

I'm not sure that my solution is the best but I tested it and I didn't find any regression.

Please keep in mind that this taglib can be used in any theme like "$taglibLiferay.language("fm", null, "languageId", 3)".

Thanks in advance for your review,
 Zsaga 