### PR TITLE
LPS-58607 Information Message "Please select a tool from the left menu" is missing

### DIFF
--- a/portal-web/docroot/html/portal/layout/edit/embedded.jsp
+++ b/portal-web/docroot/html/portal/layout/edit/embedded.jsp
@@ -24,10 +24,10 @@ if (selLayout != null) {
 	UnicodeProperties typeSettingsProperties = selLayout.getTypeSettingsProperties();
 
 	url = typeSettingsProperties.getProperty("url", StringPool.BLANK);
-	description = typeSettingsProperties.getProperty("description", StringPool.BLANK);
+	description = typeSettingsProperties.getProperty("embeddedLayoutDescription", StringPool.BLANK);
 }
 %>
 
 <aui:input cssClass="lfr-input-text-container" id="urlEmbedded" label="url" name="TypeSettingsProperties--url--" type="text" value="<%= url %>" />
 
-<aui:input cssClass="layout-description" id="descriptionEmbedded" label="description" name="TypeSettingsProperties--description--" type="textarea" value="<%= description %>" wrap="soft" />
+<aui:input cssClass="layout-description" id="descriptionEmbedded" label="description" name="TypeSettingsProperties--embeddedLayoutDescription--" type="textarea" value="<%= description %>" wrap="soft" />

--- a/portal-web/docroot/html/portal/layout/edit/panel.jsp
+++ b/portal-web/docroot/html/portal/layout/edit/panel.jsp
@@ -25,12 +25,12 @@ String panelSelectedPortlets = StringPool.BLANK;
 if (selLayout != null) {
 	UnicodeProperties typeSettingsProperties = selLayout.getTypeSettingsProperties();
 
-	description = typeSettingsProperties.getProperty("description", StringPool.BLANK);
+	description = typeSettingsProperties.getProperty("panelLayoutDescription", StringPool.BLANK);
 	panelSelectedPortlets = typeSettingsProperties.getProperty("panelSelectedPortlets", StringPool.BLANK);
 }
 %>
 
-<aui:input cssClass="layout-description" id="descriptionPanel" label="description" name="TypeSettingsProperties--description--" type="textarea" value="<%= description %>" wrap="soft" />
+<aui:input cssClass="layout-description" id="descriptionPanel" label="description" name="TypeSettingsProperties--panelLayoutDescription--" type="textarea" value="<%= description %>" wrap="soft" />
 
 <div class="alert alert-info">
 	<liferay-ui:message key="select-the-applications-that-are-available-in-the-panel" />

--- a/portal-web/docroot/html/portal/layout/edit/url.jsp
+++ b/portal-web/docroot/html/portal/layout/edit/url.jsp
@@ -24,10 +24,10 @@ if (selLayout != null) {
 	UnicodeProperties typeSettingsProperties = selLayout.getTypeSettingsProperties();
 
 	url = typeSettingsProperties.getProperty("url", StringPool.BLANK);
-	description = typeSettingsProperties.getProperty("description", StringPool.BLANK);
+	description = typeSettingsProperties.getProperty("urlLayoutDescription", StringPool.BLANK);
 }
 %>
 
 <aui:input cssClass="lfr-input-text-container" id="url" label="url" name="TypeSettingsProperties--url--" type="text" value="<%= url %>" />
 
-<aui:input cssClass="layout-description" id="descriptionUrl" label="description" name="TypeSettingsProperties--description--" type="textarea" value="<%= description %>" wrap="soft" />
+<aui:input cssClass="layout-description" id="descriptionUrl" label="description" name="TypeSettingsProperties--urlLayoutDescription--" type="textarea" value="<%= description %>" wrap="soft" />

--- a/portal-web/docroot/html/portal/layout/view/panel_description.jspf
+++ b/portal-web/docroot/html/portal/layout/view/panel_description.jspf
@@ -39,7 +39,7 @@ if (themeDisplay.isStatePopUp() || layoutTypePortlet.hasStateMax()) {
 else {
 	UnicodeProperties typeSettingsProperties = layout.getTypeSettingsProperties();
 
-	String description = typeSettingsProperties.getProperty("description");
+	String description = typeSettingsProperties.getProperty("panelLayoutDescription");
 
 	if (Validator.isNull(description)) {
 		description = LanguageUtil.get(request, "please-select-a-tool-from-the-left-menu");


### PR DESCRIPTION
Since there are three fields with the same name (description), the request will join them with commas. So, the method will receive ",," instead of a blank field. Now they have unique names