### PR TITLE
LPS-69799 CORS error when site virtualhost is a subdomain of portal virtualhost

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -7715,11 +7715,11 @@ public class PortalImpl implements Portal {
 				virtualHostname = getCanonicalDomain(
 					virtualHostname, portalDomain);
 
-				virtualHostname = getPortalURL(
-					virtualHostname, themeDisplay.getServerPort(),
-					themeDisplay.isSecure());
+				if (canonicalURL || virtualHostname.startsWith(portalDomain)) {
+					virtualHostname = getPortalURL(
+						virtualHostname, themeDisplay.getServerPort(),
+						themeDisplay.isSecure());
 
-				if (canonicalURL || virtualHostname.contains(portalDomain)) {
 					String path = StringPool.BLANK;
 
 					if (themeDisplay.isWidget()) {


### PR DESCRIPTION
Hi Eudaldo,

This comes from [this PR](https://github.com/ealonso/liferay-portal/pull/756).

After our talk and a further investigation we found out the key is in [LPS-3241](https://issues.liferay.com/browse/LPS-3241) and [this commit](https://github.com/liferay/liferay-portal/commit/0c0ae6f0873cdf8e320163829a7166d4f95e3331), because in case we use _contains_ instead of _startsWith_ we are not taking into account the possibility of the virtualhost is a subdomain of the portal domain.

So, if we compare both (virtualhost and portal domain) without protocol, then we can use again _startsWith_, and there will not be any problem with subdomains.

Thanks in advance!