### PR TITLE
LPS-70688 Load DDMStructure class name for upgrades from 6.0.x

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_12_to_6_1_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_12_to_6_1_0.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.upgrade.v6_0_12_to_6_1_0.UpgradeAsset;
 import com.liferay.portal.upgrade.v6_0_12_to_6_1_0.UpgradeCompanyId;
 import com.liferay.portal.upgrade.v6_0_12_to_6_1_0.UpgradeDocumentLibrary;
+import com.liferay.portal.upgrade.v6_0_12_to_6_1_0.UpgradeDynamicDataMapping;
 import com.liferay.portal.upgrade.v6_0_12_to_6_1_0.UpgradeMessageBoards;
 import com.liferay.portal.upgrade.v6_0_12_to_6_1_0.UpgradePermission;
 import com.liferay.portal.upgrade.v6_0_12_to_6_1_0.UpgradePortletPreferences;
@@ -57,6 +58,7 @@ public class UpgradeProcess_6_0_12_to_6_1_0 extends Pre7UpgradeProcess {
 		upgrade(UpgradeCamelCasePortletPreferences.class);
 		upgrade(UpgradeCountry.class);
 		upgrade(UpgradeDocumentLibrary.class);
+		upgrade(UpgradeDynamicDataMapping.class);
 		upgrade(UpgradeGroup.class);
 		upgrade(UpgradeIFrame.class);
 		upgrade(UpgradeImageGallery.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_0_12_to_6_1_0/UpgradeDynamicDataMapping.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_0_12_to_6_1_0/UpgradeDynamicDataMapping.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v6_0_12_to_6_1_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+
+/**
+ * @author Alberto Chaparro
+ */
+public class UpgradeDynamicDataMapping extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement ps = connection.prepareStatement(
+				"insert into ClassName_ (mvccVersion, classNameId, value) " +
+					"values (?, ?, ?)")) {
+
+			ps.setLong(1, 0);
+			ps.setLong(2, increment());
+			ps.setString(
+				3, "com.liferay.portlet.dynamicdatamapping.model.DDMStructure");
+
+			ps.executeUpdate();
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
@@ -210,8 +210,6 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 		setUpStrutureAttributesMappings();
 
-		updateClassNameId();
-
 		updateStructures();
 		updateTemplates();
 
@@ -431,38 +429,6 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 				ps2.executeBatch();
 			}
-		}
-	}
-
-	protected void updateClassNameId() throws Exception {
-		try (PreparedStatement ps = connection.prepareStatement(
-				"update ClassName_ set value = ? where value = ?")) {
-
-			long ddmStructureClassNameId = PortalUtil.getClassNameId(
-				"com.liferay.portlet.dynamicdatamapping.model.DDMStructure");
-
-			ps.setString(
-				1, "com.liferay.portlet.dynamicdatamapping.model.DDMStructure");
-			ps.setString(
-				2, "com.liferay.portlet.journal.model.JournalStructure");
-
-			if (ddmStructureClassNameId == 0) {
-				ps.addBatch();
-			}
-
-			long ddmTemplateClassNameId = PortalUtil.getClassNameId(
-				"com.liferay.portlet.dynamicdatamapping.model.DDMTemplate");
-
-			ps.setString(
-				1, "com.liferay.portlet.dynamicdatamapping.model.DDMTemplate");
-			ps.setString(
-				2, "com.liferay.portlet.journal.model.JournalTemplate");
-
-			if (ddmTemplateClassNameId == 0) {
-				ps.addBatch();
-			}
-
-			ps.executeBatch();
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
@@ -210,6 +210,8 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 		setUpStrutureAttributesMappings();
 
+		updateClassNameId();
+
 		updateStructures();
 		updateTemplates();
 
@@ -429,6 +431,38 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 				ps2.executeBatch();
 			}
+		}
+	}
+
+	protected void updateClassNameId() throws Exception {
+		try (PreparedStatement ps = connection.prepareStatement(
+				"update ClassName_ set value = ? where value = ?")) {
+
+			long ddmStructureClassNameId = PortalUtil.getClassNameId(
+				"com.liferay.portlet.dynamicdatamapping.model.DDMStructure");
+
+			ps.setString(
+				1, "com.liferay.portlet.dynamicdatamapping.model.DDMStructure");
+			ps.setString(
+				2, "com.liferay.portlet.journal.model.JournalStructure");
+
+			if (ddmStructureClassNameId == 0) {
+				ps.addBatch();
+			}
+
+			long ddmTemplateClassNameId = PortalUtil.getClassNameId(
+				"com.liferay.portlet.dynamicdatamapping.model.DDMTemplate");
+
+			ps.setString(
+				1, "com.liferay.portlet.dynamicdatamapping.model.DDMTemplate");
+			ps.setString(
+				2, "com.liferay.portlet.journal.model.JournalTemplate");
+
+			if (ddmTemplateClassNameId == 0) {
+				ps.addBatch();
+			}
+
+			ps.executeBatch();
 		}
 	}
 


### PR DESCRIPTION
Hola @ealonso, @pavel-savinov,

He adelantado la creación de className de DDMStructure porque si lo hacemos en el UpgradeJournal esto sigue fallando:
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeDynamicDataMapping.java#L85

Lo he adelantado el punto más reciente posible dado que sólo es necesario para usuarios que vengan de 6.0.x (en otros casos ya existe el valor en base de datos). No he creado el DDMTemplate porque no es necesario para el upgrade, se creará luego al levantar el módulo.

Por otro lado, he intentado evitar el uso de PortalUtil.getClassNameId() porque estos métodos pueden cambiar a lo largo del tiempo pero el upgrade necesita permanecer invariable. De hecho por este motivo falla, porque la lógica del método se modificó en DXP.

Por otro lado, si queremos ser puristas deberíamos hacer lo siguiente:
- Crear un método de utilidad getClassNameId() para los upgrades y reemplazar todas las ocurrencias de PortalUtil.getClassNameId() de los procesos de upgrade dado que se invoca más de 40 veces y puede haber errores como éste.

Podemos ir por partes, ya me diréis.

Gracias!

cc @migue