### PR TITLE
LPS-70373

### DIFF
--- a/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_misc.scss
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_misc.scss
@@ -26,6 +26,13 @@
 	vertical-align: middle;
 }
 
+.lfr-asset-anchor:before {
+	content: "";
+	display: block;
+	height: 64px;
+	margin: -64px 0 0;
+}
+
 .lfr-url-error {
 	display: inline-block;
 	white-space: normal;

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/abstracts.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/abstracts.jsp
@@ -31,11 +31,14 @@ if (Validator.isNull(title)) {
 
 boolean viewInContext = ((Boolean)request.getAttribute("view.jsp-viewInContext")).booleanValue();
 
+String assetEntryId = String.valueOf(assetEntry.getEntryId());
 String viewURL = AssetPublisherHelper.getAssetViewURL(liferayPortletRequest, liferayPortletResponse, assetEntry, viewInContext);
 %>
 
 <div class="asset-abstract <%= AssetUtil.isDefaultAssetPublisher(layout, portletDisplay.getId(), assetPublisherDisplayContext.getPortletResource()) ? "default-asset-publisher" : StringPool.BLANK %>">
 	<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
+
+	<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntryId %>"></span>
 
 	<h4 class="asset-title">
 		<c:if test="<%= Validator.isNotNull(viewURL) %>">

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
@@ -17,6 +17,22 @@
 <%@ include file="/init.jsp" %>
 
 <%
+List results = (List)request.getAttribute("view.jsp-results");
+
+int assetEntryIndex = ((Integer)request.getAttribute("view.jsp-assetEntryIndex")).intValue();
+
+AssetEntry assetEntry = (AssetEntry)request.getAttribute("view.jsp-assetEntry");
+AssetRendererFactory<?> assetRendererFactory = (AssetRendererFactory<?>)request.getAttribute("view.jsp-assetRendererFactory");
+AssetRenderer<?> assetRenderer = (AssetRenderer<?>)request.getAttribute("view.jsp-assetRenderer");
+
+String assetEntryId = String.valueOf(assetEntry.getEntryId());
+String languageId = LanguageUtil.getLanguageId(request);
+
+String title = assetRenderer.getTitle(LocaleUtil.fromLanguageId(languageId));
+
+boolean print = ((Boolean)request.getAttribute("view.jsp-print")).booleanValue();
+boolean workflowEnabled = WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(assetEntry.getCompanyId(), assetEntry.getGroupId(), assetEntry.getClassName());
+
 String redirect = ParamUtil.getString(request, "redirect");
 
 if (Validator.isNull(redirect)) {
@@ -29,24 +45,10 @@ if (Validator.isNull(redirect)) {
 	PortletURL portletURL = renderResponse.createRenderURL();
 
 	portletURL.setParameter("mvcPath", "/view.jsp");
+	portletURL.setParameter("assetEntry", assetEntryId);
 
 	redirect = portletURL.toString();
 }
-
-List results = (List)request.getAttribute("view.jsp-results");
-
-int assetEntryIndex = ((Integer)request.getAttribute("view.jsp-assetEntryIndex")).intValue();
-
-AssetEntry assetEntry = (AssetEntry)request.getAttribute("view.jsp-assetEntry");
-AssetRendererFactory<?> assetRendererFactory = (AssetRendererFactory<?>)request.getAttribute("view.jsp-assetRendererFactory");
-AssetRenderer<?> assetRenderer = (AssetRenderer<?>)request.getAttribute("view.jsp-assetRenderer");
-
-String languageId = LanguageUtil.getLanguageId(request);
-
-String title = assetRenderer.getTitle(LocaleUtil.fromLanguageId(languageId));
-
-boolean print = ((Boolean)request.getAttribute("view.jsp-print")).booleanValue();
-boolean workflowEnabled = WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(assetEntry.getCompanyId(), assetEntry.getGroupId(), assetEntry.getClassName());
 
 assetPublisherDisplayContext.setLayoutAssetEntry(assetEntry);
 

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/table.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/table.jsp
@@ -40,6 +40,7 @@ PortletURL editPortletURL = assetRenderer.getURLEdit(liferayPortletRequest, life
 
 boolean viewInContext = ((Boolean)request.getAttribute("view.jsp-viewInContext")).booleanValue();
 
+String assetEntryId = String.valueOf(assetEntry.getEntryId());
 String viewURL = AssetPublisherHelper.getAssetViewURL(liferayPortletRequest, liferayPortletResponse, assetEntry, viewInContext);
 
 request.setAttribute("view.jsp-showIconLabel", false);
@@ -78,6 +79,8 @@ request.setAttribute("view.jsp-showIconLabel", false);
 
 			<tr>
 				<td class="clamp-horizontal content-column table-cell-content title-column" colspan="1">
+					<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntryId %>"></span>
+
 					<div class="clamp-container">
 						<span class="truncate-text">
 							<c:choose>

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/title_list.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/title_list.jsp
@@ -35,6 +35,7 @@ request.setAttribute("view.jsp-showIconLabel", false);
 
 boolean viewInContext = ((Boolean)request.getAttribute("view.jsp-viewInContext")).booleanValue();
 
+String assetEntryId = String.valueOf(assetEntry.getEntryId());
 String viewURL = AssetPublisherHelper.getAssetViewURL(liferayPortletRequest, liferayPortletResponse, assetEntry, viewInContext);
 %>
 
@@ -43,6 +44,8 @@ String viewURL = AssetPublisherHelper.getAssetViewURL(liferayPortletRequest, lif
 </c:if>
 
 <li class="h3 <%= assetRendererFactory.getType() %>">
+	<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntryId %>"></span>
+
 	<aui:a href="<%= viewURL %>">
 		<%= HtmlUtil.escape(title) %>
 	</aui:a>

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -116,6 +116,18 @@ request.setAttribute("view.jsp-viewInContext", assetPublisherDisplayContext.isAs
 	<liferay-ui:search-paginator searchContainer="<%= searchContainer %>" type="<%= assetPublisherDisplayContext.getPaginationType() %>" />
 </c:if>
 
+<aui:script use="querystring-parse">
+	var queryString = window.location.search.substring(1);
+
+	var queryParamObj = new A.QueryString.parse(queryString);
+
+	var assetEntryId = queryParamObj['<portlet:namespace />assetEntry'];
+
+	if (assetEntryId) {
+		window.location.hash = assetEntryId;
+	}
+</aui:script>
+
 <%!
 private static Log _log = LogFactoryUtil.getLog("com_liferay_asset_publisher_web.view_jsp");
 %>


### PR DESCRIPTION
Hey @ealonso,

Attached is an update for http://issues.liferay.com/browse/LPS-70373.  This is the protoype of the asset publisher link I mentioned in the email.

There is another to resolve this issue that was to remove the ```ignored-parameter``` entries from https://github.com/liferay/liferay-portal/blame/master/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/friendly-url-routes/routes.xml.

If we remove that, we do not have to add the new parameter at https://github.com/ealonso/liferay-portal/pull/815/files#diff-c97dbfa843060d59a5832198f5004a17R48.

Also, I do not know how to have the asset entries back link go back to say page 2 or 3 of the asset publisher if there are paginated results in the asset publisher.

Please let me know if you have any questions. Thanks!