### PR TITLE
Lps 71092 fix

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -1182,14 +1182,20 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 
 		if (group.isSite()) {
-			if (UserGroupRoleLocalServiceUtil.hasUserGroupRole(
-					getUserId(), group.getGroupId(),
-					RoleConstants.SITE_ADMINISTRATOR, true) ||
-				UserGroupRoleLocalServiceUtil.hasUserGroupRole(
-					getUserId(), group.getGroupId(), RoleConstants.SITE_OWNER,
-					true)) {
+			Group curGroup = group;
 
-				return true;
+			while (curGroup != null) {
+				if (UserGroupRoleLocalServiceUtil.hasUserGroupRole(
+						getUserId(), curGroup.getGroupId(),
+						RoleConstants.SITE_ADMINISTRATOR, true) ||
+					UserGroupRoleLocalServiceUtil.hasUserGroupRole(
+						getUserId(), curGroup.getGroupId(),
+						RoleConstants.SITE_OWNER, true)) {
+
+					return true;
+				}
+
+				curGroup = curGroup.getParentGroup();
 			}
 
 			StopWatch stopWatch = new StopWatch();


### PR DESCRIPTION
Hello Eduardo,
From this ticket: https://issues.liferay.com/browse/LPP-24655
Reasons for choosing current solution:
1. No MANAGE_SUBGROUPS permissions for site admin or organization admin, ie. no such entry for admin role in resourcePermission table. Trying to retrieve corresponding actionId always returns false.
2. The MANAGE_SUBGROUPS checking in isGroupAdminImpl() in AdvancedPermissionChecker class is actually for parent site/org member who has custom role with MANAGE_SUBGROUPS permission, not for site admin or org admin.
3. I debugged through organization permission checking logic, and it turns out the reason parent org admin can pass the permission checking in child org is that they have a loop in advancedPermissionChecker to look up parent org permission, exactly the same as I did in my previous pull request.