### PR TITLE
LPS-71385

### DIFF
--- a/modules/apps/web-experience/portlet-display-template/portlet-display-template-web/src/main/java/com/liferay/portlet/display/template/web/internal/dynamic/data/mapping/util/PortletDisplayTemplateDDMDisplay.java
+++ b/modules/apps/web-experience/portlet-display-template/portlet-display-template-web/src/main/java/com/liferay/portlet/display/template/web/internal/dynamic/data/mapping/util/PortletDisplayTemplateDDMDisplay.java
@@ -20,9 +20,11 @@ import com.liferay.dynamic.data.mapping.model.DDMTemplateConstants;
 import com.liferay.dynamic.data.mapping.util.BaseDDMDisplay;
 import com.liferay.dynamic.data.mapping.util.DDMDisplay;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateHandlerRegistryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -80,14 +82,25 @@ public class PortletDisplayTemplateDDMDisplay extends BaseDDMDisplay {
 			ThemeDisplay themeDisplay, boolean includeAncestorTemplates)
 		throws Exception {
 
+		long ddmTemplateGroupId = themeDisplay.getScopeGroupId();
+
+		Group ddmTemplateGroup = _groupLocalService.getGroup(
+			ddmTemplateGroupId);
+
+		if (ddmTemplateGroup.isLayoutPrototype()) {
+			ddmTemplateGroup = _groupLocalService.getCompanyGroup(
+				ddmTemplateGroup.getCompanyId());
+
+			ddmTemplateGroupId = ddmTemplateGroup.getGroupId();
+		}
+
 		if (includeAncestorTemplates) {
 			return _portal.getCurrentAndAncestorSiteGroupIds(
-				themeDisplay.getScopeGroupId());
+				ddmTemplateGroupId);
 		}
 
 		return new long[] {
-			portletDisplayTemplate.getDDMTemplateGroupId(
-				themeDisplay.getScopeGroupId())
+			portletDisplayTemplate.getDDMTemplateGroupId(ddmTemplateGroupId)
 		};
 	}
 
@@ -190,6 +203,11 @@ public class PortletDisplayTemplateDDMDisplay extends BaseDDMDisplay {
 	}
 
 	@Reference(unbind = "-")
+	protected void setGroupLocalService(GroupLocalService groupLocalService) {
+		_groupLocalService = groupLocalService;
+	}
+
+	@Reference(unbind = "-")
 	protected void setPortletDisplayTemplate(
 		PortletDisplayTemplate portletDisplayTemplate) {
 
@@ -200,6 +218,8 @@ public class PortletDisplayTemplateDDMDisplay extends BaseDDMDisplay {
 
 	private static final Set<String> _viewTemplateExcludedColumnNames =
 		SetUtil.fromArray(new String[] {"language", "mode", "structure"});
+
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
/cc @jonathanmccann @SamZiemer

Re-sending from https://github.com/ealonso/liferay-portal/pull/845 without the dynamic-data-mapping change (change 2 below).

Copied from https://github.com/ealonso/liferay-portal/pull/845:

> /cc @moltam89
> 
> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-24582
> https://issues.liferay.com/browse/LPS-71385
> 
> If an Application Display Template is added using a Page Template, then if a page based on it is exported and imported to a separate environment (the Page Template must be imported as well), then the Application Display Template can no longer be used for portlets on the imported page; there are also various inconsistencies with when these can be selected for the portlets, also related to this issue (should be resolved by these changes).
> 
> When a Page Template is created and ADT's are added through portlets on the page, they are added to the scope group of that Page Template; however, this appears to be unintentional, as ADT's cannot be added to Page Templates normally, and this case is not handled when exporting/importing the same way as for Site Templates (for Site Templates, any site based on it will have its data copied, including ADT's, avoiding any confusion by replicating the data with the new site).
> 
> After some discussion, although the pattern is not clearly defined, we concluded using the Global site for ADT's from Page Templates makes the most sense, as it is not only a fairly simple solution, but seems that it could be the only way to handle this case in a way applicable to 6.2 as well (in 6.2, this kind of dependency between sites would only work between environments for the Global site). Given that they work differently from Site Templates, and you cannot normally create ADT's for a Page Template, it still seems consistent with the pattern in place, too.
> 
> Note that two places in the code needed to be changed for this to look and work consistently:
> 
> 1 - PortletDisplayTemplateDDMDisplay.getTemplateGroupIds() is used when searching the ADT's in the "Manage Application Display Templates" menu for portlet configuration
> 2 - The ddmTemplateGroupId in template_selector/page.jsp seems to separately determine what group new ADT's are added to (used in the Liferay.Util.openDDMPortlet() call near the bottom), so it needs to be changed separately