### PR TITLE
LPS-72227 Updates npm-shrinkwrap (auto-generated)

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/npm-shrinkwrap.json
+++ b/modules/apps/collaboration/message-boards/message-boards-web/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -62,8 +62,8 @@
 		},
 		"bluebird": {
 			"from": "bluebird@>=3.0.6 <4.0.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"version": "3.4.7"
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+			"version": "3.5.0"
 		},
 		"boxen": {
 			"dependencies": {
@@ -79,8 +79,8 @@
 		},
 		"brace-expansion": {
 			"from": "brace-expansion@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-			"version": "1.1.6"
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+			"version": "1.1.7"
 		},
 		"braces": {
 			"from": "braces@>=1.8.2 <2.0.0",
@@ -88,7 +88,7 @@
 			"version": "1.8.5"
 		},
 		"buffer-shims": {
-			"from": "buffer-shims@>=1.0.0 <2.0.0",
+			"from": "buffer-shims@>=1.0.0 <1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 			"version": "1.0.0"
 		},
@@ -215,8 +215,8 @@
 		},
 		"error-ex": {
 			"from": "error-ex@>=1.2.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-			"version": "1.3.0"
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"escape-string-regexp": {
 			"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -451,8 +451,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
@@ -521,8 +526,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -535,9 +540,9 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-			"version": "1.1.4"
+			"from": "is-buffer@>=1.1.5 <2.0.0",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"version": "1.1.5"
 		},
 		"is-dotfile": {
 			"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -640,9 +645,9 @@
 			"version": "0.0.1"
 		},
 		"isexe": {
-			"from": "isexe@>=1.1.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-			"version": "1.1.2"
+			"from": "isexe@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"isobject": {
 			"dependencies": {
@@ -658,8 +663,8 @@
 		},
 		"js-beautify": {
 			"from": "js-beautify@>=1.5.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.11.tgz",
-			"version": "1.6.11"
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.12.tgz",
+			"version": "1.6.12"
 		},
 		"jsonfile": {
 			"from": "jsonfile@>=2.1.0 <3.0.0",
@@ -673,8 +678,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -838,20 +843,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -865,18 +860,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -888,22 +878,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -912,8 +897,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -929,13 +914,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -943,73 +928,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1034,198 +1019,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1234,8 +1220,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1244,13 +1230,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1258,24 +1244,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1299,8 +1275,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1314,8 +1290,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1327,64 +1303,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1410,23 +1347,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1472,8 +1409,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1485,32 +1422,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1521,11 +1446,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1583,8 +1503,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1624,9 +1544,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1655,25 +1575,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1689,8 +1609,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1700,9 +1625,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1710,14 +1635,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1757,26 +1689,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1790,28 +1705,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1830,8 +1735,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1844,7 +1749,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1901,9 +1806,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1916,9 +1821,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1927,13 +1832,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1949,8 +1849,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -1961,18 +1866,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2041,8 +1934,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2065,43 +1958,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2122,13 +1986,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2137,23 +2006,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2178,18 +2043,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2200,9 +2058,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2214,15 +2072,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2236,8 +2089,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2258,13 +2111,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2293,47 +2156,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2341,9 +2177,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2352,18 +2188,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2377,20 +2203,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2412,6 +2238,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2419,13 +2250,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2446,13 +2277,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2466,33 +2302,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2504,20 +2320,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2528,21 +2334,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2584,20 +2375,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2622,14 +2408,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2651,10 +2442,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2666,16 +2457,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2686,11 +2467,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2700,8 +2476,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2715,13 +2491,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2730,8 +2511,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2745,8 +2526,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2754,7 +2535,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2769,9 +2550,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.1.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-events": {
 			"from": "metal-events@>=2.6.0 <3.0.0",
@@ -2827,8 +2608,8 @@
 		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"number-is-nan": {
 			"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2984,8 +2765,8 @@
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"version": "1.2.1"
 		},
 		"read-all-stream": {
 			"dependencies": {
@@ -2996,8 +2777,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
@@ -3033,13 +2819,18 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"version": "3.1.0"
+		},
+		"remove-trailing-separator": {
+			"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"repeat-element": {
 			"from": "repeat-element@>=1.1.2 <2.0.0",
@@ -3063,8 +2854,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3075,6 +2866,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3162,8 +2958,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.1.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
@@ -3249,8 +3050,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-			"version": "2.0.11"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3301,8 +3102,8 @@
 		},
 		"which": {
 			"from": "which@>=1.2.12 <2.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-			"version": "1.2.12"
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+			"version": "1.2.14"
 		},
 		"widest-line": {
 			"from": "widest-line@>=1.0.0 <2.0.0",
@@ -3316,8 +3117,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/collaboration/message-boards/message-boards-web/package.json
+++ b/modules/apps/collaboration/message-boards/message-boards-web/package.json
@@ -5,7 +5,7 @@
 	},
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.1.2"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "message-boards-web",
 	"version": "1.2.12"

--- a/modules/apps/collaboration/wiki/wiki-web/npm-shrinkwrap.json
+++ b/modules/apps/collaboration/wiki/wiki-web/npm-shrinkwrap.json
@@ -6,9 +6,9 @@
 			"version": "1.1.0"
 		},
 		"acorn": {
-			"from": "acorn@4.0.4",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
-			"version": "4.0.4"
+			"from": "acorn@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+			"version": "5.0.3"
 		},
 		"acorn-jsx": {
 			"dependencies": {
@@ -24,8 +24,8 @@
 		},
 		"ajv": {
 			"from": "ajv@>=4.7.0 <5.0.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.3.tgz",
-			"version": "4.11.3"
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+			"version": "4.11.7"
 		},
 		"ajv-keywords": {
 			"from": "ajv-keywords@>=1.0.0 <2.0.0",
@@ -64,8 +64,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -99,8 +99,8 @@
 		},
 		"autoprefixer": {
 			"from": "autoprefixer@>=6.0.0 <7.0.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.6.tgz",
-			"version": "6.7.6"
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+			"version": "6.7.7"
 		},
 		"babel-code-frame": {
 			"from": "babel-code-frame@>=6.16.0 <7.0.0",
@@ -109,8 +109,8 @@
 		},
 		"babylon": {
 			"from": "babylon@>=6.0.0 <7.0.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
-			"version": "6.16.1"
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+			"version": "6.17.0"
 		},
 		"balanced-match": {
 			"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -124,8 +124,8 @@
 		},
 		"bluebird": {
 			"from": "bluebird@>=3.0.6 <4.0.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"version": "3.4.7"
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+			"version": "3.5.0"
 		},
 		"boxen": {
 			"dependencies": {
@@ -141,8 +141,8 @@
 		},
 		"brace-expansion": {
 			"from": "brace-expansion@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-			"version": "1.1.6"
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+			"version": "1.1.7"
 		},
 		"braces": {
 			"from": "braces@>=1.8.2 <2.0.0",
@@ -150,12 +150,12 @@
 			"version": "1.8.5"
 		},
 		"browserslist": {
-			"from": "browserslist@>=1.7.5 <2.0.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.5.tgz",
-			"version": "1.7.5"
+			"from": "browserslist@>=1.7.6 <2.0.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+			"version": "1.7.7"
 		},
 		"buffer-shims": {
-			"from": "buffer-shims@>=1.0.0 <2.0.0",
+			"from": "buffer-shims@>=1.0.0 <1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 			"version": "1.0.0"
 		},
@@ -170,9 +170,9 @@
 			"version": "0.2.0"
 		},
 		"caniuse-db": {
-			"from": "caniuse-db@>=1.0.30000628 <2.0.0",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000631.tgz",
-			"version": "1.0.30000631"
+			"from": "caniuse-db@>=1.0.30000634 <2.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000662.tgz",
+			"version": "1.0.30000662"
 		},
 		"capture-stack-trace": {
 			"from": "capture-stack-trace@>=1.0.0 <2.0.0",
@@ -238,11 +238,16 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.2.2 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
-			"from": "concat-stream@>=1.4.6 <2.0.0",
+			"from": "concat-stream@>=1.5.2 <2.0.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 			"version": "1.6.0"
 		},
@@ -279,9 +284,9 @@
 			"version": "3.0.2"
 		},
 		"d": {
-			"from": "d@>=0.1.1 <0.2.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-			"version": "0.1.1"
+			"from": "d@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"version": "1.0.0"
 		},
 		"dateformat": {
 			"from": "dateformat@>=2.0.0 <3.0.0",
@@ -290,8 +295,8 @@
 		},
 		"debug": {
 			"from": "debug@>=2.1.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-			"version": "2.6.1"
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+			"version": "2.6.4"
 		},
 		"deep-extend": {
 			"from": "deep-extend@>=0.4.0 <0.5.0",
@@ -338,9 +343,9 @@
 					"version": "1.0.0"
 				}
 			},
-			"from": "doctrine@>=1.2.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-			"version": "1.5.0"
+			"from": "doctrine@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"dot-prop": {
 			"from": "dot-prop@>=3.0.0 <4.0.0",
@@ -365,9 +370,9 @@
 			"version": "0.13.2"
 		},
 		"electron-to-chromium": {
-			"from": "electron-to-chromium@>=1.2.3 <2.0.0",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.2.4.tgz",
-			"version": "1.2.4"
+			"from": "electron-to-chromium@>=1.2.7 <2.0.0",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.8.tgz",
+			"version": "1.3.8"
 		},
 		"end-of-stream": {
 			"from": "end-of-stream@>=0.1.5 <0.2.0",
@@ -376,23 +381,23 @@
 		},
 		"error-ex": {
 			"from": "error-ex@>=1.2.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-			"version": "1.3.0"
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"es5-ext": {
-			"from": "es5-ext@>=0.10.11 <0.11.0",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-			"version": "0.10.12"
+			"from": "es5-ext@>=0.10.14 <0.11.0",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+			"version": "0.10.15"
 		},
 		"es6-iterator": {
-			"from": "es6-iterator@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-			"version": "2.0.0"
+			"from": "es6-iterator@>=2.0.1 <2.1.0",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+			"version": "2.0.1"
 		},
 		"es6-map": {
 			"from": "es6-map@>=0.1.3 <0.2.0",
-			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-			"version": "0.1.4"
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"version": "0.1.5"
 		},
 		"es6-plato": {
 			"dependencies": {
@@ -417,19 +422,19 @@
 			"version": "1.0.14"
 		},
 		"es6-set": {
-			"from": "es6-set@>=0.1.3 <0.2.0",
-			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-			"version": "0.1.4"
+			"from": "es6-set@>=0.1.5 <0.2.0",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"version": "0.1.5"
 		},
 		"es6-symbol": {
-			"from": "es6-symbol@>=3.1.0 <3.2.0",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-			"version": "3.1.0"
+			"from": "es6-symbol@>=3.1.1 <3.2.0",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"version": "3.1.1"
 		},
 		"es6-weak-map": {
 			"from": "es6-weak-map@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"version": "2.0.2"
 		},
 		"escape-string-regexp": {
 			"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -490,18 +495,23 @@
 				}
 			},
 			"from": "eslint@>=3.9.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.16.1.tgz",
-			"version": "3.16.1"
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+			"version": "3.19.0"
 		},
 		"espree": {
 			"from": "espree@>=3.4.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
-			"version": "3.4.0"
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+			"version": "3.4.2"
 		},
 		"esprima": {
 			"from": "esprima@>=3.1.1 <4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 			"version": "3.1.3"
+		},
+		"esquery": {
+			"from": "esquery@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+			"version": "1.0.0"
 		},
 		"esrecurse": {
 			"dependencies": {
@@ -531,9 +541,9 @@
 			"version": "2.0.2"
 		},
 		"event-emitter": {
-			"from": "event-emitter@>=0.3.4 <0.4.0",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-			"version": "0.3.4"
+			"from": "event-emitter@>=0.3.5 <0.4.0",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"version": "0.3.5"
 		},
 		"exit-hook": {
 			"from": "exit-hook@>=1.0.0 <2.0.0",
@@ -680,8 +690,8 @@
 				}
 			},
 			"from": "fs-extra@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+			"version": "2.1.2"
 		},
 		"fs.realpath": {
 			"from": "fs.realpath@>=1.0.0 <2.0.0",
@@ -757,8 +767,8 @@
 		},
 		"globals": {
 			"from": "globals@>=9.14.0 <10.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
-			"version": "9.16.0"
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+			"version": "9.17.0"
 		},
 		"globby": {
 			"dependencies": {
@@ -833,8 +843,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
@@ -865,8 +880,8 @@
 			"dependencies": {
 				"abbrev": {
 					"from": "abbrev@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-					"version": "1.0.9"
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"accepts": {
 					"from": "accepts@1.3.3",
@@ -874,9 +889,9 @@
 					"version": "1.3.3"
 				},
 				"acorn": {
-					"from": "acorn@4.0.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
-					"version": "4.0.4"
+					"from": "acorn@>=5.0.1 <6.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+					"version": "5.0.3"
 				},
 				"acorn-jsx": {
 					"dependencies": {
@@ -914,8 +929,8 @@
 				},
 				"ajv": {
 					"from": "ajv@>=4.7.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.2.tgz",
-					"version": "4.11.2"
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+					"version": "4.11.7"
 				},
 				"ajv-keywords": {
 					"from": "ajv-keywords@>=1.0.0 <2.0.0",
@@ -988,6 +1003,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "archiver@>=0.14.0 <0.15.0",
@@ -996,8 +1016,8 @@
 				},
 				"are-we-there-yet": {
 					"from": "are-we-there-yet@>=1.1.2 <1.2.0",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-					"version": "1.1.2"
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"version": "1.1.4"
 				},
 				"argparse": {
 					"from": "argparse@>=1.0.7 <2.0.0",
@@ -1011,8 +1031,8 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
@@ -1089,11 +1109,6 @@
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 					"version": "0.4.0"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"aws-sign2": {
 					"from": "aws-sign2@>=0.6.0 <0.7.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -1110,9 +1125,9 @@
 					"version": "6.22.0"
 				},
 				"babel-core": {
-					"from": "babel-core@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.22.1.tgz",
-					"version": "6.22.1"
+					"from": "babel-core@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -1127,9 +1142,9 @@
 							"version": "1.3.0"
 						}
 					},
-					"from": "babel-generator@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -1137,54 +1152,54 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
-					"from": "babel-helper-define-map@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
-					"from": "babel-helper-regex@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
 					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
@@ -1224,39 +1239,39 @@
 					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
 					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
 					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
 					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
@@ -1264,39 +1279,39 @@
 					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
-					"from": "babel-plugin-transform-es2015-modules-amd@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
 					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
@@ -1304,9 +1319,9 @@
 					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
 					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
@@ -1315,28 +1330,28 @@
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
 					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal": {
 					"from": "babel-preset-metal@>=3.0.0 <4.0.0",
@@ -1345,38 +1360,38 @@
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"from": "babel-register@>=6.4.3 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
 					"from": "babel-runtime@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
-					"from": "babel-template@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
-					"from": "babel-traverse@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
-					"version": "6.22.1"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
-					"from": "babel-types@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz",
-					"version": "6.15.0"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"backo2": {
 					"from": "backo2@1.0.2",
@@ -1434,6 +1449,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "bl@>=0.9.0 <0.10.0",
@@ -1457,15 +1477,20 @@
 				},
 				"body-parser": {
 					"dependencies": {
-						"qs": {
-							"from": "qs@6.2.1",
-							"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-							"version": "6.2.1"
+						"debug": {
+							"from": "debug@2.6.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+							"version": "2.6.1"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "body-parser@>=1.12.4 <2.0.0",
-					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.0.tgz",
-					"version": "1.16.0"
+					"from": "body-parser@>=1.16.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.1.tgz",
+					"version": "1.17.1"
 				},
 				"boom": {
 					"from": "boom@>=2.0.0 <3.0.0",
@@ -1479,8 +1504,8 @@
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1493,7 +1518,7 @@
 					"version": "0.2.13"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
@@ -1538,9 +1563,9 @@
 					"version": "2.1.0"
 				},
 				"caseless": {
-					"from": "caseless@>=0.11.0 <0.12.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-					"version": "0.11.0"
+					"from": "caseless@>=0.12.0 <0.13.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"version": "0.12.0"
 				},
 				"catharsis": {
 					"from": "catharsis@>=0.8.8 <0.9.0",
@@ -1668,6 +1693,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "compress-commons@>=0.2.0 <0.3.0",
@@ -1680,7 +1710,7 @@
 					"version": "0.0.1"
 				},
 				"concat-stream": {
-					"from": "concat-stream@>=1.4.6 <2.0.0",
+					"from": "concat-stream@>=1.5.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 					"version": "1.6.0"
 				},
@@ -1692,19 +1722,19 @@
 				"connect": {
 					"dependencies": {
 						"debug": {
-							"from": "debug@>=2.2.0 <2.3.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-							"version": "2.2.0"
+							"from": "debug@2.6.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+							"version": "2.6.3"
 						},
 						"ms": {
-							"from": "ms@0.7.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-							"version": "0.7.1"
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "connect@>=3.3.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
-					"version": "3.5.0"
+					"from": "connect@>=3.6.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.1.tgz",
+					"version": "3.6.1"
 				},
 				"console-browserify": {
 					"from": "console-browserify@>=1.1.0 <1.2.0",
@@ -1723,8 +1753,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"cookie": {
 					"from": "cookie@0.3.1",
@@ -1752,6 +1782,11 @@
 							"from": "readable-stream@>=1.0.24 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "crc32-stream@>=0.3.1 <0.4.0",
@@ -1775,18 +1810,6 @@
 					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"version": "2.0.5"
 				},
-				"css": {
-					"dependencies": {
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
 				"ctype": {
 					"from": "ctype@0.5.3",
 					"resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
@@ -1803,9 +1826,9 @@
 					"version": "1.0.1"
 				},
 				"d": {
-					"from": "d@>=0.1.1 <0.2.0",
-					"resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-					"version": "0.1.1"
+					"from": "d@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+					"version": "1.0.0"
 				},
 				"dashdash": {
 					"dependencies": {
@@ -1836,20 +1859,8 @@
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-					"version": "2.6.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
 					"from": "decamelize@>=1.1.2 <2.0.0",
@@ -1891,11 +1902,6 @@
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 					"version": "4.0.0"
 				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
-				},
 				"di": {
 					"from": "di@>=0.0.1 <0.0.2",
 					"resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
@@ -1912,9 +1918,9 @@
 					"version": "2.0.0"
 				},
 				"doctrine": {
-					"from": "doctrine@>=1.2.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"version": "1.5.0"
+					"from": "doctrine@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"dom-serialize": {
 					"from": "dom-serialize@>=2.2.0 <3.0.0",
@@ -1969,6 +1975,11 @@
 							"from": "readable-stream@>=1.1.9 <1.2.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 							"version": "1.1.14"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "duplexer2@0.0.2",
@@ -2002,17 +2013,27 @@
 					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 					"version": "1.1.1"
 				},
+				"encodeurl": {
+					"from": "encodeurl@>=1.0.1 <1.1.0",
+					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"engine.io": {
 					"dependencies": {
 						"debug": {
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "engine.io@1.8.2",
-					"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz",
-					"version": "1.8.2"
+					"from": "engine.io@1.8.3",
+					"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
+					"version": "1.8.3"
 				},
 				"engine.io-client": {
 					"dependencies": {
@@ -2025,11 +2046,16 @@
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "engine.io-client@1.8.2",
-					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.2.tgz",
-					"version": "1.8.2"
+					"from": "engine.io-client@1.8.3",
+					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
+					"version": "1.8.3"
 				},
 				"engine.io-parser": {
 					"from": "engine.io-parser@1.3.2",
@@ -2048,38 +2074,38 @@
 				},
 				"error-ex": {
 					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"es5-ext": {
-					"from": "es5-ext@>=0.10.11 <0.11.0",
-					"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-					"version": "0.10.12"
+					"from": "es5-ext@>=0.10.14 <0.11.0",
+					"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+					"version": "0.10.15"
 				},
 				"es6-iterator": {
-					"from": "es6-iterator@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "es6-iterator@>=2.0.1 <2.1.0",
+					"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"es6-map": {
 					"from": "es6-map@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-					"version": "0.1.4"
+					"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"es6-set": {
-					"from": "es6-set@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "es6-set@>=0.1.5 <0.2.0",
+					"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"es6-symbol": {
-					"from": "es6-symbol@>=3.1.0 <3.2.0",
-					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-					"version": "3.1.0"
+					"from": "es6-symbol@>=3.1.1 <3.2.0",
+					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+					"version": "3.1.1"
 				},
 				"es6-weak-map": {
 					"from": "es6-weak-map@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"escape-html": {
 					"from": "escape-html@>=1.0.3 <1.1.0",
@@ -2157,18 +2183,23 @@
 				},
 				"eslint": {
 					"from": "eslint@>=3.12.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.15.0.tgz",
-					"version": "3.15.0"
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+					"version": "3.19.0"
 				},
 				"espree": {
 					"from": "espree@>=3.4.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
-					"version": "3.4.0"
+					"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+					"version": "3.4.2"
 				},
 				"esprima": {
 					"from": "esprima@>=3.1.1 <4.0.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 					"version": "3.1.3"
+				},
+				"esquery": {
+					"from": "esquery@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+					"version": "1.0.0"
 				},
 				"esrecurse": {
 					"dependencies": {
@@ -2193,9 +2224,9 @@
 					"version": "2.0.2"
 				},
 				"event-emitter": {
-					"from": "event-emitter@>=0.3.4 <0.4.0",
-					"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-					"version": "0.3.4"
+					"from": "event-emitter@>=0.3.5 <0.4.0",
+					"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+					"version": "0.3.5"
 				},
 				"eventemitter3": {
 					"from": "eventemitter3@>=1.0.0 <2.0.0",
@@ -2302,19 +2333,19 @@
 				"finalhandler": {
 					"dependencies": {
 						"debug": {
-							"from": "debug@>=2.2.0 <2.3.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-							"version": "2.2.0"
+							"from": "debug@2.6.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+							"version": "2.6.3"
 						},
 						"ms": {
-							"from": "ms@0.7.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-							"version": "0.7.1"
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "finalhandler@0.5.0",
-					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-					"version": "0.5.0"
+					"from": "finalhandler@1.0.1",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"find-up": {
 					"from": "find-up@>=1.0.0 <2.0.0",
@@ -2332,14 +2363,14 @@
 					"version": "1.2.2"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
 					"from": "for-own@>=0.1.4 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"forever-agent": {
 					"from": "forever-agent@>=0.6.1 <0.7.0",
@@ -2353,8 +2384,8 @@
 				},
 				"form-data": {
 					"from": "form-data@>=2.1.1 <2.2.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-					"version": "2.1.2"
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"version": "2.1.4"
 				},
 				"formatio": {
 					"from": "formatio@1.1.1",
@@ -2373,13 +2404,13 @@
 				},
 				"fstream": {
 					"from": "fstream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-					"version": "1.0.10"
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"version": "1.0.11"
 				},
 				"gauge": {
 					"from": "gauge@>=2.7.1 <2.8.0",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-					"version": "2.7.3"
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"version": "2.7.4"
 				},
 				"generate-function": {
 					"from": "generate-function@>=2.0.0 <3.0.0",
@@ -2452,8 +2483,8 @@
 				},
 				"globals": {
 					"from": "globals@>=9.0.0 <10.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-					"version": "9.14.0"
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globby": {
 					"from": "globby@>=5.0.0 <6.0.0",
@@ -2504,8 +2535,8 @@
 						},
 						"vinyl": {
 							"from": "vinyl@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+							"version": "2.0.2"
 						}
 					},
 					"from": "gulp-concat@>=2.5.2 <3.0.0",
@@ -2575,9 +2606,9 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.11.1.tgz",
-					"version": "1.11.1"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-uglify": {
 					"from": "gulp-uglify@>=1.2.0 <2.0.0",
@@ -2613,6 +2644,11 @@
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"through2": {
 							"from": "through2@>=0.6.5 <0.7.0",
 							"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
@@ -2645,10 +2681,15 @@
 					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
 					"version": "4.0.6"
 				},
+				"har-schema": {
+					"from": "har-schema@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"version": "1.0.5"
+				},
 				"har-validator": {
-					"from": "har-validator@>=2.0.6 <2.1.0",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-					"version": "2.0.6"
+					"from": "har-validator@>=4.2.1 <4.3.0",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"version": "4.2.1"
 				},
 				"has-ansi": {
 					"from": "has-ansi@>=2.0.0 <3.0.0",
@@ -2709,8 +2750,8 @@
 				},
 				"hosted-git-info": {
 					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
-					"version": "2.2.0"
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+					"version": "2.4.2"
 				},
 				"htmlparser2": {
 					"dependencies": {
@@ -2723,6 +2764,11 @@
 							"from": "readable-stream@>=1.1.0 <1.2.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 							"version": "1.1.14"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "htmlparser2@>=3.8.0 <3.9.0",
@@ -2730,9 +2776,9 @@
 					"version": "3.8.3"
 				},
 				"http-errors": {
-					"from": "http-errors@>=1.5.1 <1.6.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-					"version": "1.5.1"
+					"from": "http-errors@>=1.6.1 <1.7.0",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"http-proxy": {
 					"from": "http-proxy@>=1.13.0 <2.0.0",
@@ -2778,8 +2824,8 @@
 				},
 				"ignore": {
 					"from": "ignore@>=3.2.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.2.tgz",
-					"version": "3.2.2"
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+					"version": "3.2.7"
 				},
 				"imurmurhash": {
 					"from": "imurmurhash@>=0.1.4 <0.2.0",
@@ -2818,8 +2864,8 @@
 				},
 				"interpret": {
 					"from": "interpret@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
@@ -2847,9 +2893,9 @@
 					"version": "1.0.1"
 				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-builtin-module": {
 					"from": "is-builtin-module@>=1.0.0 <2.0.0",
@@ -2893,8 +2939,8 @@
 				},
 				"is-my-json-valid": {
 					"from": "is-my-json-valid@>=2.10.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-					"version": "2.15.0"
+					"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+					"version": "2.16.0"
 				},
 				"is-number": {
 					"from": "is-number@>=2.1.0 <3.0.0",
@@ -2967,9 +3013,9 @@
 					"version": "3.0.2"
 				},
 				"isexe": {
-					"from": "isexe@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-					"version": "1.1.2"
+					"from": "isexe@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"isobject": {
 					"from": "isobject@>=2.0.0 <3.0.0",
@@ -2995,6 +3041,11 @@
 				},
 				"istanbul": {
 					"dependencies": {
+						"abbrev": {
+							"from": "abbrev@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+							"version": "1.0.9"
+						},
 						"async": {
 							"from": "async@>=1.0.0 <2.0.0",
 							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -3059,8 +3110,8 @@
 				},
 				"js-yaml": {
 					"from": "js-yaml@>=3.5.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.1.tgz",
-					"version": "3.8.1"
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+					"version": "3.8.3"
 				},
 				"js2xmlparser": {
 					"from": "js2xmlparser@>=1.0.0 <1.1.0",
@@ -3069,8 +3120,8 @@
 				},
 				"jsbn": {
 					"from": "jsbn@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-					"version": "0.1.0"
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"version": "0.1.1"
 				},
 				"jsdoc": {
 					"dependencies": {
@@ -3157,9 +3208,16 @@
 					"version": "4.0.1"
 				},
 				"jsprim": {
+					"dependencies": {
+						"assert-plus": {
+							"from": "assert-plus@1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"version": "1.0.0"
+						}
+					},
 					"from": "jsprim@>=1.2.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+					"version": "1.4.0"
 				},
 				"karma": {
 					"dependencies": {
@@ -3170,8 +3228,8 @@
 						}
 					},
 					"from": "karma@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/karma/-/karma-1.4.1.tgz",
-					"version": "1.4.1"
+					"resolved": "https://registry.npmjs.org/karma/-/karma-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"karma-babel-preprocessor": {
 					"from": "karma-babel-preprocessor@>=6.0.1 <7.0.0",
@@ -3229,8 +3287,8 @@
 					"dependencies": {
 						"q": {
 							"from": "q@>=1.4.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-							"version": "1.4.1"
+							"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+							"version": "1.5.0"
 						}
 					},
 					"from": "karma-sauce-launcher@>=0.3.0 <0.4.0",
@@ -3254,8 +3312,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-					"version": "3.1.0"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"klaw": {
 					"from": "klaw@>=1.3.0 <1.4.0",
@@ -3266,11 +3324,6 @@
 					"from": "lazy-cache@>=1.0.3 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 					"version": "1.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -3283,6 +3336,11 @@
 							"from": "readable-stream@>=1.0.2 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "lazystream@>=0.1.0 <0.2.0",
@@ -3437,6 +3495,11 @@
 							"from": "readable-stream@>=1.0.2 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "log4js@>=0.6.31 <0.7.0",
@@ -3569,6 +3632,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -3585,21 +3653,13 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
-							"dependencies": {
-								"gulp-sourcemaps": {
-									"from": "gulp-sourcemaps@1.6.0",
-									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-									"version": "1.6.0"
-								}
-							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
 							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.2.tgz",
-					"version": "3.0.2"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"dependencies": {
@@ -3655,6 +3715,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -3671,21 +3736,13 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
-							"dependencies": {
-								"gulp-sourcemaps": {
-									"from": "gulp-sourcemaps@1.6.0",
-									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-									"version": "1.6.0"
-								}
-							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
 							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"dependencies": {
@@ -3741,6 +3798,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -3757,21 +3819,13 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
-							"dependencies": {
-								"gulp-sourcemaps": {
-									"from": "gulp-sourcemaps@1.6.0",
-									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-									"version": "1.6.0"
-								}
-							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
 							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
 					"dependencies": {
@@ -3802,11 +3856,6 @@
 							"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 							"version": "5.3.5"
 						},
-						"gulp-sourcemaps": {
-							"from": "gulp-sourcemaps@1.6.0",
-							"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-							"version": "1.6.0"
-						},
 						"is-extglob": {
 							"from": "is-extglob@>=2.1.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3832,6 +3881,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -3854,8 +3908,7 @@
 						}
 					},
 					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"version": "3.1.0"
 				},
 				"micromatch": {
 					"from": "micromatch@>=2.3.7 <3.0.0",
@@ -3868,14 +3921,14 @@
 					"version": "1.3.4"
 				},
 				"mime-db": {
-					"from": "mime-db@>=1.26.0 <1.27.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-					"version": "1.26.0"
+					"from": "mime-db@>=1.27.0 <1.28.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+					"version": "1.27.0"
 				},
 				"mime-types": {
 					"from": "mime-types@>=2.1.7 <2.2.0",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-					"version": "2.1.14"
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+					"version": "2.1.15"
 				},
 				"minimatch": {
 					"from": "minimatch@>=3.0.2 <4.0.0",
@@ -3945,9 +3998,9 @@
 					"version": "1.0.0"
 				},
 				"ms": {
-					"from": "ms@0.7.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-					"version": "0.7.2"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -3966,8 +4019,8 @@
 				},
 				"nan": {
 					"from": "nan@>=2.3.2 <3.0.0",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
-					"version": "2.5.1"
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+					"version": "2.6.2"
 				},
 				"natural-compare": {
 					"from": "natural-compare@>=1.4.0 <2.0.0",
@@ -3980,9 +4033,16 @@
 					"version": "0.6.1"
 				},
 				"node-gyp": {
+					"dependencies": {
+						"semver": {
+							"from": "semver@>=5.3.0 <5.4.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+							"version": "5.3.0"
+						}
+					},
 					"from": "node-gyp@>=3.3.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
-					"version": "3.5.0"
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
+					"version": "3.6.0"
 				},
 				"node-int64": {
 					"from": "node-int64@>=0.3.0 <0.4.0",
@@ -4045,13 +4105,13 @@
 				},
 				"normalize-package-data": {
 					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+					"version": "2.3.8"
 				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"npm-path": {
 					"from": "npm-path@>=1.0.1 <2.0.0",
@@ -4227,10 +4287,20 @@
 					"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
 					"version": "1.0.2"
 				},
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
+				},
 				"path-type": {
 					"from": "path-type@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"version": "1.1.0"
+				},
+				"performance-now": {
+					"from": "performance-now@>=0.2.0 <0.3.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"version": "0.2.0"
 				},
 				"pify": {
 					"from": "pify@>=2.0.0 <3.0.0",
@@ -4308,9 +4378,9 @@
 					"version": "1.1.5"
 				},
 				"qs": {
-					"from": "qs@>=6.3.0 <6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-					"version": "6.3.0"
+					"from": "qs@>=6.4.0 <6.5.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"version": "6.4.0"
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
@@ -4349,8 +4419,8 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.2.2 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-					"version": "2.2.2"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
 				},
 				"readdirp": {
 					"from": "readdirp@>=2.0.0 <3.0.0",
@@ -4379,13 +4449,13 @@
 				},
 				"regenerator-runtime": {
 					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-					"version": "0.10.1"
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz",
+					"version": "0.10.3"
 				},
 				"regenerator-transform": {
-					"from": "regenerator-transform@0.9.8",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
-					"version": "0.9.8"
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -4439,8 +4509,8 @@
 				},
 				"request": {
 					"from": "request@>=2.61.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-					"version": "2.79.0"
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"version": "2.81.0"
 				},
 				"require-directory": {
 					"from": "require-directory@>=2.1.1 <3.0.0",
@@ -4476,18 +4546,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.6 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"resolve-from": {
 					"from": "resolve-from@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
 				},
 				"restore-cursor": {
 					"from": "restore-cursor@>=1.0.1 <2.0.0",
@@ -4501,8 +4566,8 @@
 				},
 				"rimraf": {
 					"from": "rimraf@>=2.2.8 <3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-					"version": "2.5.4"
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+					"version": "2.6.1"
 				},
 				"rocambole": {
 					"dependencies": {
@@ -4631,14 +4696,14 @@
 					"version": "1.0.1"
 				},
 				"setprototypeof": {
-					"from": "setprototypeof@1.0.2",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "setprototypeof@1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"shelljs": {
 					"from": "shelljs@>=0.7.5 <0.8.0",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-					"version": "0.7.6"
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+					"version": "0.7.7"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
@@ -4677,15 +4742,20 @@
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
 						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
+						},
 						"object-assign": {
 							"from": "object-assign@4.1.0",
 							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
 							"version": "4.1.0"
 						}
 					},
-					"from": "socket.io@1.7.2",
-					"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz",
-					"version": "1.7.2"
+					"from": "socket.io@1.7.3",
+					"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
+					"version": "1.7.3"
 				},
 				"socket.io-adapter": {
 					"dependencies": {
@@ -4693,6 +4763,11 @@
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
 					"from": "socket.io-adapter@0.5.0",
@@ -4710,11 +4785,16 @@
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "socket.io-client@1.7.2",
-					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.2.tgz",
-					"version": "1.7.2"
+					"from": "socket.io-client@1.7.3",
+					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
+					"version": "1.7.3"
 				},
 				"socket.io-parser": {
 					"dependencies": {
@@ -4743,20 +4823,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.11.tgz",
-					"version": "0.4.11"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -4802,8 +4872,8 @@
 						}
 					},
 					"from": "sshpk@>=1.7.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-					"version": "1.10.2"
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+					"version": "1.13.0"
 				},
 				"statuses": {
 					"from": "statuses@>=1.3.1 <2.0.0",
@@ -4841,9 +4911,9 @@
 					"version": "1.0.2"
 				},
 				"string_decoder": {
-					"from": "string_decoder@>=0.10.0 <0.11.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"version": "0.10.31"
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				},
 				"stringstream": {
 					"from": "stringstream@>=0.0.4 <0.1.0",
@@ -4923,23 +4993,23 @@
 					"dependencies": {
 						"end-of-stream": {
 							"from": "end-of-stream@>=1.0.0 <2.0.0",
-							"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-							"version": "1.1.0"
+							"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+							"version": "1.4.0"
 						},
 						"isarray": {
 							"from": "isarray@0.0.1",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 							"version": "0.0.1"
 						},
-						"once": {
-							"from": "once@>=1.3.0 <1.4.0",
-							"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-							"version": "1.3.3"
-						},
 						"readable-stream": {
 							"from": "readable-stream@>=1.0.33 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "tar-stream@>=1.1.0 <1.2.0",
@@ -4994,9 +5064,9 @@
 					"version": "1.0.1"
 				},
 				"tmp": {
-					"from": "tmp@0.0.28",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-					"version": "0.0.28"
+					"from": "tmp@0.0.31",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+					"version": "0.0.31"
 				},
 				"to-absolute-glob": {
 					"from": "to-absolute-glob@>=0.1.1 <0.2.0",
@@ -5028,6 +5098,11 @@
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 					"version": "1.0.0"
 				},
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"tryit": {
 					"from": "tryit@>=1.0.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -5046,9 +5121,9 @@
 					"version": "1.0.0"
 				},
 				"tunnel-agent": {
-					"from": "tunnel-agent@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-					"version": "0.4.3"
+					"from": "tunnel-agent@>=0.6.0 <0.7.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"version": "0.6.0"
 				},
 				"tweetnacl": {
 					"from": "tweetnacl@>=0.14.0 <0.15.0",
@@ -5067,8 +5142,8 @@
 				},
 				"type-is": {
 					"from": "type-is@>=1.6.14 <1.7.0",
-					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
-					"version": "1.6.14"
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+					"version": "1.6.15"
 				},
 				"typedarray": {
 					"from": "typedarray@>=0.0.6 <0.0.7",
@@ -5149,11 +5224,6 @@
 					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
 				"user-home": {
 					"from": "user-home@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -5167,9 +5237,9 @@
 							"version": "2.2.4"
 						}
 					},
-					"from": "useragent@>=2.1.10 <3.0.0",
-					"resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.12.tgz",
-					"version": "2.1.12"
+					"from": "useragent@>=2.1.12 <3.0.0",
+					"resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
+					"version": "2.1.13"
 				},
 				"util": {
 					"dependencies": {
@@ -5319,8 +5389,8 @@
 						},
 						"node-uuid": {
 							"from": "node-uuid@>=1.4.0 <1.5.0",
-							"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-							"version": "1.4.7"
+							"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+							"version": "1.4.8"
 						},
 						"oauth-sign": {
 							"from": "oauth-sign@>=0.6.0 <0.7.0",
@@ -5341,6 +5411,11 @@
 							"from": "request@>=2.55.0 <2.56.0",
 							"resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
 							"version": "2.55.0"
+						},
+						"tunnel-agent": {
+							"from": "tunnel-agent@>=0.4.0 <0.5.0",
+							"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+							"version": "0.4.3"
 						}
 					},
 					"from": "wd@>=0.3.4 <0.4.0",
@@ -5349,8 +5424,8 @@
 				},
 				"which": {
 					"from": "which@>=1.2.12 <2.0.0",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-					"version": "1.2.12"
+					"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+					"version": "1.2.14"
 				},
 				"which-module": {
 					"from": "which-module@>=1.0.0 <2.0.0",
@@ -5388,9 +5463,9 @@
 					"version": "0.2.1"
 				},
 				"ws": {
-					"from": "ws@1.1.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-					"version": "1.1.1"
+					"from": "ws@1.1.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
+					"version": "1.1.2"
 				},
 				"wtf-8": {
 					"from": "wtf-8@1.0.0",
@@ -5414,8 +5489,8 @@
 				},
 				"yallist": {
 					"from": "yallist@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"version": "2.1.2"
 				},
 				"yargs": {
 					"from": "yargs@>=4.7.1 <5.0.0",
@@ -5455,6 +5530,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "zip-stream@>=0.5.0 <0.6.0",
@@ -5463,8 +5543,8 @@
 				}
 			},
 			"from": "gulp-metal@>=1.9.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.11.2.tgz",
-			"version": "1.11.2"
+			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.12.1.tgz",
+			"version": "1.12.1"
 		},
 		"gulp-util": {
 			"from": "gulp-util@>=3.0.0 <4.0.0",
@@ -5498,8 +5578,8 @@
 		},
 		"ignore": {
 			"from": "ignore@>=3.2.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.4.tgz",
-			"version": "3.2.4"
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+			"version": "3.2.7"
 		},
 		"imurmurhash": {
 			"from": "imurmurhash@>=0.1.4 <0.2.0",
@@ -5535,8 +5615,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -5549,9 +5629,9 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-			"version": "1.1.4"
+			"from": "is-buffer@>=1.1.5 <2.0.0",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"version": "1.1.5"
 		},
 		"is-dotfile": {
 			"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -5684,9 +5764,9 @@
 			"version": "0.0.1"
 		},
 		"isexe": {
-			"from": "isexe@>=1.1.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-			"version": "1.1.2"
+			"from": "isexe@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"isobject": {
 			"dependencies": {
@@ -5707,8 +5787,8 @@
 		},
 		"js-beautify": {
 			"from": "js-beautify@>=1.5.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.11.tgz",
-			"version": "1.6.11"
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.12.tgz",
+			"version": "1.6.12"
 		},
 		"js-tokens": {
 			"from": "js-tokens@>=3.0.0 <4.0.0",
@@ -5717,8 +5797,8 @@
 		},
 		"js-yaml": {
 			"from": "js-yaml@>=3.5.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.1.tgz",
-			"version": "3.8.1"
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+			"version": "3.8.3"
 		},
 		"json-stable-stringify": {
 			"from": "json-stable-stringify@>=1.0.0 <2.0.0",
@@ -5761,8 +5841,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"dependencies": {
@@ -5955,20 +6035,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -5982,18 +6052,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -6005,22 +6070,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -6029,8 +6089,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -6046,13 +6106,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -6060,73 +6120,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -6151,198 +6211,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -6351,8 +6412,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -6361,13 +6422,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -6375,24 +6436,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -6416,8 +6467,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -6431,8 +6482,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -6444,64 +6495,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -6527,23 +6539,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -6589,8 +6601,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -6602,32 +6614,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -6638,11 +6638,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -6700,8 +6695,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -6741,9 +6736,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -6772,25 +6767,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -6806,8 +6801,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -6817,9 +6817,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -6827,14 +6827,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -6874,26 +6881,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -6907,28 +6897,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -6947,8 +6927,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -6961,7 +6941,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -7018,9 +6998,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -7033,9 +7013,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -7044,13 +7024,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -7066,8 +7041,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -7078,18 +7058,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -7158,8 +7126,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -7182,43 +7150,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -7239,13 +7178,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -7254,23 +7198,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -7295,18 +7235,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -7317,9 +7250,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -7331,15 +7264,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -7353,8 +7281,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -7375,13 +7303,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -7410,47 +7348,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -7458,9 +7369,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -7469,18 +7380,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -7494,20 +7395,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -7529,6 +7430,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -7536,13 +7442,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -7563,13 +7469,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -7583,33 +7494,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -7621,20 +7512,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -7645,21 +7526,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -7701,20 +7567,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -7739,14 +7600,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -7768,10 +7634,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -7783,16 +7649,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7803,11 +7659,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -7817,8 +7668,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -7832,13 +7683,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -7847,8 +7703,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -7862,8 +7718,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -7871,7 +7727,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -7886,9 +7742,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.1.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-events": {
 			"from": "metal-events@>=2.5.0 <3.0.0",
@@ -7923,9 +7779,9 @@
 			"version": "0.5.1"
 		},
 		"ms": {
-			"from": "ms@0.7.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-			"version": "0.7.2"
+			"from": "ms@0.7.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+			"version": "0.7.3"
 		},
 		"multipipe": {
 			"from": "multipipe@>=0.1.2 <0.2.0",
@@ -7959,8 +7815,8 @@
 		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"normalize-range": {
 			"from": "normalize-range@>=0.1.2 <0.2.0",
@@ -8123,8 +7979,8 @@
 				}
 			},
 			"from": "postcss@>=5.0.4 <6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.15.tgz",
-			"version": "5.2.15"
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+			"version": "5.2.17"
 		},
 		"postcss-value-parser": {
 			"from": "postcss-value-parser@>=3.2.3 <4.0.0",
@@ -8183,8 +8039,8 @@
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"version": "1.2.1"
 		},
 		"read-all-stream": {
 			"dependencies": {
@@ -8195,8 +8051,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
@@ -8237,13 +8098,18 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"version": "3.1.0"
+		},
+		"remove-trailing-separator": {
+			"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"repeat-element": {
 			"from": "repeat-element@>=1.1.2 <2.0.0",
@@ -8272,8 +8138,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -8317,6 +8183,11 @@
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
 			"version": "3.1.2"
 		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
+		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
@@ -8353,8 +8224,8 @@
 				}
 			},
 			"from": "shelljs@>=0.7.5 <0.8.0",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-			"version": "0.7.6"
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+			"version": "0.7.7"
 		},
 		"sigmund": {
 			"from": "sigmund@>=1.0.0 <1.1.0",
@@ -8462,8 +8333,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.1.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
@@ -8594,8 +8470,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-			"version": "2.0.11"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -8646,8 +8522,8 @@
 		},
 		"which": {
 			"from": "which@>=1.2.12 <2.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-			"version": "1.2.12"
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+			"version": "1.2.14"
 		},
 		"widest-line": {
 			"from": "widest-line@>=1.0.0 <2.0.0",
@@ -8678,8 +8554,8 @@
 				}
 			},
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/collaboration/wiki/wiki-web/package.json
+++ b/modules/apps/collaboration/wiki/wiki-web/package.json
@@ -7,7 +7,7 @@
 		"gulp": "^3.9.1",
 		"gulp-metal": "^1.9.10",
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.1.2"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "wiki-web",
 	"version": "2.1.26"

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-accessibility-web/package.json
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-accessibility-web/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"babel-preset-react": "^6.11.1",
-		"metal-cli": "^2.0.0"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "frontend-editor-alloyeditor-accessibility-web",
 	"version": "1.0.4"

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-link-browse-web/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-link-browse-web/npm-shrinkwrap.json
@@ -46,7 +46,7 @@
 			"version": "6.23.0"
 		},
 		"babel-preset-react": {
-			"from": "babel-preset-react@>=6.11.1 <7.0.0",
+			"from": "babel-preset-react@>=6.22.0 <7.0.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"version": "6.24.1"
 		},
@@ -1799,6 +1799,6 @@
 			"version": "1.0.2"
 		}
 	},
-	"name": "frontend-editor-alloyeditor-accessibility-web",
-	"version": "1.0.4"
+	"name": "frontend-editor-alloyeditor-link-browse-web",
+	"version": "1.0.2"
 }

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-link-browse-web/package.json
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-link-browse-web/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"babel-preset-react": "^6.22.0",
-		"metal-cli": "^2.1.2"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "frontend-editor-alloyeditor-link-browse-web",
 	"version": "1.0.2"

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-brightness/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-brightness/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-brightness/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-brightness/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-capability-brightness",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-contrast/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-contrast/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-contrast/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-contrast/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-capability-contrast",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-crop/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-crop/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-crop/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-crop/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-capability-crop",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-capability-effects",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-resize/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-resize/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-resize/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-resize/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-capability-resize",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-rotate/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-rotate/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-rotate/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-rotate/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-capability-rotate",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-saturation/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-saturation/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-saturation/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-saturation/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-capability-saturation",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -541,8 +541,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -883,20 +883,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -910,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -933,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -957,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -974,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -988,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1079,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1279,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1289,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1303,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1344,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1359,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1372,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1455,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1517,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1530,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1566,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1628,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1669,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1700,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1734,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1745,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1755,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1802,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1835,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1875,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1889,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1946,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1961,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1972,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1994,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2006,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2086,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2110,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2167,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2182,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2223,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2245,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2259,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2281,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2303,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2338,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2386,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2397,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2422,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2457,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2464,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2491,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2511,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2549,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2573,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2629,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2667,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2696,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2711,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2731,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2745,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2760,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2775,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2790,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2799,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2814,9 +2590,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
@@ -3213,8 +2989,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -3248,8 +3024,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3260,6 +3036,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3439,8 +3220,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz",
-			"version": "2.0.12"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3506,8 +3287,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/package.json
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2",
+		"metal-cli": "^4.0.1",
 		"metal-components": "1.0.0-rc.19"
 	},
 	"name": "frontend-image-editor-web",

--- a/modules/apps/foundation/frontend-js/frontend-js-metal-web/build.gradle
+++ b/modules/apps/foundation/frontend-js/frontend-js-metal-web/build.gradle
@@ -1,11 +1,19 @@
+afterEvaluate {
+	transpileJS {
+		soyDependencies = []
+	}
+}
+
 configJSModules {
 	dependsOn transpileJS
 	include "**/*.js*"
 	moduleFormat "/.soy/g,.soy.js"
 }
 
+
 transpileJS {
 	skipWhenEmpty = false
 	sourceDir = npmInstall.nodeModulesDir
+	soySrcIncludes = "metal*/src/**/*.soy"
 	srcIncludes = "metal*/src/**/*.js"
 }

--- a/modules/apps/foundation/frontend-js/frontend-js-metal-web/build.gradle
+++ b/modules/apps/foundation/frontend-js/frontend-js-metal-web/build.gradle
@@ -10,7 +10,6 @@ configJSModules {
 	moduleFormat "/.soy/g,.soy.js"
 }
 
-
 transpileJS {
 	skipWhenEmpty = false
 	sourceDir = npmInstall.nodeModulesDir

--- a/modules/apps/foundation/frontend-js/frontend-js-metal-web/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-js/frontend-js-metal-web/npm-shrinkwrap.json
@@ -555,7 +555,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -693,8 +693,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -888,20 +888,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -915,18 +905,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -938,22 +923,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -962,8 +942,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -979,13 +959,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -993,73 +973,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1084,198 +1064,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1284,8 +1265,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1294,13 +1275,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1308,24 +1289,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1349,8 +1320,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1364,8 +1335,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1377,64 +1348,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1460,23 +1392,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1522,8 +1454,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1535,32 +1467,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1571,11 +1491,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1633,8 +1548,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1674,9 +1589,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1705,25 +1620,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1739,8 +1654,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1750,9 +1670,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1760,14 +1680,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1807,26 +1734,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1840,28 +1750,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1880,8 +1780,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1894,7 +1794,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1951,9 +1851,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1966,9 +1866,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1977,13 +1877,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1999,8 +1894,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2011,18 +1911,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2091,8 +1979,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2115,43 +2003,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2172,13 +2031,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2187,23 +2051,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2228,18 +2088,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2250,9 +2103,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2264,15 +2117,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2286,8 +2134,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2308,13 +2156,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2343,47 +2201,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2391,9 +2222,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2402,18 +2233,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2427,20 +2248,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2462,6 +2283,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2469,13 +2295,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2496,13 +2322,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2516,33 +2347,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2554,20 +2365,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2578,21 +2379,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2634,20 +2420,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2672,14 +2453,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2701,10 +2487,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2716,16 +2502,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2736,11 +2512,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2750,8 +2521,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2765,13 +2536,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2780,8 +2556,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2795,8 +2571,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2804,7 +2580,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2819,9 +2595,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=2.0.0 <3.0.0",
@@ -3571,8 +3347,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.3.tgz",
-			"version": "1.3.3"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-js/frontend-js-metal-web/package.json
+++ b/modules/apps/foundation/frontend-js/frontend-js-metal-web/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "frontend-js-metal-web",
 	"version": "1.0.15"

--- a/modules/apps/foundation/frontend-js/frontend-js-spa-web/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-js/frontend-js-spa-web/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -84,8 +84,8 @@
 		},
 		"brace-expansion": {
 			"from": "brace-expansion@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-			"version": "1.1.6"
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+			"version": "1.1.7"
 		},
 		"braces": {
 			"from": "braces@>=1.8.2 <2.0.0",
@@ -93,7 +93,7 @@
 			"version": "1.8.5"
 		},
 		"buffer-shims": {
-			"from": "buffer-shims@>=1.0.0 <2.0.0",
+			"from": "buffer-shims@>=1.0.0 <1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 			"version": "1.0.0"
 		},
@@ -456,8 +456,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz",
-					"version": "2.2.5"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
@@ -526,8 +531,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -540,7 +545,7 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -645,9 +650,9 @@
 			"version": "0.0.1"
 		},
 		"isexe": {
-			"from": "isexe@>=1.1.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-			"version": "1.1.2"
+			"from": "isexe@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"isobject": {
 			"dependencies": {
@@ -663,8 +668,8 @@
 		},
 		"js-beautify": {
 			"from": "js-beautify@>=1.5.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.11.tgz",
-			"version": "1.6.11"
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.12.tgz",
+			"version": "1.6.12"
 		},
 		"jsonfile": {
 			"from": "jsonfile@>=2.1.0 <3.0.0",
@@ -678,8 +683,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -848,20 +853,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -875,18 +870,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -898,22 +888,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -922,8 +907,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -939,13 +924,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -953,73 +938,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1044,198 +1029,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1244,8 +1230,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1254,13 +1240,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1268,24 +1254,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1309,8 +1285,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1324,8 +1300,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1337,64 +1313,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1420,23 +1357,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1482,8 +1419,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1495,32 +1432,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1531,11 +1456,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1593,8 +1513,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1634,9 +1554,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1665,25 +1585,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1699,8 +1619,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1710,9 +1635,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1720,14 +1645,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1767,26 +1699,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1800,28 +1715,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1840,8 +1745,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1854,7 +1759,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1911,9 +1816,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1926,9 +1831,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1937,13 +1842,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1959,8 +1859,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -1971,18 +1876,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2051,8 +1944,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2075,43 +1968,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2132,13 +1996,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2147,23 +2016,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2188,18 +2053,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2210,9 +2068,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2224,15 +2082,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2246,8 +2099,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2268,13 +2121,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2303,47 +2166,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2351,9 +2187,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2362,18 +2198,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2387,20 +2213,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2422,6 +2248,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2429,13 +2260,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2456,13 +2287,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2476,33 +2312,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2514,20 +2330,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2538,21 +2344,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2594,20 +2385,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2632,14 +2418,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2661,10 +2452,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2676,16 +2467,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2696,11 +2477,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2710,8 +2486,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2725,13 +2501,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2740,8 +2521,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2755,8 +2536,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2764,7 +2545,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2779,9 +2560,9 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-debounce": {
 			"from": "metal-debounce@>=2.0.0 <3.0.0",
@@ -2790,8 +2571,8 @@
 		},
 		"metal-dom": {
 			"from": "metal-dom@>=2.4.7 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.6.4.tgz",
-			"version": "2.6.4"
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-events": {
 			"from": "metal-events@>=2.6.4 <3.0.0",
@@ -2815,8 +2596,8 @@
 		},
 		"metal-uri": {
 			"from": "metal-uri@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-uri/-/metal-uri-2.0.2.tgz",
-			"version": "2.0.2"
+			"resolved": "https://registry.npmjs.org/metal-uri/-/metal-uri-2.1.0.tgz",
+			"version": "2.1.0"
 		},
 		"metal-useragent": {
 			"from": "metal-useragent@>=2.0.0 <3.0.0",
@@ -2872,8 +2653,8 @@
 		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"number-is-nan": {
 			"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2957,6 +2738,11 @@
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"version": "1.0.0"
 		},
+		"path-browserify": {
+			"from": "path-browserify@0.0.0",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+			"version": "0.0.0"
+		},
 		"path-is-absolute": {
 			"from": "path-is-absolute@>=1.0.0 <2.0.0",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3022,6 +2808,16 @@
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"version": "1.0.2"
 		},
+		"punycode": {
+			"from": "punycode@1.3.2",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+			"version": "1.3.2"
+		},
+		"querystring": {
+			"from": "querystring@0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"version": "0.2.0"
+		},
 		"randomatic": {
 			"from": "randomatic@>=1.1.3 <2.0.0",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
@@ -3029,8 +2825,8 @@
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"version": "1.2.1"
 		},
 		"read-all-stream": {
 			"dependencies": {
@@ -3041,8 +2837,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz",
-					"version": "2.2.5"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
@@ -3078,13 +2879,18 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"version": "3.1.0"
+		},
+		"remove-trailing-separator": {
+			"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"repeat-element": {
 			"from": "repeat-element@>=1.1.2 <2.0.0",
@@ -3108,8 +2914,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3120,6 +2926,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3212,8 +3023,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.1.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.5.tgz",
-					"version": "2.2.5"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
@@ -3277,6 +3093,11 @@
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.3.tgz",
 			"version": "0.6.3"
 		},
+		"url": {
+			"from": "url@>=0.11.0 <0.12.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"version": "0.11.0"
+		},
 		"url-parse-lax": {
 			"from": "url-parse-lax@>=1.0.0 <2.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -3299,8 +3120,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-			"version": "2.0.11"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3351,8 +3172,8 @@
 		},
 		"which": {
 			"from": "which@>=1.2.12 <2.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-			"version": "1.2.12"
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+			"version": "1.2.14"
 		},
 		"widest-line": {
 			"from": "widest-line@>=1.0.0 <2.0.0",
@@ -3366,8 +3187,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/foundation/frontend-js/frontend-js-spa-web/package.json
@@ -7,7 +7,7 @@
 	},
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.2"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "frontend-js-spa-web",
 	"version": "1.0.25"

--- a/modules/apps/foundation/frontend-js/frontend-js-web/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/npm-shrinkwrap.json
@@ -457,8 +457,8 @@
 		},
 		"babylon": {
 			"from": "babylon@>=6.0.0 <7.0.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
-			"version": "6.16.1"
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+			"version": "6.17.0"
 		},
 		"backo2": {
 			"from": "backo2@1.0.2",
@@ -511,6 +511,11 @@
 					"from": "debug@2.6.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
 					"version": "2.6.1"
+				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				}
 			},
 			"from": "body-parser@>=1.16.1 <2.0.0",
@@ -593,8 +598,8 @@
 		},
 		"caniuse-db": {
 			"from": "caniuse-db@>=1.0.30000634 <2.0.0",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000655.tgz",
-			"version": "1.0.30000655"
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000662.tgz",
+			"version": "1.0.30000662"
 		},
 		"capture-stack-trace": {
 			"from": "capture-stack-trace@>=1.0.0 <2.0.0",
@@ -757,14 +762,19 @@
 		"connect": {
 			"dependencies": {
 				"debug": {
-					"from": "debug@2.6.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-					"version": "2.6.1"
+					"from": "debug@2.6.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+					"version": "2.6.3"
+				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				}
 			},
 			"from": "connect@>=3.6.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.0.tgz",
-			"version": "3.6.0"
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.1.tgz",
+			"version": "3.6.1"
 		},
 		"content-type": {
 			"from": "content-type@>=1.0.2 <1.1.0",
@@ -818,8 +828,8 @@
 		},
 		"debug": {
 			"from": "debug@>=2.1.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-			"version": "2.6.3"
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+			"version": "2.6.4"
 		},
 		"decamelize": {
 			"from": "decamelize@>=1.0.0 <2.0.0",
@@ -934,8 +944,8 @@
 		},
 		"electron-to-chromium": {
 			"from": "electron-to-chromium@>=1.2.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.4.tgz",
-			"version": "1.3.4"
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.8.tgz",
+			"version": "1.3.8"
 		},
 		"encodeurl": {
 			"from": "encodeurl@>=1.0.1 <1.1.0",
@@ -953,6 +963,11 @@
 					"from": "debug@2.3.3",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 					"version": "2.3.3"
+				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				}
 			},
 			"from": "engine.io@1.8.3",
@@ -970,6 +985,11 @@
 					"from": "debug@2.3.3",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 					"version": "2.3.3"
+				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				}
 			},
 			"from": "engine.io-client@1.8.3",
@@ -1139,8 +1159,8 @@
 		},
 		"espree": {
 			"from": "espree@>=3.4.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.1.tgz",
-			"version": "3.4.1"
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+			"version": "3.4.2"
 		},
 		"esprima": {
 			"from": "esprima@>=3.1.1 <4.0.0",
@@ -1298,14 +1318,19 @@
 		"finalhandler": {
 			"dependencies": {
 				"debug": {
-					"from": "debug@2.6.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-					"version": "2.6.1"
+					"from": "debug@2.6.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+					"version": "2.6.3"
+				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				}
 			},
-			"from": "finalhandler@1.0.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz",
-			"version": "1.0.0"
+			"from": "finalhandler@1.0.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"find-index": {
 			"from": "find-index@>=0.1.1 <0.2.0",
@@ -1588,8 +1613,8 @@
 			"dependencies": {
 				"abbrev": {
 					"from": "abbrev@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-					"version": "1.0.9"
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"accepts": {
 					"from": "accepts@1.3.3",
@@ -1597,9 +1622,9 @@
 					"version": "1.3.3"
 				},
 				"acorn": {
-					"from": "acorn@4.0.4",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
-					"version": "4.0.4"
+					"from": "acorn@>=5.0.1 <6.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+					"version": "5.0.3"
 				},
 				"acorn-jsx": {
 					"dependencies": {
@@ -1637,8 +1662,8 @@
 				},
 				"ajv": {
 					"from": "ajv@>=4.7.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.2.tgz",
-					"version": "4.11.2"
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+					"version": "4.11.7"
 				},
 				"ajv-keywords": {
 					"from": "ajv-keywords@>=1.0.0 <2.0.0",
@@ -1711,6 +1736,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "archiver@>=0.14.0 <0.15.0",
@@ -1719,8 +1749,8 @@
 				},
 				"are-we-there-yet": {
 					"from": "are-we-there-yet@>=1.1.2 <1.2.0",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-					"version": "1.1.2"
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"version": "1.1.4"
 				},
 				"argparse": {
 					"from": "argparse@>=1.0.7 <2.0.0",
@@ -1734,8 +1764,8 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
@@ -1812,11 +1842,6 @@
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 					"version": "0.4.0"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"aws-sign2": {
 					"from": "aws-sign2@>=0.6.0 <0.7.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -1833,9 +1858,9 @@
 					"version": "6.22.0"
 				},
 				"babel-core": {
-					"from": "babel-core@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.22.1.tgz",
-					"version": "6.22.1"
+					"from": "babel-core@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -1850,9 +1875,9 @@
 							"version": "1.3.0"
 						}
 					},
-					"from": "babel-generator@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -1860,54 +1885,54 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
-					"from": "babel-helper-define-map@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
-					"from": "babel-helper-regex@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
 					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
@@ -1947,39 +1972,39 @@
 					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
 					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
 					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
 					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
@@ -1987,39 +2012,39 @@
 					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
-					"from": "babel-plugin-transform-es2015-modules-amd@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
 					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
@@ -2027,9 +2052,9 @@
 					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
 					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
@@ -2038,28 +2063,28 @@
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
 					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal": {
 					"from": "babel-preset-metal@>=3.0.0 <4.0.0",
@@ -2068,38 +2093,38 @@
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"from": "babel-register@>=6.4.3 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
 					"from": "babel-runtime@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-					"version": "6.22.0"
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
-					"from": "babel-template@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
-					"from": "babel-traverse@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
-					"version": "6.22.1"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
-					"from": "babel-types@>=6.22.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
-					"version": "6.22.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz",
-					"version": "6.15.0"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"backo2": {
 					"from": "backo2@1.0.2",
@@ -2157,6 +2182,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "bl@>=0.9.0 <0.10.0",
@@ -2180,15 +2210,20 @@
 				},
 				"body-parser": {
 					"dependencies": {
-						"qs": {
-							"from": "qs@6.2.1",
-							"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-							"version": "6.2.1"
+						"debug": {
+							"from": "debug@2.6.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+							"version": "2.6.1"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "body-parser@>=1.12.4 <2.0.0",
-					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.0.tgz",
-					"version": "1.16.0"
+					"from": "body-parser@>=1.16.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.1.tgz",
+					"version": "1.17.1"
 				},
 				"boom": {
 					"from": "boom@>=2.0.0 <3.0.0",
@@ -2202,8 +2237,8 @@
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -2216,7 +2251,7 @@
 					"version": "0.2.13"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
@@ -2261,9 +2296,9 @@
 					"version": "2.1.0"
 				},
 				"caseless": {
-					"from": "caseless@>=0.11.0 <0.12.0",
-					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-					"version": "0.11.0"
+					"from": "caseless@>=0.12.0 <0.13.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"version": "0.12.0"
 				},
 				"catharsis": {
 					"from": "catharsis@>=0.8.8 <0.9.0",
@@ -2391,6 +2426,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "compress-commons@>=0.2.0 <0.3.0",
@@ -2403,7 +2443,7 @@
 					"version": "0.0.1"
 				},
 				"concat-stream": {
-					"from": "concat-stream@>=1.4.6 <2.0.0",
+					"from": "concat-stream@>=1.5.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 					"version": "1.6.0"
 				},
@@ -2415,19 +2455,19 @@
 				"connect": {
 					"dependencies": {
 						"debug": {
-							"from": "debug@>=2.2.0 <2.3.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-							"version": "2.2.0"
+							"from": "debug@2.6.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+							"version": "2.6.3"
 						},
 						"ms": {
-							"from": "ms@0.7.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-							"version": "0.7.1"
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "connect@>=3.3.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
-					"version": "3.5.0"
+					"from": "connect@>=3.6.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.1.tgz",
+					"version": "3.6.1"
 				},
 				"console-browserify": {
 					"from": "console-browserify@>=1.1.0 <1.2.0",
@@ -2446,8 +2486,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"cookie": {
 					"from": "cookie@0.3.1",
@@ -2475,6 +2515,11 @@
 							"from": "readable-stream@>=1.0.24 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "crc32-stream@>=0.3.1 <0.4.0",
@@ -2498,18 +2543,6 @@
 					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"version": "2.0.5"
 				},
-				"css": {
-					"dependencies": {
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
 				"ctype": {
 					"from": "ctype@0.5.3",
 					"resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
@@ -2526,9 +2559,9 @@
 					"version": "1.0.1"
 				},
 				"d": {
-					"from": "d@>=0.1.1 <0.2.0",
-					"resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-					"version": "0.1.1"
+					"from": "d@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+					"version": "1.0.0"
 				},
 				"dashdash": {
 					"dependencies": {
@@ -2559,20 +2592,8 @@
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-					"version": "2.6.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
 					"from": "decamelize@>=1.1.2 <2.0.0",
@@ -2614,11 +2635,6 @@
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 					"version": "4.0.0"
 				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
-				},
 				"di": {
 					"from": "di@>=0.0.1 <0.0.2",
 					"resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
@@ -2635,9 +2651,9 @@
 					"version": "2.0.0"
 				},
 				"doctrine": {
-					"from": "doctrine@>=1.2.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"version": "1.5.0"
+					"from": "doctrine@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"dom-serialize": {
 					"from": "dom-serialize@>=2.2.0 <3.0.0",
@@ -2692,6 +2708,11 @@
 							"from": "readable-stream@>=1.1.9 <1.2.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 							"version": "1.1.14"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "duplexer2@0.0.2",
@@ -2725,17 +2746,27 @@
 					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 					"version": "1.1.1"
 				},
+				"encodeurl": {
+					"from": "encodeurl@>=1.0.1 <1.1.0",
+					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"engine.io": {
 					"dependencies": {
 						"debug": {
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "engine.io@1.8.2",
-					"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz",
-					"version": "1.8.2"
+					"from": "engine.io@1.8.3",
+					"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
+					"version": "1.8.3"
 				},
 				"engine.io-client": {
 					"dependencies": {
@@ -2748,11 +2779,16 @@
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "engine.io-client@1.8.2",
-					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.2.tgz",
-					"version": "1.8.2"
+					"from": "engine.io-client@1.8.3",
+					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
+					"version": "1.8.3"
 				},
 				"engine.io-parser": {
 					"from": "engine.io-parser@1.3.2",
@@ -2771,38 +2807,38 @@
 				},
 				"error-ex": {
 					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"es5-ext": {
-					"from": "es5-ext@>=0.10.11 <0.11.0",
-					"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-					"version": "0.10.12"
+					"from": "es5-ext@>=0.10.14 <0.11.0",
+					"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+					"version": "0.10.15"
 				},
 				"es6-iterator": {
-					"from": "es6-iterator@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "es6-iterator@>=2.0.1 <2.1.0",
+					"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"es6-map": {
 					"from": "es6-map@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-					"version": "0.1.4"
+					"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"es6-set": {
-					"from": "es6-set@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "es6-set@>=0.1.5 <0.2.0",
+					"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"es6-symbol": {
-					"from": "es6-symbol@>=3.1.0 <3.2.0",
-					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-					"version": "3.1.0"
+					"from": "es6-symbol@>=3.1.1 <3.2.0",
+					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+					"version": "3.1.1"
 				},
 				"es6-weak-map": {
 					"from": "es6-weak-map@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"escape-html": {
 					"from": "escape-html@>=1.0.3 <1.1.0",
@@ -2880,18 +2916,23 @@
 				},
 				"eslint": {
 					"from": "eslint@>=3.12.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.15.0.tgz",
-					"version": "3.15.0"
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+					"version": "3.19.0"
 				},
 				"espree": {
 					"from": "espree@>=3.4.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
-					"version": "3.4.0"
+					"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+					"version": "3.4.2"
 				},
 				"esprima": {
 					"from": "esprima@>=3.1.1 <4.0.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 					"version": "3.1.3"
+				},
+				"esquery": {
+					"from": "esquery@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+					"version": "1.0.0"
 				},
 				"esrecurse": {
 					"dependencies": {
@@ -2916,9 +2957,9 @@
 					"version": "2.0.2"
 				},
 				"event-emitter": {
-					"from": "event-emitter@>=0.3.4 <0.4.0",
-					"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-					"version": "0.3.4"
+					"from": "event-emitter@>=0.3.5 <0.4.0",
+					"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+					"version": "0.3.5"
 				},
 				"eventemitter3": {
 					"from": "eventemitter3@>=1.0.0 <2.0.0",
@@ -3025,19 +3066,19 @@
 				"finalhandler": {
 					"dependencies": {
 						"debug": {
-							"from": "debug@>=2.2.0 <2.3.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-							"version": "2.2.0"
+							"from": "debug@2.6.3",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+							"version": "2.6.3"
 						},
 						"ms": {
-							"from": "ms@0.7.1",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-							"version": "0.7.1"
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "finalhandler@0.5.0",
-					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-					"version": "0.5.0"
+					"from": "finalhandler@1.0.1",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"find-up": {
 					"from": "find-up@>=1.0.0 <2.0.0",
@@ -3055,14 +3096,14 @@
 					"version": "1.2.2"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
 					"from": "for-own@>=0.1.4 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"forever-agent": {
 					"from": "forever-agent@>=0.6.1 <0.7.0",
@@ -3076,8 +3117,8 @@
 				},
 				"form-data": {
 					"from": "form-data@>=2.1.1 <2.2.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-					"version": "2.1.2"
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"version": "2.1.4"
 				},
 				"formatio": {
 					"from": "formatio@1.1.1",
@@ -3096,13 +3137,13 @@
 				},
 				"fstream": {
 					"from": "fstream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-					"version": "1.0.10"
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"version": "1.0.11"
 				},
 				"gauge": {
 					"from": "gauge@>=2.7.1 <2.8.0",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-					"version": "2.7.3"
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"version": "2.7.4"
 				},
 				"generate-function": {
 					"from": "generate-function@>=2.0.0 <3.0.0",
@@ -3175,8 +3216,8 @@
 				},
 				"globals": {
 					"from": "globals@>=9.0.0 <10.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-					"version": "9.14.0"
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globby": {
 					"from": "globby@>=5.0.0 <6.0.0",
@@ -3227,8 +3268,8 @@
 						},
 						"vinyl": {
 							"from": "vinyl@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+							"version": "2.0.2"
 						}
 					},
 					"from": "gulp-concat@>=2.5.2 <3.0.0",
@@ -3298,9 +3339,9 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.11.1.tgz",
-					"version": "1.11.1"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-uglify": {
 					"from": "gulp-uglify@>=1.2.0 <2.0.0",
@@ -3336,6 +3377,11 @@
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"through2": {
 							"from": "through2@>=0.6.5 <0.7.0",
 							"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
@@ -3368,10 +3414,15 @@
 					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
 					"version": "4.0.6"
 				},
+				"har-schema": {
+					"from": "har-schema@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"version": "1.0.5"
+				},
 				"har-validator": {
-					"from": "har-validator@>=2.0.6 <2.1.0",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-					"version": "2.0.6"
+					"from": "har-validator@>=4.2.1 <4.3.0",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"version": "4.2.1"
 				},
 				"has-ansi": {
 					"from": "has-ansi@>=2.0.0 <3.0.0",
@@ -3432,8 +3483,8 @@
 				},
 				"hosted-git-info": {
 					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
-					"version": "2.2.0"
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+					"version": "2.4.2"
 				},
 				"htmlparser2": {
 					"dependencies": {
@@ -3446,6 +3497,11 @@
 							"from": "readable-stream@>=1.1.0 <1.2.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 							"version": "1.1.14"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "htmlparser2@>=3.8.0 <3.9.0",
@@ -3453,9 +3509,9 @@
 					"version": "3.8.3"
 				},
 				"http-errors": {
-					"from": "http-errors@>=1.5.1 <1.6.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-					"version": "1.5.1"
+					"from": "http-errors@>=1.6.1 <1.7.0",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"http-proxy": {
 					"from": "http-proxy@>=1.13.0 <2.0.0",
@@ -3501,8 +3557,8 @@
 				},
 				"ignore": {
 					"from": "ignore@>=3.2.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.2.tgz",
-					"version": "3.2.2"
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+					"version": "3.2.7"
 				},
 				"imurmurhash": {
 					"from": "imurmurhash@>=0.1.4 <0.2.0",
@@ -3541,8 +3597,8 @@
 				},
 				"interpret": {
 					"from": "interpret@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
@@ -3570,9 +3626,9 @@
 					"version": "1.0.1"
 				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-builtin-module": {
 					"from": "is-builtin-module@>=1.0.0 <2.0.0",
@@ -3616,8 +3672,8 @@
 				},
 				"is-my-json-valid": {
 					"from": "is-my-json-valid@>=2.10.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-					"version": "2.15.0"
+					"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+					"version": "2.16.0"
 				},
 				"is-number": {
 					"from": "is-number@>=2.1.0 <3.0.0",
@@ -3690,9 +3746,9 @@
 					"version": "3.0.2"
 				},
 				"isexe": {
-					"from": "isexe@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-					"version": "1.1.2"
+					"from": "isexe@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"isobject": {
 					"from": "isobject@>=2.0.0 <3.0.0",
@@ -3718,6 +3774,11 @@
 				},
 				"istanbul": {
 					"dependencies": {
+						"abbrev": {
+							"from": "abbrev@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+							"version": "1.0.9"
+						},
 						"async": {
 							"from": "async@>=1.0.0 <2.0.0",
 							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -3782,8 +3843,8 @@
 				},
 				"js-yaml": {
 					"from": "js-yaml@>=3.5.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.1.tgz",
-					"version": "3.8.1"
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+					"version": "3.8.3"
 				},
 				"js2xmlparser": {
 					"from": "js2xmlparser@>=1.0.0 <1.1.0",
@@ -3792,8 +3853,8 @@
 				},
 				"jsbn": {
 					"from": "jsbn@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-					"version": "0.1.0"
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"version": "0.1.1"
 				},
 				"jsdoc": {
 					"dependencies": {
@@ -3880,9 +3941,16 @@
 					"version": "4.0.1"
 				},
 				"jsprim": {
+					"dependencies": {
+						"assert-plus": {
+							"from": "assert-plus@1.0.0",
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"version": "1.0.0"
+						}
+					},
 					"from": "jsprim@>=1.2.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+					"version": "1.4.0"
 				},
 				"karma": {
 					"dependencies": {
@@ -3893,8 +3961,8 @@
 						}
 					},
 					"from": "karma@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/karma/-/karma-1.4.1.tgz",
-					"version": "1.4.1"
+					"resolved": "https://registry.npmjs.org/karma/-/karma-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"karma-babel-preprocessor": {
 					"from": "karma-babel-preprocessor@>=6.0.1 <7.0.0",
@@ -3952,8 +4020,8 @@
 					"dependencies": {
 						"q": {
 							"from": "q@>=1.4.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-							"version": "1.4.1"
+							"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+							"version": "1.5.0"
 						}
 					},
 					"from": "karma-sauce-launcher@>=0.3.0 <0.4.0",
@@ -3977,8 +4045,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-					"version": "3.1.0"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"klaw": {
 					"from": "klaw@>=1.3.0 <1.4.0",
@@ -3989,11 +4057,6 @@
 					"from": "lazy-cache@>=1.0.3 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 					"version": "1.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -4006,6 +4069,11 @@
 							"from": "readable-stream@>=1.0.2 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "lazystream@>=0.1.0 <0.2.0",
@@ -4160,6 +4228,11 @@
 							"from": "readable-stream@>=1.0.2 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "log4js@>=0.6.31 <0.7.0",
@@ -4292,6 +4365,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -4308,21 +4386,13 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
-							"dependencies": {
-								"gulp-sourcemaps": {
-									"from": "gulp-sourcemaps@1.6.0",
-									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-									"version": "1.6.0"
-								}
-							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
 							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.2.tgz",
-					"version": "3.0.2"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"dependencies": {
@@ -4378,6 +4448,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -4394,21 +4469,13 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
-							"dependencies": {
-								"gulp-sourcemaps": {
-									"from": "gulp-sourcemaps@1.6.0",
-									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-									"version": "1.6.0"
-								}
-							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
 							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"dependencies": {
@@ -4464,6 +4531,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -4480,21 +4552,13 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
-							"dependencies": {
-								"gulp-sourcemaps": {
-									"from": "gulp-sourcemaps@1.6.0",
-									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-									"version": "1.6.0"
-								}
-							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
 							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
 					"dependencies": {
@@ -4525,11 +4589,6 @@
 							"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 							"version": "5.3.5"
 						},
-						"gulp-sourcemaps": {
-							"from": "gulp-sourcemaps@1.6.0",
-							"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-							"version": "1.6.0"
-						},
 						"is-extglob": {
 							"from": "is-extglob@>=2.1.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4555,6 +4614,11 @@
 							"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 							"version": "0.3.0"
 						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
+						},
 						"strip-bom": {
 							"from": "strip-bom@>=2.0.0 <3.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -4577,8 +4641,7 @@
 						}
 					},
 					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"version": "3.1.0"
 				},
 				"micromatch": {
 					"from": "micromatch@>=2.3.7 <3.0.0",
@@ -4591,14 +4654,14 @@
 					"version": "1.3.4"
 				},
 				"mime-db": {
-					"from": "mime-db@>=1.26.0 <1.27.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-					"version": "1.26.0"
+					"from": "mime-db@>=1.27.0 <1.28.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+					"version": "1.27.0"
 				},
 				"mime-types": {
 					"from": "mime-types@>=2.1.7 <2.2.0",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-					"version": "2.1.14"
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+					"version": "2.1.15"
 				},
 				"minimatch": {
 					"from": "minimatch@>=3.0.2 <4.0.0",
@@ -4668,9 +4731,9 @@
 					"version": "1.0.0"
 				},
 				"ms": {
-					"from": "ms@0.7.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-					"version": "0.7.2"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -4689,8 +4752,8 @@
 				},
 				"nan": {
 					"from": "nan@>=2.3.2 <3.0.0",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
-					"version": "2.5.1"
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+					"version": "2.6.2"
 				},
 				"natural-compare": {
 					"from": "natural-compare@>=1.4.0 <2.0.0",
@@ -4703,9 +4766,16 @@
 					"version": "0.6.1"
 				},
 				"node-gyp": {
+					"dependencies": {
+						"semver": {
+							"from": "semver@>=5.3.0 <5.4.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+							"version": "5.3.0"
+						}
+					},
 					"from": "node-gyp@>=3.3.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
-					"version": "3.5.0"
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
+					"version": "3.6.0"
 				},
 				"node-int64": {
 					"from": "node-int64@>=0.3.0 <0.4.0",
@@ -4768,13 +4838,13 @@
 				},
 				"normalize-package-data": {
 					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+					"version": "2.3.8"
 				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"npm-path": {
 					"from": "npm-path@>=1.0.1 <2.0.0",
@@ -4950,10 +5020,20 @@
 					"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
 					"version": "1.0.2"
 				},
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
+				},
 				"path-type": {
 					"from": "path-type@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"version": "1.1.0"
+				},
+				"performance-now": {
+					"from": "performance-now@>=0.2.0 <0.3.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"version": "0.2.0"
 				},
 				"pify": {
 					"from": "pify@>=2.0.0 <3.0.0",
@@ -5031,9 +5111,9 @@
 					"version": "1.1.5"
 				},
 				"qs": {
-					"from": "qs@>=6.3.0 <6.4.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-					"version": "6.3.0"
+					"from": "qs@>=6.4.0 <6.5.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"version": "6.4.0"
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
@@ -5072,8 +5152,8 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.2.2 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-					"version": "2.2.2"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
 				},
 				"readdirp": {
 					"from": "readdirp@>=2.0.0 <3.0.0",
@@ -5102,13 +5182,13 @@
 				},
 				"regenerator-runtime": {
 					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-					"version": "0.10.1"
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz",
+					"version": "0.10.3"
 				},
 				"regenerator-transform": {
-					"from": "regenerator-transform@0.9.8",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
-					"version": "0.9.8"
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -5162,8 +5242,8 @@
 				},
 				"request": {
 					"from": "request@>=2.61.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-					"version": "2.79.0"
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"version": "2.81.0"
 				},
 				"require-directory": {
 					"from": "require-directory@>=2.1.1 <3.0.0",
@@ -5199,18 +5279,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.6 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"resolve-from": {
 					"from": "resolve-from@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
 				},
 				"restore-cursor": {
 					"from": "restore-cursor@>=1.0.1 <2.0.0",
@@ -5224,8 +5299,8 @@
 				},
 				"rimraf": {
 					"from": "rimraf@>=2.2.8 <3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-					"version": "2.5.4"
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+					"version": "2.6.1"
 				},
 				"rocambole": {
 					"dependencies": {
@@ -5354,14 +5429,14 @@
 					"version": "1.0.1"
 				},
 				"setprototypeof": {
-					"from": "setprototypeof@1.0.2",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "setprototypeof@1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"shelljs": {
 					"from": "shelljs@>=0.7.5 <0.8.0",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-					"version": "0.7.6"
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+					"version": "0.7.7"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
@@ -5400,15 +5475,20 @@
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
 						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
+						},
 						"object-assign": {
 							"from": "object-assign@4.1.0",
 							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
 							"version": "4.1.0"
 						}
 					},
-					"from": "socket.io@1.7.2",
-					"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz",
-					"version": "1.7.2"
+					"from": "socket.io@1.7.3",
+					"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
+					"version": "1.7.3"
 				},
 				"socket.io-adapter": {
 					"dependencies": {
@@ -5416,6 +5496,11 @@
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
 					"from": "socket.io-adapter@0.5.0",
@@ -5433,11 +5518,16 @@
 							"from": "debug@2.3.3",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 							"version": "2.3.3"
+						},
+						"ms": {
+							"from": "ms@0.7.2",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+							"version": "0.7.2"
 						}
 					},
-					"from": "socket.io-client@1.7.2",
-					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.2.tgz",
-					"version": "1.7.2"
+					"from": "socket.io-client@1.7.3",
+					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
+					"version": "1.7.3"
 				},
 				"socket.io-parser": {
 					"dependencies": {
@@ -5466,20 +5556,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.11.tgz",
-					"version": "0.4.11"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -5525,8 +5605,8 @@
 						}
 					},
 					"from": "sshpk@>=1.7.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-					"version": "1.10.2"
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+					"version": "1.13.0"
 				},
 				"statuses": {
 					"from": "statuses@>=1.3.1 <2.0.0",
@@ -5564,9 +5644,9 @@
 					"version": "1.0.2"
 				},
 				"string_decoder": {
-					"from": "string_decoder@>=0.10.0 <0.11.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"version": "0.10.31"
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				},
 				"stringstream": {
 					"from": "stringstream@>=0.0.4 <0.1.0",
@@ -5646,23 +5726,23 @@
 					"dependencies": {
 						"end-of-stream": {
 							"from": "end-of-stream@>=1.0.0 <2.0.0",
-							"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-							"version": "1.1.0"
+							"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+							"version": "1.4.0"
 						},
 						"isarray": {
 							"from": "isarray@0.0.1",
 							"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 							"version": "0.0.1"
 						},
-						"once": {
-							"from": "once@>=1.3.0 <1.4.0",
-							"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-							"version": "1.3.3"
-						},
 						"readable-stream": {
 							"from": "readable-stream@>=1.0.33 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "tar-stream@>=1.1.0 <1.2.0",
@@ -5717,9 +5797,9 @@
 					"version": "1.0.1"
 				},
 				"tmp": {
-					"from": "tmp@0.0.28",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-					"version": "0.0.28"
+					"from": "tmp@0.0.31",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+					"version": "0.0.31"
 				},
 				"to-absolute-glob": {
 					"from": "to-absolute-glob@>=0.1.1 <0.2.0",
@@ -5751,6 +5831,11 @@
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 					"version": "1.0.0"
 				},
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"tryit": {
 					"from": "tryit@>=1.0.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -5769,9 +5854,9 @@
 					"version": "1.0.0"
 				},
 				"tunnel-agent": {
-					"from": "tunnel-agent@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-					"version": "0.4.3"
+					"from": "tunnel-agent@>=0.6.0 <0.7.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"version": "0.6.0"
 				},
 				"tweetnacl": {
 					"from": "tweetnacl@>=0.14.0 <0.15.0",
@@ -5790,8 +5875,8 @@
 				},
 				"type-is": {
 					"from": "type-is@>=1.6.14 <1.7.0",
-					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
-					"version": "1.6.14"
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+					"version": "1.6.15"
 				},
 				"typedarray": {
 					"from": "typedarray@>=0.0.6 <0.0.7",
@@ -5872,11 +5957,6 @@
 					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
 				"user-home": {
 					"from": "user-home@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -5890,9 +5970,9 @@
 							"version": "2.2.4"
 						}
 					},
-					"from": "useragent@>=2.1.10 <3.0.0",
-					"resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.12.tgz",
-					"version": "2.1.12"
+					"from": "useragent@>=2.1.12 <3.0.0",
+					"resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
+					"version": "2.1.13"
 				},
 				"util": {
 					"dependencies": {
@@ -6042,8 +6122,8 @@
 						},
 						"node-uuid": {
 							"from": "node-uuid@>=1.4.0 <1.5.0",
-							"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-							"version": "1.4.7"
+							"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+							"version": "1.4.8"
 						},
 						"oauth-sign": {
 							"from": "oauth-sign@>=0.6.0 <0.7.0",
@@ -6064,6 +6144,11 @@
 							"from": "request@>=2.55.0 <2.56.0",
 							"resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
 							"version": "2.55.0"
+						},
+						"tunnel-agent": {
+							"from": "tunnel-agent@>=0.4.0 <0.5.0",
+							"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+							"version": "0.4.3"
 						}
 					},
 					"from": "wd@>=0.3.4 <0.4.0",
@@ -6072,8 +6157,8 @@
 				},
 				"which": {
 					"from": "which@>=1.2.12 <2.0.0",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-					"version": "1.2.12"
+					"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+					"version": "1.2.14"
 				},
 				"which-module": {
 					"from": "which-module@>=1.0.0 <2.0.0",
@@ -6111,9 +6196,9 @@
 					"version": "0.2.1"
 				},
 				"ws": {
-					"from": "ws@1.1.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-					"version": "1.1.1"
+					"from": "ws@1.1.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
+					"version": "1.1.2"
 				},
 				"wtf-8": {
 					"from": "wtf-8@1.0.0",
@@ -6137,8 +6222,8 @@
 				},
 				"yallist": {
 					"from": "yallist@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"version": "2.1.2"
 				},
 				"yargs": {
 					"from": "yargs@>=4.7.1 <5.0.0",
@@ -6178,6 +6263,11 @@
 							"from": "readable-stream@>=1.0.26 <1.1.0",
 							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 							"version": "1.0.34"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=0.10.0 <0.11.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+							"version": "0.10.31"
 						}
 					},
 					"from": "zip-stream@>=0.5.0 <0.6.0",
@@ -6186,8 +6276,8 @@
 				}
 			},
 			"from": "gulp-metal@>=1.9.8 <2.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.11.2.tgz",
-			"version": "1.11.2"
+			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.12.1.tgz",
+			"version": "1.12.1"
 		},
 		"gulp-util": {
 			"from": "gulp-util@>=3.0.0 <4.0.0",
@@ -6344,7 +6434,7 @@
 			"version": "1.0.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
@@ -6753,8 +6843,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"dependencies": {
@@ -7033,20 +7123,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -7060,18 +7140,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -7083,22 +7158,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -7107,8 +7177,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -7124,13 +7194,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -7138,73 +7208,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -7229,198 +7299,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -7429,8 +7500,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -7439,13 +7510,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -7453,24 +7524,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -7494,8 +7555,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -7509,8 +7570,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -7522,64 +7583,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -7605,23 +7627,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -7667,8 +7689,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -7680,32 +7702,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -7716,11 +7726,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -7778,8 +7783,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -7819,9 +7824,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -7850,25 +7855,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -7884,8 +7889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -7895,9 +7905,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -7905,14 +7915,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -7952,26 +7969,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -7985,28 +7985,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -8025,8 +8015,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -8039,7 +8029,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -8096,9 +8086,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -8111,9 +8101,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -8122,13 +8112,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -8144,8 +8129,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -8156,18 +8146,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -8236,8 +8214,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -8260,43 +8238,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -8317,13 +8266,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -8332,23 +8286,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -8373,18 +8323,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -8395,9 +8338,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -8409,15 +8352,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -8431,8 +8369,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -8453,13 +8391,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -8488,47 +8436,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -8536,9 +8457,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -8547,18 +8468,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -8572,20 +8483,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -8607,6 +8518,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -8614,13 +8530,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -8641,13 +8557,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -8661,33 +8582,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -8699,20 +8600,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -8723,21 +8614,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -8779,20 +8655,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -8817,14 +8688,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -8846,10 +8722,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -8861,16 +8737,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8881,11 +8747,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -8895,8 +8756,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -8910,13 +8771,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -8925,8 +8791,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -8940,8 +8806,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -8949,7 +8815,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -8964,19 +8830,19 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.1.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-component": {
 			"from": "metal-component@>=2.5.13 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-2.7.0.tgz",
-			"version": "2.7.0"
+			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-dom": {
 			"from": "metal-dom@>=2.5.13 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.6.4.tgz",
-			"version": "2.6.4"
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-events": {
 			"from": "metal-events@>=2.5.16 <3.0.0",
@@ -9006,9 +8872,9 @@
 			"version": "2.2.0"
 		},
 		"metal-state": {
-			"from": "metal-state@>=2.7.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.7.0.tgz",
-			"version": "2.7.0"
+			"from": "metal-state@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"micromatch": {
 			"from": "micromatch@>=2.3.7 <3.0.0",
@@ -9095,9 +8961,9 @@
 			"version": "2.5.3"
 		},
 		"ms": {
-			"from": "ms@0.7.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-			"version": "0.7.2"
+			"from": "ms@0.7.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+			"version": "0.7.3"
 		},
 		"multipipe": {
 			"from": "multipipe@>=0.1.2 <0.2.0",
@@ -9163,8 +9029,8 @@
 		},
 		"normalize-package-data": {
 			"from": "normalize-package-data@>=2.3.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-			"version": "2.3.6"
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+			"version": "2.3.8"
 		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
@@ -9592,8 +9458,8 @@
 		},
 		"regenerator-runtime": {
 			"from": "regenerator-runtime@>=0.10.0 <0.11.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz",
-			"version": "0.10.3"
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+			"version": "0.10.4"
 		},
 		"regenerator-transform": {
 			"from": "regenerator-transform@0.9.11",
@@ -9612,8 +9478,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.2.tgz",
-			"version": "3.1.2"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -9667,8 +9533,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -9813,6 +9679,11 @@
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 					"version": "2.3.3"
 				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
+				},
 				"object-assign": {
 					"from": "object-assign@4.1.0",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
@@ -9829,6 +9700,11 @@
 					"from": "debug@2.3.3",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 					"version": "2.3.3"
+				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				}
 			},
 			"from": "socket.io-adapter@0.5.0",
@@ -9846,6 +9722,11 @@
 					"from": "debug@2.3.3",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
 					"version": "2.3.3"
+				},
+				"ms": {
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				}
 			},
 			"from": "socket.io-client@1.7.3",
@@ -10320,8 +10201,8 @@
 				}
 			},
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"ws": {
 			"from": "ws@1.1.2",

--- a/modules/apps/foundation/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/package.json
@@ -11,7 +11,7 @@
 		"liferay-karma-config": "0.0.4",
 		"liferay-module-config-generator": "^1.2.1",
 		"metal": "^2.5.12",
-		"metal-cli": "^2.1.2",
+		"metal-cli": "^4.0.1",
 		"metal-component": "^2.5.13",
 		"metal-dom": "^2.5.13",
 		"metal-events": "^2.5.16",

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib/npm-shrinkwrap.json
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -62,8 +62,8 @@
 		},
 		"bluebird": {
 			"from": "bluebird@>=3.0.6 <4.0.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"version": "3.4.7"
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+			"version": "3.5.0"
 		},
 		"bootstrap": {
 			"from": "bootstrap@>=3.3.6 <4.0.0",
@@ -84,8 +84,8 @@
 		},
 		"brace-expansion": {
 			"from": "brace-expansion@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-			"version": "1.1.6"
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+			"version": "1.1.7"
 		},
 		"braces": {
 			"from": "braces@>=1.8.2 <2.0.0",
@@ -93,7 +93,7 @@
 			"version": "1.8.5"
 		},
 		"buffer-shims": {
-			"from": "buffer-shims@>=1.0.0 <2.0.0",
+			"from": "buffer-shims@>=1.0.0 <1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 			"version": "1.0.0"
 		},
@@ -220,8 +220,8 @@
 		},
 		"error-ex": {
 			"from": "error-ex@>=1.2.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-			"version": "1.3.0"
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"escape-string-regexp": {
 			"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -456,8 +456,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
@@ -531,8 +536,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -545,9 +550,9 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-			"version": "1.1.4"
+			"from": "is-buffer@>=1.1.5 <2.0.0",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"version": "1.1.5"
 		},
 		"is-dotfile": {
 			"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -650,9 +655,9 @@
 			"version": "0.0.1"
 		},
 		"isexe": {
-			"from": "isexe@>=1.1.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-			"version": "1.1.2"
+			"from": "isexe@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"isobject": {
 			"dependencies": {
@@ -668,8 +673,8 @@
 		},
 		"js-beautify": {
 			"from": "js-beautify@>=1.5.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.11.tgz",
-			"version": "1.6.11"
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.12.tgz",
+			"version": "1.6.12"
 		},
 		"jsonfile": {
 			"from": "jsonfile@>=2.1.0 <3.0.0",
@@ -683,8 +688,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -848,20 +853,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -875,18 +870,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -898,22 +888,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -922,8 +907,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -939,13 +924,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -953,73 +938,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1044,198 +1029,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1244,8 +1230,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1254,13 +1240,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1268,24 +1254,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1309,8 +1285,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1324,8 +1300,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1337,64 +1313,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1420,23 +1357,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1482,8 +1419,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1495,32 +1432,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1531,11 +1456,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1593,8 +1513,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1634,9 +1554,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1665,25 +1585,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1699,8 +1619,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1710,9 +1635,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1720,14 +1645,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1767,26 +1699,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1800,28 +1715,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1840,8 +1745,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1854,7 +1759,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1911,9 +1816,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1926,9 +1831,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1937,13 +1842,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1959,8 +1859,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -1971,18 +1876,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2051,8 +1944,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2075,43 +1968,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2132,13 +1996,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2147,23 +2016,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2188,18 +2053,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2210,9 +2068,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2224,15 +2082,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2246,8 +2099,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2268,13 +2121,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2303,47 +2166,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2351,9 +2187,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2362,18 +2198,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2387,20 +2213,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2422,6 +2248,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2429,13 +2260,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2456,13 +2287,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2476,33 +2312,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2514,20 +2330,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2538,21 +2344,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2594,20 +2385,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2632,14 +2418,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2661,10 +2452,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2676,16 +2467,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2696,11 +2477,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2710,8 +2486,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2725,13 +2501,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2740,8 +2521,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2755,8 +2536,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2764,7 +2545,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2779,19 +2560,19 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.1.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-component": {
 			"from": "metal-component@>=2.4.5 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-2.6.4.tgz",
-			"version": "2.6.4"
+			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-dom": {
-			"from": "metal-dom@>=2.6.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.6.4.tgz",
-			"version": "2.6.4"
+			"from": "metal-dom@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-dropdown": {
 			"from": "metal-dropdown@>=2.0.0 <3.0.0",
@@ -2804,9 +2585,9 @@
 			"version": "2.6.4"
 		},
 		"metal-incremental-dom": {
-			"from": "metal-incremental-dom@>=2.6.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-2.6.4.tgz",
-			"version": "2.6.4"
+			"from": "metal-incremental-dom@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-position": {
 			"from": "metal-position@>=2.0.0 <3.0.0",
@@ -2815,18 +2596,18 @@
 		},
 		"metal-soy": {
 			"from": "metal-soy@>=2.4.5 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-soy/-/metal-soy-2.6.4.tgz",
-			"version": "2.6.4"
+			"resolved": "https://registry.npmjs.org/metal-soy/-/metal-soy-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-soy-bundle": {
-			"from": "metal-soy-bundle@>=2.6.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-2.6.4.tgz",
-			"version": "2.6.4"
+			"from": "metal-soy-bundle@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-state": {
 			"from": "metal-state@>=2.6.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.6.4.tgz",
-			"version": "2.6.4"
+			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"micromatch": {
 			"from": "micromatch@>=2.3.7 <3.0.0",
@@ -2877,8 +2658,8 @@
 		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"number-is-nan": {
 			"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -3034,8 +2815,8 @@
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"version": "1.2.1"
 		},
 		"read-all-stream": {
 			"dependencies": {
@@ -3046,8 +2827,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
@@ -3083,13 +2869,18 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"version": "3.1.0"
+		},
+		"remove-trailing-separator": {
+			"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"repeat-element": {
 			"from": "repeat-element@>=1.1.2 <2.0.0",
@@ -3113,8 +2904,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3125,6 +2916,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3212,8 +3008,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.1.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
@@ -3299,8 +3100,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-			"version": "2.0.11"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3351,8 +3152,8 @@
 		},
 		"which": {
 			"from": "which@>=1.2.12 <2.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-			"version": "1.2.12"
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+			"version": "1.2.14"
 		},
 		"widest-line": {
 			"from": "widest-line@>=1.0.0 <2.0.0",
@@ -3366,8 +3167,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib/package.json
@@ -8,7 +8,7 @@
 	},
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.1.2"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "frontend-taglib",
 	"version": "2.2.0"

--- a/modules/apps/foundation/hello-soy/hello-soy-web/npm-shrinkwrap.json
+++ b/modules/apps/foundation/hello-soy/hello-soy-web/npm-shrinkwrap.json
@@ -27,8 +27,8 @@
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
@@ -62,8 +62,8 @@
 		},
 		"bluebird": {
 			"from": "bluebird@>=3.0.6 <4.0.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"version": "3.4.7"
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+			"version": "3.5.0"
 		},
 		"boxen": {
 			"dependencies": {
@@ -79,8 +79,8 @@
 		},
 		"brace-expansion": {
 			"from": "brace-expansion@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-			"version": "1.1.6"
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+			"version": "1.1.7"
 		},
 		"braces": {
 			"from": "braces@>=1.8.2 <2.0.0",
@@ -88,7 +88,7 @@
 			"version": "1.8.5"
 		},
 		"buffer-shims": {
-			"from": "buffer-shims@>=1.0.0 <2.0.0",
+			"from": "buffer-shims@>=1.0.0 <1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 			"version": "1.0.0"
 		},
@@ -215,8 +215,8 @@
 		},
 		"error-ex": {
 			"from": "error-ex@>=1.2.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-			"version": "1.3.0"
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"escape-string-regexp": {
 			"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -451,8 +451,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
@@ -526,8 +531,8 @@
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
@@ -540,9 +545,9 @@
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-			"version": "1.1.4"
+			"from": "is-buffer@>=1.1.5 <2.0.0",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"version": "1.1.5"
 		},
 		"is-dotfile": {
 			"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -645,9 +650,9 @@
 			"version": "0.0.1"
 		},
 		"isexe": {
-			"from": "isexe@>=1.1.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-			"version": "1.1.2"
+			"from": "isexe@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"isobject": {
 			"dependencies": {
@@ -663,8 +668,8 @@
 		},
 		"js-beautify": {
 			"from": "js-beautify@>=1.5.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.11.tgz",
-			"version": "1.6.11"
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.12.tgz",
+			"version": "1.6.12"
 		},
 		"jsonfile": {
 			"from": "jsonfile@>=2.1.0 <3.0.0",
@@ -678,8 +683,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -843,20 +848,10 @@
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -870,18 +865,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -893,22 +883,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -917,8 +902,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -934,13 +919,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -948,73 +933,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1039,198 +1024,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1239,8 +1225,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1249,13 +1235,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1263,24 +1249,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1304,8 +1280,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1319,8 +1295,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1332,64 +1308,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1415,23 +1352,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1477,8 +1414,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1490,32 +1427,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1526,11 +1451,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1588,8 +1508,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1629,9 +1549,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1660,25 +1580,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1694,8 +1614,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1705,9 +1630,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1715,14 +1640,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1762,26 +1694,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1795,28 +1710,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1835,8 +1740,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1849,7 +1754,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1906,9 +1811,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1921,9 +1826,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1932,13 +1837,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1954,8 +1854,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -1966,18 +1871,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2046,8 +1939,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2070,43 +1963,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2127,13 +1991,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2142,23 +2011,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2183,18 +2048,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2205,9 +2063,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2219,15 +2077,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2241,8 +2094,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2263,13 +2116,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2298,47 +2161,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2346,9 +2182,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2357,18 +2193,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2382,20 +2208,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2417,6 +2243,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2424,13 +2255,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2451,13 +2282,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2471,33 +2307,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2509,20 +2325,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2533,21 +2339,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2589,20 +2380,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2627,14 +2413,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2656,10 +2447,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2671,16 +2462,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2691,11 +2472,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2705,8 +2481,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2720,13 +2496,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2735,8 +2516,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2750,8 +2531,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2759,7 +2540,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2774,19 +2555,19 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.1.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-component": {
 			"from": "metal-component@>=2.4.5 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-2.6.4.tgz",
-			"version": "2.6.4"
+			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-dom": {
-			"from": "metal-dom@>=2.6.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.6.4.tgz",
-			"version": "2.6.4"
+			"from": "metal-dom@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-events": {
 			"from": "metal-events@>=2.6.4 <3.0.0",
@@ -2794,24 +2575,24 @@
 			"version": "2.6.4"
 		},
 		"metal-incremental-dom": {
-			"from": "metal-incremental-dom@>=2.6.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-2.6.4.tgz",
-			"version": "2.6.4"
+			"from": "metal-incremental-dom@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-soy": {
 			"from": "metal-soy@>=2.4.5 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-soy/-/metal-soy-2.6.4.tgz",
-			"version": "2.6.4"
+			"resolved": "https://registry.npmjs.org/metal-soy/-/metal-soy-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-soy-bundle": {
-			"from": "metal-soy-bundle@>=2.6.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-2.6.4.tgz",
-			"version": "2.6.4"
+			"from": "metal-soy-bundle@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"metal-state": {
-			"from": "metal-state@>=2.6.4 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.6.4.tgz",
-			"version": "2.6.4"
+			"from": "metal-state@>=2.9.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.9.0.tgz",
+			"version": "2.9.0"
 		},
 		"micromatch": {
 			"from": "micromatch@>=2.3.7 <3.0.0",
@@ -2862,8 +2643,8 @@
 		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"number-is-nan": {
 			"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -3019,8 +2800,8 @@
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"version": "1.2.1"
 		},
 		"read-all-stream": {
 			"dependencies": {
@@ -3031,8 +2812,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
@@ -3068,13 +2854,18 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"version": "3.1.0"
+		},
+		"remove-trailing-separator": {
+			"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"repeat-element": {
 			"from": "repeat-element@>=1.1.2 <2.0.0",
@@ -3098,8 +2889,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -3110,6 +2901,11 @@
 			"from": "rimraf@>=2.2.8 <3.0.0",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
@@ -3197,8 +2993,13 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.1.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-					"version": "2.2.3"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
@@ -3284,8 +3085,8 @@
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-			"version": "2.0.11"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
@@ -3336,8 +3137,8 @@
 		},
 		"which": {
 			"from": "which@>=1.2.12 <2.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-			"version": "1.2.12"
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+			"version": "1.2.14"
 		},
 		"widest-line": {
 			"from": "widest-line@>=1.0.0 <2.0.0",
@@ -3351,8 +3152,8 @@
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",

--- a/modules/apps/foundation/hello-soy/hello-soy-web/package.json
+++ b/modules/apps/foundation/hello-soy/hello-soy-web/package.json
@@ -5,7 +5,7 @@
 	},
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.1.2"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "hello-soy-web",
 	"version": "1.0.6"

--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/npm-shrinkwrap.json
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/npm-shrinkwrap.json
@@ -2,896 +2,891 @@
 	"dependencies": {
 		"abbrev": {
 			"from": "abbrev@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
 			"version": "1.1.0"
 		},
 		"ansi-regex": {
 			"from": "ansi-regex@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"version": "2.1.1"
 		},
 		"ansi-styles": {
 			"from": "ansi-styles@>=2.2.1 <3.0.0",
-			"resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 			"version": "2.2.1"
 		},
 		"archy": {
 			"from": "archy@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"arr-diff": {
 			"from": "arr-diff@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"arr-flatten": {
 			"from": "arr-flatten@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"array-differ": {
 			"from": "array-differ@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"array-uniq": {
 			"from": "array-uniq@>=1.0.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
 			"version": "1.0.3"
 		},
 		"array-unique": {
 			"from": "array-unique@>=0.2.1 <0.3.0",
-			"resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"version": "0.2.1"
 		},
 		"ast-types": {
 			"from": "ast-types@0.8.15",
-			"resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
 			"version": "0.8.15"
 		},
 		"balanced-match": {
 			"from": "balanced-match@>=0.4.1 <0.5.0",
-			"resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
 			"version": "0.4.2"
 		},
 		"beeper": {
 			"from": "beeper@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
 			"version": "1.1.1"
 		},
 		"bluebird": {
 			"from": "bluebird@>=3.0.6 <4.0.0",
-			"resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
 			"version": "3.5.0"
 		},
 		"bootstrap": {
 			"from": "bootstrap@>=3.3.6 <4.0.0",
-			"resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
 			"version": "3.3.7"
 		},
 		"bootstrap-sass": {
 			"from": "bootstrap-sass@>=3.3.6 <4.0.0",
-			"resolved": "http://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+			"resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
 			"version": "3.3.7"
 		},
 		"boxen": {
 			"dependencies": {
 				"object-assign": {
 					"from": "object-assign@>=4.0.1 <5.0.0",
-					"resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"version": "4.1.1"
 				}
 			},
 			"from": "boxen@>=0.3.1 <0.4.0",
-			"resolved": "http://registry.npmjs.org/boxen/-/boxen-0.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-0.3.1.tgz",
 			"version": "0.3.1"
 		},
 		"brace-expansion": {
 			"from": "brace-expansion@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-			"version": "1.1.6"
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+			"version": "1.1.7"
 		},
 		"braces": {
 			"from": "braces@>=1.8.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"version": "1.8.5"
 		},
 		"buffer-shims": {
-			"from": "buffer-shims@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+			"from": "buffer-shims@>=1.0.0 <1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"capture-stack-trace": {
 			"from": "capture-stack-trace@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"chalk": {
 			"from": "chalk@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"version": "1.1.3"
 		},
 		"clone": {
 			"from": "clone@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"clone-stats": {
 			"from": "clone-stats@>=0.0.1 <0.0.2",
-			"resolved": "http://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
 			"version": "0.0.1"
 		},
 		"code-point-at": {
 			"from": "code-point-at@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"version": "1.1.0"
 		},
 		"commander": {
 			"from": "commander@>=2.8.1 <3.0.0",
-			"resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 			"version": "2.9.0"
 		},
 		"concat-map": {
 			"from": "concat-map@0.0.1",
-			"resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"version": "0.0.1"
 		},
 		"config-chain": {
 			"from": "config-chain@>=1.1.5 <1.2.0",
-			"resolved": "http://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
 			"version": "1.1.11"
 		},
 		"configstore": {
 			"dependencies": {
 				"object-assign": {
 					"from": "object-assign@>=4.0.1 <5.0.0",
-					"resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"version": "4.1.1"
 				}
 			},
 			"from": "configstore@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
 			"version": "2.1.0"
 		},
 		"core-util-is": {
 			"from": "core-util-is@>=1.0.0 <1.1.0",
-			"resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"create-error-class": {
 			"from": "create-error-class@>=3.0.1 <4.0.0",
-			"resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"version": "3.0.2"
 		},
 		"dateformat": {
 			"from": "dateformat@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"deep-extend": {
 			"from": "deep-extend@>=0.4.0 <0.5.0",
-			"resolved": "http://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
 			"version": "0.4.1"
 		},
 		"defaults": {
 			"from": "defaults@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"version": "1.0.3"
 		},
 		"deprecated": {
 			"from": "deprecated@>=0.0.1 <0.0.2",
-			"resolved": "http://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
 			"version": "0.0.1"
 		},
 		"detect-file": {
 			"from": "detect-file@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
 			"version": "0.1.0"
 		},
 		"dot-prop": {
 			"from": "dot-prop@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"duplexer2": {
 			"from": "duplexer2@0.0.2",
-			"resolved": "http://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
 			"version": "0.0.2"
 		},
 		"editorconfig": {
 			"dependencies": {
 				"lru-cache": {
 					"from": "lru-cache@>=3.2.0 <4.0.0",
-					"resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
 					"version": "3.2.0"
 				}
 			},
 			"from": "editorconfig@>=0.13.2 <0.14.0",
-			"resolved": "http://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
 			"version": "0.13.2"
 		},
 		"end-of-stream": {
 			"dependencies": {
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
-					"resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
 					"version": "1.3.3"
 				}
 			},
 			"from": "end-of-stream@>=0.1.5 <0.2.0",
-			"resolved": "http://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
 			"version": "0.1.5"
 		},
 		"error-ex": {
 			"from": "error-ex@>=1.2.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"version": "1.3.1"
 		},
 		"escape-string-regexp": {
 			"from": "escape-string-regexp@>=1.0.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"esprima": {
 			"from": "esprima@>=2.5.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
 			"version": "2.7.3"
 		},
 		"estraverse": {
 			"from": "estraverse@>=4.1.0 <5.0.0",
-			"resolved": "http://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
 			"version": "4.2.0"
 		},
 		"expand-brackets": {
 			"from": "expand-brackets@>=0.1.4 <0.2.0",
-			"resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"version": "0.1.5"
 		},
 		"expand-range": {
 			"from": "expand-range@>=1.8.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"version": "1.8.2"
 		},
 		"expand-tilde": {
 			"from": "expand-tilde@>=1.2.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
 			"version": "1.2.2"
 		},
 		"extend": {
 			"from": "extend@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"extglob": {
 			"from": "extglob@>=0.3.1 <0.4.0",
-			"resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"version": "0.3.2"
 		},
 		"fancy-log": {
 			"from": "fancy-log@>=1.1.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
 			"version": "1.3.0"
 		},
 		"filename-regex": {
 			"from": "filename-regex@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"fill-range": {
 			"from": "fill-range@>=2.1.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"version": "2.2.3"
 		},
 		"filled-array": {
 			"from": "filled-array@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
 			"version": "1.1.0"
 		},
 		"find-index": {
 			"from": "find-index@>=0.1.1 <0.2.0",
-			"resolved": "http://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
 			"version": "0.1.1"
 		},
 		"findup-sync": {
 			"from": "findup-sync@>=0.4.2 <0.5.0",
-			"resolved": "http://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
 			"version": "0.4.3"
 		},
 		"fined": {
 			"from": "fined@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"first-chunk-stream": {
 			"from": "first-chunk-stream@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"flagged-respawn": {
 			"from": "flagged-respawn@>=0.3.2 <0.4.0",
-			"resolved": "http://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
 			"version": "0.3.2"
 		},
 		"for-in": {
 			"from": "for-in@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"for-own": {
 			"from": "for-own@>=0.1.4 <0.2.0",
-			"resolved": "http://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"version": "0.1.5"
 		},
 		"foreachasync": {
 			"from": "foreachasync@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"fs-exists-sync": {
 			"from": "fs-exists-sync@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
 			"version": "0.1.0"
 		},
 		"fs-extra": {
 			"from": "fs-extra@>=0.26.2 <0.27.0",
-			"resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
 			"version": "0.26.7"
 		},
 		"fs.realpath": {
 			"from": "fs.realpath@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"gaze": {
 			"from": "gaze@>=0.5.1 <0.6.0",
-			"resolved": "http://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+			"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 			"version": "0.5.2"
 		},
 		"glob": {
 			"from": "glob@>=7.0.5 <8.0.0",
-			"resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
 			"version": "7.1.1"
 		},
 		"glob-base": {
 			"from": "glob-base@>=0.3.0 <0.4.0",
-			"resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"version": "0.3.0"
 		},
 		"glob-parent": {
 			"from": "glob-parent@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"glob-stream": {
 			"dependencies": {
 				"glob": {
 					"from": "glob@>=4.3.1 <5.0.0",
-					"resolved": "http://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
 					"version": "4.5.3"
 				},
 				"minimatch": {
 					"from": "minimatch@>=2.0.1 <3.0.0",
-					"resolved": "http://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"version": "2.0.10"
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"version": "1.0.34"
 				},
 				"through2": {
 					"from": "through2@>=0.6.1 <0.7.0",
-					"resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"version": "0.6.5"
 				}
 			},
 			"from": "glob-stream@>=3.1.5 <4.0.0",
-			"resolved": "http://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
 			"version": "3.1.18"
 		},
 		"glob-watcher": {
 			"from": "glob-watcher@>=0.0.6 <0.0.7",
-			"resolved": "http://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
 			"version": "0.0.6"
 		},
 		"glob2base": {
 			"from": "glob2base@>=0.0.12 <0.0.13",
-			"resolved": "http://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
 			"version": "0.0.12"
 		},
 		"global-modules": {
 			"from": "global-modules@>=0.2.3 <0.3.0",
-			"resolved": "http://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
 			"version": "0.2.3"
 		},
 		"global-prefix": {
 			"from": "global-prefix@>=0.1.4 <0.2.0",
-			"resolved": "http://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
 			"version": "0.1.5"
 		},
 		"globule": {
 			"dependencies": {
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
-					"resolved": "http://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
 					"version": "3.1.21"
 				},
 				"graceful-fs": {
 					"from": "graceful-fs@>=1.2.0 <1.3.0",
-					"resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
 					"version": "1.2.3"
 				},
 				"inherits": {
 					"from": "inherits@>=1.0.0 <2.0.0",
-					"resolved": "http://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
 					"version": "1.0.2"
 				},
 				"minimatch": {
 					"from": "minimatch@>=0.2.11 <0.3.0",
-					"resolved": "http://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
 					"version": "0.2.14"
 				}
 			},
 			"from": "globule@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
 			"version": "0.1.0"
 		},
 		"glogg": {
 			"from": "glogg@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"got": {
 			"dependencies": {
 				"duplexer2": {
 					"from": "duplexer2@>=0.1.4 <0.2.0",
-					"resolved": "http://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+					"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
 					"version": "0.1.4"
 				},
 				"isarray": {
 					"from": "isarray@>=1.0.0 <1.1.0",
-					"resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"object-assign": {
 					"from": "object-assign@>=4.0.1 <5.0.0",
-					"resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"version": "4.1.1"
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-					"version": "2.2.6"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
-			"resolved": "http://registry.npmjs.org/got/-/got-5.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
 			"version": "5.7.1"
 		},
 		"graceful-fs": {
 			"from": "graceful-fs@>=4.1.2 <5.0.0",
-			"resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
 			"version": "4.1.11"
 		},
 		"graceful-readlink": {
 			"from": "graceful-readlink@>=1.0.0",
-			"resolved": "http://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"gulp": {
 			"from": "gulp@>=3.9.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+			"resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
 			"version": "3.9.1"
 		},
 		"gulp-util": {
 			"from": "gulp-util@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
 			"version": "3.0.8"
 		},
 		"gulplog": {
 			"from": "gulplog@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"has-ansi": {
 			"from": "has-ansi@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"has-gulplog": {
 			"from": "has-gulplog@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
 			"version": "0.1.0"
 		},
 		"homedir-polyfill": {
 			"from": "homedir-polyfill@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"html2incdom": {
 			"from": "html2incdom@>=0.1.1 <0.2.0",
-			"resolved": "http://registry.npmjs.org/html2incdom/-/html2incdom-0.1.8.tgz",
+			"resolved": "https://registry.npmjs.org/html2incdom/-/html2incdom-0.1.8.tgz",
 			"version": "0.1.8"
 		},
 		"imurmurhash": {
 			"from": "imurmurhash@>=0.1.4 <0.2.0",
-			"resolved": "http://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"version": "0.1.4"
 		},
 		"inflight": {
 			"from": "inflight@>=1.0.4 <2.0.0",
-			"resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"version": "1.0.6"
 		},
 		"inherits": {
 			"from": "inherits@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"version": "2.0.3"
 		},
 		"ini": {
 			"from": "ini@>=1.3.4 <2.0.0",
-			"resolved": "http://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
 			"version": "1.3.4"
 		},
 		"interpret": {
 			"from": "interpret@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"is-absolute": {
 			"from": "is-absolute@>=0.2.3 <0.3.0",
-			"resolved": "http://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
 			"version": "0.2.6"
 		},
 		"is-arrayish": {
 			"from": "is-arrayish@>=0.2.1 <0.3.0",
-			"resolved": "http://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"version": "0.2.1"
 		},
 		"is-buffer": {
-			"from": "is-buffer@>=1.0.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"from": "is-buffer@>=1.1.5 <2.0.0",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
 			"version": "1.1.5"
 		},
 		"is-dotfile": {
 			"from": "is-dotfile@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"is-equal-shallow": {
 			"from": "is-equal-shallow@>=0.1.3 <0.2.0",
-			"resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"version": "0.1.3"
 		},
 		"is-extendable": {
 			"from": "is-extendable@>=0.1.1 <0.2.0",
-			"resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"version": "0.1.1"
 		},
 		"is-extglob": {
 			"from": "is-extglob@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"is-finite": {
 			"from": "is-finite@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"is-fullwidth-code-point": {
 			"from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"is-glob": {
 			"from": "is-glob@>=2.0.1 <3.0.0",
-			"resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"version": "2.0.1"
 		},
 		"is-npm": {
 			"from": "is-npm@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"is-number": {
 			"from": "is-number@>=2.1.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"version": "2.1.0"
 		},
 		"is-obj": {
 			"from": "is-obj@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"is-posix-bracket": {
 			"from": "is-posix-bracket@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"version": "0.1.1"
 		},
 		"is-primitive": {
 			"from": "is-primitive@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"is-redirect": {
 			"from": "is-redirect@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"is-relative": {
 			"from": "is-relative@>=0.2.1 <0.3.0",
-			"resolved": "http://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
 			"version": "0.2.1"
 		},
 		"is-retry-allowed": {
 			"from": "is-retry-allowed@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
 			"version": "1.1.0"
 		},
 		"is-stream": {
 			"from": "is-stream@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"version": "1.1.0"
 		},
 		"is-unc-path": {
 			"from": "is-unc-path@>=0.1.1 <0.2.0",
-			"resolved": "http://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
 			"version": "0.1.2"
 		},
 		"is-utf8": {
 			"from": "is-utf8@>=0.2.0 <0.3.0",
-			"resolved": "http://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"version": "0.2.1"
 		},
 		"is-windows": {
 			"from": "is-windows@>=0.2.0 <0.3.0",
-			"resolved": "http://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
 			"version": "0.2.0"
 		},
 		"isarray": {
 			"from": "isarray@0.0.1",
-			"resolved": "http://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 			"version": "0.0.1"
 		},
 		"isexe": {
-			"from": "isexe@>=1.1.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-			"version": "1.1.2"
+			"from": "isexe@>=2.0.0 <3.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"version": "2.0.0"
 		},
 		"isobject": {
 			"dependencies": {
 				"isarray": {
 					"from": "isarray@1.0.0",
-					"resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"version": "1.0.0"
 				}
 			},
 			"from": "isobject@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"version": "2.1.0"
 		},
 		"js-beautify": {
 			"from": "js-beautify@>=1.5.10 <2.0.0",
-			"resolved": "http://registry.npmjs.org/js-beautify/-/js-beautify-1.6.12.tgz",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.12.tgz",
 			"version": "1.6.12"
 		},
 		"jsonfile": {
 			"from": "jsonfile@>=2.1.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"version": "2.4.0"
 		},
 		"jsstana": {
 			"from": "jsstana@>=0.1.5 <0.2.0",
-			"resolved": "http://registry.npmjs.org/jsstana/-/jsstana-0.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/jsstana/-/jsstana-0.1.6.tgz",
 			"version": "0.1.6"
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+			"version": "3.2.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"version": "1.3.1"
 		},
 		"latest-version": {
 			"from": "latest-version@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"levenshtein": {
 			"from": "levenshtein@>=1.0.2 <1.1.0",
-			"resolved": "http://registry.npmjs.org/levenshtein/-/levenshtein-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/levenshtein/-/levenshtein-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"liferay-module-config-generator": {
 			"from": "liferay-module-config-generator@>=1.2.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/liferay-module-config-generator/-/liferay-module-config-generator-1.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/liferay-module-config-generator/-/liferay-module-config-generator-1.2.1.tgz",
 			"version": "1.2.1"
 		},
 		"liftoff": {
 			"from": "liftoff@>=2.1.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
 			"version": "2.3.0"
 		},
 		"lodash": {
 			"from": "lodash@>=1.0.1 <1.1.0",
-			"resolved": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"lodash._basecopy": {
 			"from": "lodash._basecopy@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
 			"version": "3.0.1"
 		},
 		"lodash._basetostring": {
 			"from": "lodash._basetostring@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
 			"version": "3.0.1"
 		},
 		"lodash._basevalues": {
 			"from": "lodash._basevalues@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"lodash._getnative": {
 			"from": "lodash._getnative@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
 			"version": "3.9.1"
 		},
 		"lodash._isiterateecall": {
 			"from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
 			"version": "3.0.9"
 		},
 		"lodash._reescape": {
 			"from": "lodash._reescape@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"lodash._reevaluate": {
 			"from": "lodash._reevaluate@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"lodash._reinterpolate": {
 			"from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"lodash._root": {
 			"from": "lodash._root@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
 			"version": "3.0.1"
 		},
 		"lodash.assignwith": {
 			"from": "lodash.assignwith@>=4.0.7 <5.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
 			"version": "4.2.0"
 		},
 		"lodash.escape": {
 			"from": "lodash.escape@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
 			"version": "3.2.0"
 		},
 		"lodash.isarguments": {
 			"from": "lodash.isarguments@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
 			"version": "3.1.0"
 		},
 		"lodash.isarray": {
 			"from": "lodash.isarray@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
 			"version": "3.0.4"
 		},
 		"lodash.isempty": {
 			"from": "lodash.isempty@>=4.2.1 <5.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
 			"version": "4.4.0"
 		},
 		"lodash.isplainobject": {
 			"from": "lodash.isplainobject@>=4.0.4 <5.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"version": "4.0.6"
 		},
 		"lodash.isstring": {
 			"from": "lodash.isstring@>=4.0.1 <5.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
 			"version": "4.0.1"
 		},
 		"lodash.keys": {
 			"from": "lodash.keys@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"version": "3.1.2"
 		},
 		"lodash.mapvalues": {
 			"from": "lodash.mapvalues@>=4.4.0 <5.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
 			"version": "4.6.0"
 		},
 		"lodash.pick": {
 			"from": "lodash.pick@>=4.2.1 <5.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
 			"version": "4.4.0"
 		},
 		"lodash.restparam": {
 			"from": "lodash.restparam@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
 			"version": "3.6.1"
 		},
 		"lodash.template": {
 			"from": "lodash.template@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
 			"version": "3.6.2"
 		},
 		"lodash.templatesettings": {
 			"from": "lodash.templatesettings@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
 			"version": "3.1.1"
 		},
 		"lowercase-keys": {
 			"from": "lowercase-keys@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"lru-cache": {
 			"from": "lru-cache@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 			"version": "2.7.3"
 		},
 		"map-cache": {
 			"from": "map-cache@>=0.2.0 <0.3.0",
-			"resolved": "http://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"version": "0.2.2"
 		},
 		"metal": {
 			"from": "metal@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal/-/metal-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/metal/-/metal-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"metal-affix": {
 			"from": "metal-affix@>=1.0.0-rc.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-affix/-/metal-affix-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-affix/-/metal-affix-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-alert": {
 			"from": "metal-alert@>=1.0.0-rc.5 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-alert/-/metal-alert-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-alert/-/metal-alert-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-anim": {
 			"from": "metal-anim@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-anim/-/metal-anim-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-anim/-/metal-anim-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-autocomplete": {
 			"from": "metal-autocomplete@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-autocomplete/-/metal-autocomplete-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-autocomplete/-/metal-autocomplete-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-button-group": {
 			"from": "metal-button-group@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-button-group/-/metal-button-group-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-button-group/-/metal-button-group-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-cli": {
 			"dependencies": {
-				"acorn": {
-					"from": "acorn@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-					"version": "4.0.3"
-				},
-				"amdefine": {
-					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"ansi-styles": {
 					"from": "ansi-styles@>=2.2.1 <3.0.0",
@@ -905,18 +900,13 @@
 				},
 				"arr-flatten": {
 					"from": "arr-flatten@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"array-differ": {
 					"from": "array-differ@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"array-find-index": {
-					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-					"version": "1.0.2"
 				},
 				"array-uniq": {
 					"from": "array-uniq@>=1.0.2 <2.0.0",
@@ -928,22 +918,17 @@
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"version": "0.2.1"
 				},
-				"atob": {
-					"from": "atob@>=1.1.0 <1.2.0",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-					"version": "1.1.3"
-				},
 				"babel-code-frame": {
-					"from": "babel-code-frame@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-code-frame@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-core": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						},
 						"minimatch": {
 							"from": "minimatch@>=3.0.2 <4.0.0",
@@ -952,8 +937,8 @@
 						}
 					},
 					"from": "babel-core@>=6.3.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.17.0.tgz",
-					"version": "6.17.0"
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -969,13 +954,13 @@
 						},
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-generator@>=6.17.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-generator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -983,73 +968,73 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-define-map": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-regex": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-helpers": {
-					"from": "babel-helpers@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helpers@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-messages": {
-					"from": "babel-messages@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-messages@>=6.23.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-check-es2015-constants": {
-					"from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-external-helpers-2": {
 					"dependencies": {
@@ -1074,198 +1059,199 @@
 					"version": "2.0.1"
 				},
 				"babel-plugin-transform-es2015-arrow-functions": {
-					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoped-functions": {
-					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
-					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
-					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
-					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-literals": {
-					"from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
 					"from": "babel-plugin-transform-es2015-modules-amd@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-object-super": {
-					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.17.0.tgz",
-					"version": "6.17.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-spread": {
-					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-sticky-regex": {
-					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-es2015-template-literals": {
-					"from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+					"version": "6.22.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
-					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz",
-					"version": "6.11.0"
+					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-regenerator": {
-					"from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz",
-					"version": "6.16.1"
+					"from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"babel-register": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-register@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"from": "babel-register@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-runtime": {
-					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"from": "babel-runtime@>=6.22.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+					"version": "6.23.0"
 				},
 				"babel-template": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-template@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-template@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-traverse": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-traverse@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babel-types": {
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.2.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-							"version": "4.16.4"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+							"version": "4.17.4"
 						}
 					},
-					"from": "babel-types@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.24.1 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+					"version": "6.24.1"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
+					"version": "6.17.0"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -1274,8 +1260,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1284,13 +1270,13 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-					"version": "1.1.6"
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"version": "1.1.7"
 				},
 				"braces": {
 					"from": "braces@>=1.8.2 <2.0.0",
@@ -1298,24 +1284,14 @@
 					"version": "1.8.5"
 				},
 				"buffer-shims": {
-					"from": "buffer-shims@>=1.0.0 <2.0.0",
+					"from": "buffer-shims@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"builtin-modules": {
-					"from": "builtin-modules@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"camelcase": {
-					"from": "camelcase@>=2.0.0 <3.0.0",
+					"from": "camelcase@>=2.0.1 <3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 					"version": "2.1.1"
-				},
-				"camelcase-keys": {
-					"from": "camelcase-keys@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"version": "2.1.0"
 				},
 				"chalk": {
 					"from": "chalk@>=1.1.1 <2.0.0",
@@ -1339,8 +1315,8 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"concat-map": {
 					"from": "concat-map@0.0.1",
@@ -1354,8 +1330,8 @@
 				},
 				"convert-source-map": {
 					"from": "convert-source-map@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-					"version": "1.3.0"
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"core-js": {
 					"from": "core-js@>=2.4.0 <3.0.0",
@@ -1367,64 +1343,25 @@
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"css": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-							"version": "2.0.3"
-						},
-						"source-map": {
-							"from": "source-map@>=0.1.38 <0.2.0",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-							"version": "0.1.43"
-						}
-					},
-					"from": "css@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-					"version": "2.2.1"
-				},
-				"currently-unhandled": {
-					"from": "currently-unhandled@>=0.4.1 <0.5.0",
-					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-					"version": "0.4.1"
-				},
 				"dateformat": {
-					"from": "dateformat@>=1.0.11 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"version": "1.0.12"
+					"from": "dateformat@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"debug-fabulous": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@4.1.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "debug-fabulous@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
-					"version": "0.0.4"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+					"version": "2.6.4"
 				},
 				"decamelize": {
-					"from": "decamelize@>=1.1.2 <2.0.0",
+					"from": "decamelize@>=1.1.1 <2.0.0",
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"version": "1.2.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
-				},
-				"detect-newline": {
-					"from": "detect-newline@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"duplexer": {
 					"from": "duplexer@>=0.1.1 <0.2.0",
@@ -1450,23 +1387,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"end-of-stream": {
 					"from": "end-of-stream@1.0.0",
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"error-ex": {
-					"from": "error-ex@>=1.2.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-					"version": "1.3.0"
 				},
 				"escape-string-regexp": {
 					"from": "escape-string-regexp@>=1.0.2 <2.0.0",
@@ -1512,8 +1449,8 @@
 				},
 				"fancy-log": {
 					"from": "fancy-log@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"filename-regex": {
 					"from": "filename-regex@>=2.0.0 <3.0.0",
@@ -1525,32 +1462,20 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
-				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
-					"from": "find-up@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"version": "1.1.2"
-				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"for-in": {
-					"from": "for-in@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "for-in@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-					"version": "0.1.4"
+					"from": "for-own@>=0.1.4 <0.2.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"version": "0.1.5"
 				},
 				"fork-stream": {
 					"from": "fork-stream@>=0.0.4 <0.0.5",
@@ -1561,11 +1486,6 @@
 					"from": "gaze@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
 					"version": "0.5.2"
-				},
-				"get-stdin": {
-					"from": "get-stdin@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"version": "4.0.1"
 				},
 				"glob": {
 					"from": "glob@>=3.1.21 <3.2.0",
@@ -1623,8 +1543,8 @@
 				},
 				"glob-parent": {
 					"from": "glob-parent@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-					"version": "3.0.0"
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"version": "3.1.0"
 				},
 				"glob-stream": {
 					"dependencies": {
@@ -1664,9 +1584,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+					"version": "9.17.0"
 				},
 				"globule": {
 					"from": "globule@>=0.1.0 <0.2.0",
@@ -1695,25 +1615,25 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-match": {
 					"dependencies": {
 						"minimatch": {
-							"from": "minimatch@>=3.0.0 <4.0.0",
+							"from": "minimatch@>=3.0.3 <4.0.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 							"version": "3.0.3"
 						}
 					},
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-replace": {
 					"dependencies": {
@@ -1729,8 +1649,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -1740,9 +1665,9 @@
 				"gulp-sourcemaps": {
 					"dependencies": {
 						"graceful-fs": {
-							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"from": "graceful-fs@>=4.1.2 <5.0.0",
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -1750,14 +1675,21 @@
 							"version": "1.2.0"
 						}
 					},
-					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.7.3.tgz",
-					"version": "1.7.3"
+					"from": "gulp-sourcemaps@1.6.0",
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+					"version": "1.6.0"
 				},
 				"gulp-util": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "gulp-util@>=3.0.5 <4.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-					"version": "3.0.7"
+					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+					"version": "3.0.8"
 				},
 				"gulp-wrapper": {
 					"dependencies": {
@@ -1797,26 +1729,9 @@
 					"version": "0.1.0"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"hosted-git-info": {
-					"from": "hosted-git-info@>=2.1.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-					"version": "2.1.5"
-				},
-				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
-					"from": "indent-string@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"version": "2.1.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
@@ -1830,28 +1745,18 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"is-arrayish": {
-					"from": "is-arrayish@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"version": "0.2.1"
-				},
 				"is-buffer": {
-					"from": "is-buffer@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-					"version": "1.1.4"
-				},
-				"is-builtin-module": {
-					"from": "is-builtin-module@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "is-buffer@>=1.1.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+					"version": "1.1.5"
 				},
 				"is-dotfile": {
 					"from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -1870,8 +1775,8 @@
 				},
 				"is-extglob": {
 					"from": "is-extglob@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
-					"version": "2.1.0"
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
@@ -1884,7 +1789,7 @@
 					"version": "1.0.0"
 				},
 				"is-glob": {
-					"from": "is-glob@>=3.0.0 <4.0.0",
+					"from": "is-glob@>=3.1.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"version": "3.1.0"
 				},
@@ -1941,9 +1846,9 @@
 					"version": "1.0.2"
 				},
 				"js-tokens": {
-					"from": "js-tokens@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "js-tokens@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -1956,9 +1861,9 @@
 					"version": "1.0.1"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -1967,13 +1872,8 @@
 				},
 				"kind-of": {
 					"from": "kind-of@>=3.0.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-					"version": "3.0.4"
-				},
-				"lazy-debug-legacy": {
-					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
-					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
-					"version": "0.0.1"
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+					"version": "3.2.0"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -1989,8 +1889,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.5 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "lazystream@>=1.0.0 <2.0.0",
@@ -2001,18 +1906,6 @@
 					"from": "lcid@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"load-json-file": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "load-json-file@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"version": "1.1.0"
 				},
 				"lodash": {
 					"from": "lodash@>=1.0.1 <1.1.0",
@@ -2081,8 +1974,8 @@
 				},
 				"lodash.isequal": {
 					"from": "lodash.isequal@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
-					"version": "4.4.0"
+					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+					"version": "4.5.0"
 				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
@@ -2105,43 +1998,14 @@
 					"version": "3.1.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
-				},
-				"loud-rejection": {
-					"from": "loud-rejection@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lru-cache": {
 					"from": "lru-cache@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
 					"version": "2.7.3"
-				},
-				"map-obj": {
-					"from": "map-obj@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"meow": {
-					"dependencies": {
-						"object-assign": {
-							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
-						}
-					},
-					"from": "meow@>=3.3.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"version": "3.7.0"
 				},
 				"merge": {
 					"from": "merge@>=1.2.0 <2.0.0",
@@ -2162,13 +2026,18 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -2177,23 +2046,19 @@
 				},
 				"metal-tools-build-amd": {
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.3"
 				},
 				"metal-tools-build-globals": {
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-globals/-/metal-tools-build-globals-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-build-jquery": {
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-jquery/-/metal-tools-build-jquery-2.0.1.tgz",
-					"version": "2.0.1"
+					"version": "2.0.2"
 				},
 				"metal-tools-soy": {
-					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-soy/-/metal-tools-soy-3.0.2.tgz",
-					"version": "3.0.2"
+					"from": "metal-tools-soy@>=4.0.0 <5.0.0",
+					"version": "4.0.0"
 				},
 				"micromatch": {
 					"dependencies": {
@@ -2218,18 +2083,11 @@
 					"version": "0.2.14"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -2240,9 +2098,9 @@
 					"version": "0.11.1"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"version": "0.7.3"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -2254,15 +2112,10 @@
 					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 					"version": "0.1.2"
 				},
-				"normalize-package-data": {
-					"from": "normalize-package-data@>=2.3.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-					"version": "2.3.5"
-				},
 				"normalize-path": {
 					"from": "normalize-path@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"version": "2.1.1"
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -2276,8 +2129,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"once": {
 					"from": "once@>=1.3.0 <1.4.0",
@@ -2298,13 +2151,23 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "ordered-read-streams@>=0.3.0 <0.4.0",
 					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 					"version": "0.3.0"
+				},
+				"os-homedir": {
+					"from": "os-homedir@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-locale": {
 					"from": "os-locale@>=1.4.0 <2.0.0",
@@ -2333,47 +2196,20 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"version": "3.0.4"
 				},
-				"parse-json": {
-					"from": "parse-json@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"version": "2.2.0"
-				},
-				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"version": "1.0.1"
 				},
-				"path-type": {
-					"dependencies": {
-						"graceful-fs": {
-							"from": "graceful-fs@>=4.1.2 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
-						}
-					},
-					"from": "path-type@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"pify": {
-					"from": "pify@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"version": "2.3.0"
-				},
-				"pinkie": {
-					"from": "pinkie@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"version": "2.0.4"
-				},
-				"pinkie-promise": {
-					"from": "pinkie-promise@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"version": "2.0.1"
+				"path-parse": {
+					"from": "path-parse@>=1.0.5 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"version": "1.0.5"
 				},
 				"preserve": {
 					"from": "preserve@>=0.2.0 <0.3.0",
@@ -2381,9 +2217,9 @@
 					"version": "0.2.0"
 				},
 				"private": {
-					"from": "private@>=0.1.5 <0.2.0",
-					"resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-					"version": "0.1.6"
+					"from": "private@>=0.1.6 <0.2.0",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+					"version": "0.1.7"
 				},
 				"process-nextick-args": {
 					"from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -2392,18 +2228,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
-				},
-				"read-pkg": {
-					"from": "read-pkg@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"version": "1.1.0"
-				},
-				"read-pkg-up": {
-					"from": "read-pkg-up@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"readable-stream": {
 					"dependencies": {
@@ -2417,20 +2243,20 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"version": "1.1.14"
 				},
-				"redent": {
-					"from": "redent@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"version": "1.0.0"
-				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
-					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"from": "regenerator-runtime@>=0.10.0 <0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.4.tgz",
+					"version": "0.10.4"
+				},
+				"regenerator-transform": {
+					"from": "regenerator-transform@0.9.11",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+					"version": "0.9.11"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -2452,6 +2278,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -2459,13 +2290,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -2486,13 +2317,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -2506,33 +2342,13 @@
 				},
 				"resolve": {
 					"from": "resolve@>=1.1.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"version": "1.1.7"
-				},
-				"resolve-url": {
-					"from": "resolve-url@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"version": "0.2.1"
-				},
-				"semver": {
-					"from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"version": "5.3.0"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+					"version": "1.3.3"
 				},
 				"sigmund": {
 					"from": "sigmund@>=1.0.0 <1.1.0",
 					"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"signal-exit": {
-					"from": "signal-exit@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-					"version": "3.0.1"
 				},
 				"slash": {
 					"from": "slash@>=1.0.0 <2.0.0",
@@ -2544,20 +2360,10 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
-				"source-map-resolve": {
-					"from": "source-map-resolve@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-					"version": "0.3.1"
-				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
-				},
-				"source-map-url": {
-					"from": "source-map-url@>=0.3.0 <0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-					"version": "0.3.0"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
+					"version": "0.4.14"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -2568,21 +2374,6 @@
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"spdx-correct": {
-					"from": "spdx-correct@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"version": "1.0.2"
-				},
-				"spdx-expression-parse": {
-					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"version": "1.0.4"
-				},
-				"spdx-license-ids": {
-					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"version": "1.2.2"
 				},
 				"stream-combiner": {
 					"from": "stream-combiner@>=0.2.2 <0.3.0",
@@ -2624,20 +2415,15 @@
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"strip-indent": {
-					"from": "strip-indent@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"version": "1.0.1"
-				},
 				"supports-color": {
 					"from": "supports-color@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"version": "2.0.0"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"textextensions": {
 					"from": "textextensions@>=1.0.0 <1.1.0",
@@ -2662,14 +2448,19 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -2691,10 +2482,10 @@
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
 					"version": "1.0.2"
 				},
-				"trim-newlines": {
-					"from": "trim-newlines@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"version": "1.0.0"
+				"trim-right": {
+					"from": "trim-right@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"tunic": {
 					"from": "tunic@>=1.0.0 <2.0.0",
@@ -2706,16 +2497,6 @@
 					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 					"version": "2.2.1"
 				},
-				"urix": {
-					"from": "urix@>=0.1.0 <0.2.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"version": "0.1.0"
-				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
-				},
 				"util-deprecate": {
 					"from": "util-deprecate@>=1.0.1 <1.1.0",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2726,11 +2507,6 @@
 					"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"validate-npm-package-license": {
-					"from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"version": "3.0.1"
-				},
 				"vinyl": {
 					"from": "vinyl@>=0.5.0 <0.6.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
@@ -2740,8 +2516,8 @@
 					"dependencies": {
 						"graceful-fs": {
 							"from": "graceful-fs@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-							"version": "4.1.9"
+							"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+							"version": "4.1.11"
 						},
 						"inherits": {
 							"from": "inherits@>=2.0.1 <2.1.0",
@@ -2755,13 +2531,18 @@
 						},
 						"object-assign": {
 							"from": "object-assign@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-							"version": "4.1.0"
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"version": "4.1.1"
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+							"version": "2.2.9"
+						},
+						"string_decoder": {
+							"from": "string_decoder@>=1.0.0 <1.1.0",
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+							"version": "1.0.0"
 						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
@@ -2770,8 +2551,8 @@
 						}
 					},
 					"from": "vinyl-fs@>=2.2.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-					"version": "2.4.3"
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+					"version": "2.4.4"
 				},
 				"vinyl-sourcemaps-apply": {
 					"from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
@@ -2785,8 +2566,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -2794,7 +2575,7 @@
 					"version": "1.0.2"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -2809,694 +2590,714 @@
 					"version": "3.32.0"
 				}
 			},
-			"from": "metal-cli@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/metal-cli/-/metal-cli-2.1.2.tgz",
-			"version": "2.1.2"
+			"from": "metal-cli@>=4.0.1 <5.0.0",
+			"resolved": "https://registry.npmjs.org/metal-cli/-/metal-cli-4.0.1.tgz",
+			"version": "4.0.1"
 		},
 		"metal-clipboard": {
 			"from": "metal-clipboard@>=1.0.0-rc.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-clipboard/-/metal-clipboard-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-clipboard/-/metal-clipboard-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-component": {
 			"from": "metal-component@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-component/-/metal-component-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/metal-component/-/metal-component-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"metal-components": {
 			"from": "metal-components@1.0.0-rc.19",
-			"resolved": "http://registry.npmjs.org/metal-components/-/metal-components-1.0.0-rc.19.tgz",
+			"resolved": "https://registry.npmjs.org/metal-components/-/metal-components-1.0.0-rc.19.tgz",
 			"version": "1.0.0-rc.19"
 		},
 		"metal-datatable": {
 			"from": "metal-datatable@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-datatable/-/metal-datatable-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-datatable/-/metal-datatable-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-debounce": {
 			"from": "metal-debounce@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-debounce/-/metal-debounce-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-debounce/-/metal-debounce-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-dom": {
 			"from": "metal-dom@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-dom/-/metal-dom-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"metal-drag-drop": {
 			"from": "metal-drag-drop@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-drag-drop/-/metal-drag-drop-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/metal-drag-drop/-/metal-drag-drop-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"metal-dropdown": {
 			"from": "metal-dropdown@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-dropdown/-/metal-dropdown-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-dropdown/-/metal-dropdown-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-events": {
 			"from": "metal-events@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-events/-/metal-events-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"metal-incremental-dom": {
 			"from": "metal-incremental-dom@>=1.0.5 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/metal-incremental-dom/-/metal-incremental-dom-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"metal-list": {
 			"from": "metal-list@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-list/-/metal-list-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-list/-/metal-list-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-modal": {
 			"from": "metal-modal@>=1.0.0-rc.3 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-modal/-/metal-modal-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/metal-modal/-/metal-modal-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"metal-popover": {
 			"from": "metal-popover@>=1.0.0-rc.3 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-popover/-/metal-popover-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-popover/-/metal-popover-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-position": {
 			"from": "metal-position@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-position/-/metal-position-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-position/-/metal-position-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-progressbar": {
 			"from": "metal-progressbar@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-progressbar/-/metal-progressbar-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/metal-progressbar/-/metal-progressbar-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"metal-promise": {
 			"from": "metal-promise@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-promise/-/metal-promise-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-promise/-/metal-promise-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-rating": {
 			"from": "metal-rating@>=1.0.0-rc.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-rating/-/metal-rating-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/metal-rating/-/metal-rating-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"metal-scrollspy": {
 			"from": "metal-scrollspy@>=1.0.0-rc.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-scrollspy/-/metal-scrollspy-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-scrollspy/-/metal-scrollspy-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-select": {
 			"from": "metal-select@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-select/-/metal-select-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-select/-/metal-select-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-slider": {
 			"from": "metal-slider@>=1.0.0-rc.3 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-slider/-/metal-slider-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/metal-slider/-/metal-slider-1.1.1.tgz",
 			"version": "1.1.1"
 		},
 		"metal-soy": {
 			"from": "metal-soy@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-soy/-/metal-soy-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/metal-soy/-/metal-soy-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"metal-soy-bundle": {
 			"from": "metal-soy-bundle@>=1.1.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/metal-soy-bundle/-/metal-soy-bundle-1.3.1.tgz",
 			"version": "1.3.1"
 		},
 		"metal-state": {
 			"from": "metal-state@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-state/-/metal-state-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"metal-switcher": {
 			"from": "metal-switcher@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-switcher/-/metal-switcher-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-switcher/-/metal-switcher-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-toggler": {
 			"from": "metal-toggler@>=1.0.0-rc.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-toggler/-/metal-toggler-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-toggler/-/metal-toggler-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-tooltip": {
 			"from": "metal-tooltip@>=1.0.0-rc.3 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-tooltip/-/metal-tooltip-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-tooltip/-/metal-tooltip-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"metal-treeview": {
 			"from": "metal-treeview@>=1.0.0-rc.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/metal-treeview/-/metal-treeview-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/metal-treeview/-/metal-treeview-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"micromatch": {
 			"from": "micromatch@>=2.3.7 <3.0.0",
-			"resolved": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"version": "2.3.11"
 		},
 		"minimatch": {
 			"from": "minimatch@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 			"version": "3.0.3"
 		},
 		"minimist": {
 			"from": "minimist@>=1.1.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"version": "1.2.0"
 		},
 		"mkdirp": {
 			"dependencies": {
 				"minimist": {
 					"from": "minimist@0.0.8",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"version": "0.0.8"
 				}
 			},
 			"from": "mkdirp@>=0.5.0 <0.6.0",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"version": "0.5.1"
 		},
 		"multipipe": {
 			"from": "multipipe@>=0.1.2 <0.2.0",
-			"resolved": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 			"version": "0.1.2"
 		},
 		"natives": {
 			"from": "natives@>=1.1.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
 			"version": "1.1.0"
 		},
 		"node-status-codes": {
 			"from": "node-status-codes@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"nopt": {
 			"from": "nopt@>=3.0.1 <3.1.0",
-			"resolved": "http://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"version": "3.0.6"
 		},
 		"normalize-path": {
 			"from": "normalize-path@>=2.0.1 <3.0.0",
-			"resolved": "http://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"number-is-nan": {
 			"from": "number-is-nan@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"object-assign": {
 			"from": "object-assign@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
 			"version": "3.0.0"
 		},
 		"object.omit": {
 			"from": "object.omit@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"version": "2.0.1"
 		},
 		"once": {
 			"from": "once@>=1.3.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"version": "1.4.0"
 		},
 		"orchestrator": {
 			"from": "orchestrator@>=0.3.0 <0.4.0",
-			"resolved": "http://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+			"resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
 			"version": "0.3.8"
 		},
 		"ordered-read-streams": {
 			"from": "ordered-read-streams@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
 			"version": "0.1.0"
 		},
 		"os-homedir": {
 			"from": "os-homedir@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"os-tmpdir": {
 			"from": "os-tmpdir@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"osenv": {
 			"from": "osenv@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 			"version": "0.1.4"
 		},
 		"package-json": {
 			"dependencies": {
 				"semver": {
 					"from": "semver@>=5.1.0 <6.0.0",
-					"resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"version": "5.3.0"
 				}
 			},
 			"from": "package-json@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
 			"version": "2.4.0"
 		},
 		"packrattle": {
 			"from": "packrattle@>=4.1.0 <5.0.0",
-			"resolved": "http://registry.npmjs.org/packrattle/-/packrattle-4.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/packrattle/-/packrattle-4.1.0.tgz",
 			"version": "4.1.0"
 		},
 		"parse-filepath": {
 			"from": "parse-filepath@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"parse-glob": {
 			"from": "parse-glob@>=3.0.4 <4.0.0",
-			"resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"version": "3.0.4"
 		},
 		"parse-json": {
 			"from": "parse-json@>=2.1.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"version": "2.2.0"
 		},
 		"parse-passwd": {
 			"from": "parse-passwd@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"path-is-absolute": {
 			"from": "path-is-absolute@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"path-parse": {
 			"from": "path-parse@>=1.0.5 <2.0.0",
-			"resolved": "http://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
 			"version": "1.0.5"
 		},
 		"path-root": {
 			"from": "path-root@>=0.1.1 <0.2.0",
-			"resolved": "http://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
 			"version": "0.1.1"
 		},
 		"path-root-regex": {
 			"from": "path-root-regex@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
 			"version": "0.1.2"
 		},
 		"pinkie": {
 			"from": "pinkie@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
 			"version": "2.0.4"
 		},
 		"pinkie-promise": {
 			"from": "pinkie-promise@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"version": "2.0.1"
 		},
 		"prepend-http": {
 			"from": "prepend-http@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"version": "1.0.4"
 		},
 		"preserve": {
 			"from": "preserve@>=0.2.0 <0.3.0",
-			"resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"version": "0.2.0"
 		},
 		"pretty-hrtime": {
 			"from": "pretty-hrtime@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
 			"version": "1.0.3"
 		},
 		"private": {
 			"from": "private@>=0.1.5 <0.2.0",
-			"resolved": "http://registry.npmjs.org/private/-/private-0.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
 			"version": "0.1.7"
 		},
 		"process-nextick-args": {
 			"from": "process-nextick-args@>=1.0.6 <1.1.0",
-			"resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
 			"version": "1.0.7"
 		},
 		"proto-list": {
 			"from": "proto-list@>=1.2.1 <1.3.0",
-			"resolved": "http://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"version": "1.2.4"
 		},
 		"pseudomap": {
 			"from": "pseudomap@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"randomatic": {
 			"from": "randomatic@>=1.1.3 <2.0.0",
-			"resolved": "http://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
 			"version": "1.1.6"
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
-			"resolved": "http://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"version": "1.2.1"
 		},
 		"read-all-stream": {
 			"dependencies": {
 				"isarray": {
 					"from": "isarray@>=1.0.0 <1.1.0",
-					"resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-					"version": "2.2.6"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
 			"version": "3.1.0"
 		},
 		"readable-stream": {
 			"from": "readable-stream@>=1.1.9 <1.2.0",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 			"version": "1.1.14"
 		},
 		"recast": {
 			"dependencies": {
 				"esprima-fb": {
 					"from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-					"resolved": "http://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
 					"version": "15001.1001.0-dev-harmony-fb"
 				}
 			},
 			"from": "recast@>=0.10.22 <0.11.0",
-			"resolved": "http://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
 			"version": "0.10.43"
 		},
 		"rechoir": {
 			"from": "rechoir@>=0.6.2 <0.7.0",
-			"resolved": "http://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"version": "0.6.2"
 		},
 		"regex-cache": {
 			"from": "regex-cache@>=0.4.2 <0.5.0",
-			"resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"version": "0.4.3"
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "http://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-			"version": "3.1.0"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+			"version": "3.3.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
-			"resolved": "http://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"version": "3.1.0"
+		},
+		"remove-trailing-separator": {
+			"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"repeat-element": {
 			"from": "repeat-element@>=1.1.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
 			"version": "1.1.2"
 		},
 		"repeat-string": {
 			"from": "repeat-string@>=1.5.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"version": "1.6.1"
 		},
 		"repeating": {
 			"from": "repeating@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"version": "2.0.1"
 		},
 		"replace-ext": {
 			"from": "replace-ext@0.0.1",
-			"resolved": "http://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
 			"version": "0.0.1"
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "http://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-			"version": "1.3.2"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"version": "1.3.3"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
 			"version": "0.1.1"
 		},
 		"rimraf": {
 			"from": "rimraf@>=2.2.8 <3.0.0",
-			"resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"version": "2.6.1"
+		},
+		"safe-buffer": {
+			"from": "safe-buffer@>=5.0.1 <6.0.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+			"version": "5.0.1"
 		},
 		"semver": {
 			"from": "semver@>=4.1.0 <5.0.0",
-			"resolved": "http://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
 			"version": "4.3.6"
 		},
 		"semver-diff": {
 			"dependencies": {
 				"semver": {
 					"from": "semver@>=5.0.3 <6.0.0",
-					"resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"version": "5.3.0"
 				}
 			},
 			"from": "semver-diff@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 			"version": "2.1.0"
 		},
 		"sequencify": {
 			"from": "sequencify@>=0.0.7 <0.1.0",
-			"resolved": "http://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+			"resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
 			"version": "0.0.7"
 		},
 		"sigmund": {
 			"from": "sigmund@>=1.0.0 <1.1.0",
-			"resolved": "http://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"slide": {
 			"from": "slide@>=1.1.5 <2.0.0",
-			"resolved": "http://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
 			"version": "1.1.6"
 		},
 		"source-map": {
 			"from": "source-map@>=0.5.1 <0.6.0",
-			"resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 			"version": "0.5.6"
 		},
 		"sparkles": {
 			"from": "sparkles@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"stream-consume": {
 			"from": "stream-consume@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
 			"version": "0.1.0"
 		},
 		"string-width": {
 			"from": "string-width@>=1.0.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"string_decoder": {
 			"from": "string_decoder@>=0.10.0 <0.11.0",
-			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 			"version": "0.10.31"
 		},
 		"strip-ansi": {
 			"from": "strip-ansi@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"version": "3.0.1"
 		},
 		"strip-bom": {
 			"from": "strip-bom@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"strip-json-comments": {
 			"from": "strip-json-comments@>=2.0.1 <2.1.0",
-			"resolved": "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"version": "2.0.1"
 		},
 		"supports-color": {
 			"from": "supports-color@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"through2": {
 			"dependencies": {
 				"isarray": {
 					"from": "isarray@>=1.0.0 <1.1.0",
-					"resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"version": "1.0.0"
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.1.5 <3.0.0",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-					"version": "2.2.6"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"version": "2.2.9"
+				},
+				"string_decoder": {
+					"from": "string_decoder@>=1.0.0 <1.1.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+					"version": "1.0.0"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"version": "2.0.3"
 		},
 		"tildify": {
 			"from": "tildify@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
 			"version": "1.2.0"
 		},
 		"time-stamp": {
 			"from": "time-stamp@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
 			"version": "1.0.1"
 		},
 		"timed-out": {
 			"from": "timed-out@>=3.0.0 <4.0.0",
-			"resolved": "http://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
 			"version": "3.1.3"
 		},
 		"unc-path-regex": {
 			"from": "unc-path-regex@>=0.1.0 <0.2.0",
-			"resolved": "http://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
 			"version": "0.1.2"
 		},
 		"underscore": {
 			"from": "underscore@>=1.8.2 <1.9.0",
-			"resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
 			"version": "1.8.3"
 		},
 		"underscore.string": {
 			"from": "underscore.string@>=2.3.0 <2.4.0",
-			"resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
 			"version": "2.3.3"
 		},
 		"unique-stream": {
 			"from": "unique-stream@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"unzip-response": {
 			"from": "unzip-response@>=1.0.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"upath": {
 			"dependencies": {
 				"lodash": {
 					"from": "lodash@>=3.0.0 <4.0.0",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"version": "3.10.1"
 				}
 			},
 			"from": "upath@>=0.1.6 <0.2.0",
-			"resolved": "http://registry.npmjs.org/upath/-/upath-0.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-0.1.7.tgz",
 			"version": "0.1.7"
 		},
 		"update-notifier": {
 			"from": "update-notifier@>=0.6.0 <0.7.0",
-			"resolved": "http://registry.npmjs.org/update-notifier/-/update-notifier-0.6.3.tgz",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.3.tgz",
 			"version": "0.6.3"
 		},
 		"url-parse-lax": {
 			"from": "url-parse-lax@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"user-home": {
 			"from": "user-home@>=1.1.1 <2.0.0",
-			"resolved": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
 			"version": "1.1.1"
 		},
 		"util-deprecate": {
 			"from": "util-deprecate@>=1.0.1 <1.1.0",
-			"resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"uuid": {
 			"from": "uuid@>=2.0.1 <3.0.0",
-			"resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
 			"version": "2.0.3"
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
-			"resolved": "http://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-			"version": "2.0.11"
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"version": "2.1.1"
 		},
 		"vinyl": {
 			"from": "vinyl@>=0.5.0 <0.6.0",
-			"resolved": "http://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
 			"version": "0.5.3"
 		},
 		"vinyl-fs": {
 			"dependencies": {
 				"clone": {
 					"from": "clone@>=0.2.0 <0.3.0",
-					"resolved": "http://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
 					"version": "0.2.0"
 				},
 				"graceful-fs": {
 					"from": "graceful-fs@>=3.0.0 <4.0.0",
-					"resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
 					"version": "3.0.11"
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"version": "1.0.34"
 				},
 				"through2": {
 					"from": "through2@>=0.6.1 <0.7.0",
-					"resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"version": "0.6.5"
 				},
 				"vinyl": {
 					"from": "vinyl@>=0.4.0 <0.5.0",
-					"resolved": "http://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
 					"version": "0.4.6"
 				}
 			},
 			"from": "vinyl-fs@>=0.3.0 <0.4.0",
-			"resolved": "http://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
 			"version": "0.3.14"
 		},
 		"walk": {
 			"from": "walk@>=2.3.9 <3.0.0",
-			"resolved": "http://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
+			"resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
 			"version": "2.3.9"
 		},
 		"walkdir": {
 			"from": "walkdir@0.0.10",
-			"resolved": "http://registry.npmjs.org/walkdir/-/walkdir-0.0.10.tgz",
+			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.10.tgz",
 			"version": "0.0.10"
 		},
 		"which": {
 			"from": "which@>=1.2.12 <2.0.0",
-			"resolved": "http://registry.npmjs.org/which/-/which-1.2.12.tgz",
-			"version": "1.2.12"
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+			"version": "1.2.14"
 		},
 		"widest-line": {
 			"from": "widest-line@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
 			"version": "1.0.0"
 		},
 		"wrappy": {
 			"from": "wrappy@>=1.0.0 <2.0.0",
-			"resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"version": "1.0.2"
 		},
 		"write-file-atomic": {
 			"from": "write-file-atomic@>=1.1.2 <2.0.0",
-			"resolved": "http://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-			"version": "1.3.1"
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+			"version": "1.3.4"
 		},
 		"xdg-basedir": {
 			"from": "xdg-basedir@>=2.0.0 <3.0.0",
-			"resolved": "http://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
 			"version": "2.0.0"
 		},
 		"xtend": {
 			"from": "xtend@>=4.0.1 <4.1.0",
-			"resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"version": "4.0.1"
 		}
 	},

--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/package.json
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/package.json
@@ -4,7 +4,7 @@
 	},
 	"devDependencies": {
 		"liferay-module-config-generator": "^1.2.1",
-		"metal-cli": "^2.0.0"
+		"metal-cli": "^4.0.1"
 	},
 	"name": "portlet-configuration-css-web",
 	"version": "2.0.9"


### PR DESCRIPTION
Hola, @ealonso, esta pull es sólo para comprobar que el portlet `css-web` afectado funciona bien con estos cambios. No hace falta pasarla, simplemente probar que todo funciona.

Gracias!