### PR TITLE
[TECH SUPPORT] LPS-72312 Page icons are not rendered in the Navigation Menu

### DIFF
--- a/util-taglib/src/com/liferay/taglib/theme/LayoutIconTag.java
+++ b/util-taglib/src/com/liferay/taglib/theme/LayoutIconTag.java
@@ -69,7 +69,7 @@ public class LayoutIconTag
 			jspWriter.write(themeDisplay.getPathImage());
 
 			jspWriter.write("/layout_icon?img_id=");
-			jspWriter.write(String.valueOf(layout.getIconImage()));
+			jspWriter.write(String.valueOf(layout.getIconImageId()));
 			jspWriter.write("&t=");
 			jspWriter.write(
 				WebServerServletTokenUtil.getToken(layout.getIconImageId()));


### PR DESCRIPTION
Hi @ealonso,

Please review. See https://issues.liferay.com/browse/LPS-72312 for details.

Regards,
G

/cc @janditibi 