### PR TITLE
LPS-72628 Fix apostrophe and ampersand escaping in Navigation Menu - …

### DIFF
--- a/modules/apps/web-experience/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navigation_menu_macro.ftl
+++ b/modules/apps/web-experience/site-navigation/site-navigation-menu-web/src/main/resources/com/liferay/site/navigation/menu/web/portlet/template/dependencies/portlet_display_template_navigation_menu_macro.ftl
@@ -27,9 +27,9 @@
 
 				<li class="${nav_item_css_class}" ${nav_item_attr_selected}>
 					<#if navItem.isBrowsable()>
-						<a class="${nav_item_css_class}" href="${navItem.getRegularURL()!""}" ${navItem.getTarget()}>${htmlUtil.escape(navItem.getName())}</a>
+						<a class="${nav_item_css_class}" href="${navItem.getRegularURL()!""}" ${navItem.getTarget()}>${navItem.getName()}</a>
 					<#else>
-						${htmlUtil.escape(navItem.getName())}
+						${navItem.getName()}
 					</#if>
 
 					<#if includeAllChildNavItems || navItem.isInNavigation(branchNavItems)>


### PR DESCRIPTION
/cc @JonathanAichler

Hi Eudaldo

I am sending you this directly because Jonathan Mccann is out of the office.

Note from Jonathan:
> https://issues.liferay.com/browse/LPS-72628
> 
> The issue had to do with escaping the names that were put into the List Menu, so I tested this fix against the bug in [LPS-46156](https://issues.liferay.com/browse/LPS-46156) since that ticket seemed to add the HTML escaping back in 6.1 and 6.2. It seemed to pass regression and I could not reproduce the LPS-46156 issue after my changes.