### PR TITLE
LPS-72736 'My Dashboard' and 'My Profile' links in Product Menu retain previous portlet name in URL

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -311,7 +311,7 @@ public class GroupImpl extends GroupBaseImpl {
 					layoutSet, themeDisplay);
 
 				return PortalUtil.addPreservedParameters(
-					themeDisplay, groupFriendlyURL);
+					themeDisplay, groupFriendlyURL, isUser());
 			}
 		}
 		catch (PortalException pe) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -782,9 +782,9 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public String addPreservedParameters(
-		ThemeDisplay themeDisplay, String url, boolean isUser) {
+		ThemeDisplay themeDisplay, String url, boolean user) {
 
-		if (isUser) {
+		if (user) {
 			return addPreservedParameters(themeDisplay, url, false, true);
 		}
 		else {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -782,6 +782,19 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public String addPreservedParameters(
+		ThemeDisplay themeDisplay, String url, boolean isUser) {
+
+		if (isUser) {
+			return addPreservedParameters(themeDisplay, url, false, true);
+		}
+		else {
+			return addPreservedParameters(
+				themeDisplay, themeDisplay.getLayout(), url, true);
+		}
+	}
+
+	@Override
+	public String addPreservedParameters(
 		ThemeDisplay themeDisplay, String url, boolean typeControlPanel,
 		boolean doAsUser) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -233,6 +233,9 @@ public interface Portal {
 	public String addPreservedParameters(ThemeDisplay themeDisplay, String url);
 
 	public String addPreservedParameters(
+		ThemeDisplay themeDisplay, String url, boolean isUser);
+
+	public String addPreservedParameters(
 		ThemeDisplay themeDisplay, String url, boolean typeControlPanel,
 		boolean doAsUser);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -233,7 +233,7 @@ public interface Portal {
 	public String addPreservedParameters(ThemeDisplay themeDisplay, String url);
 
 	public String addPreservedParameters(
-		ThemeDisplay themeDisplay, String url, boolean isUser);
+		ThemeDisplay themeDisplay, String url, boolean user);
 
 	public String addPreservedParameters(
 		ThemeDisplay themeDisplay, String url, boolean typeControlPanel,

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -264,9 +264,9 @@ public class PortalUtil {
 	}
 
 	public static String addPreservedParameters(
-		ThemeDisplay themeDisplay, String url, boolean isUser) {
+		ThemeDisplay themeDisplay, String url, boolean user) {
 
-		return getPortal().addPreservedParameters(themeDisplay, url, isUser);
+		return getPortal().addPreservedParameters(themeDisplay, url, user);
 	}
 
 	public static String addPreservedParameters(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -264,6 +264,12 @@ public class PortalUtil {
 	}
 
 	public static String addPreservedParameters(
+		ThemeDisplay themeDisplay, String url, boolean isUser) {
+
+		return getPortal().addPreservedParameters(themeDisplay, url, isUser);
+	}
+
+	public static String addPreservedParameters(
 		ThemeDisplay themeDisplay, String url, boolean typeControlPanel,
 		boolean doAsUser) {
 


### PR DESCRIPTION
Hi Eudaldo,

Please, review (again :) )this PR. You can find further information in LPS-72736. The issue is similar to the one solved in LPS-70752 so I tried to follow the same approach.

After reviewing antonio-ortega#36, I think there is no point including last commit because is breaking the change due to is not setting typeControlPanel to false for user pages. But as we talked, if you know a better way to make it clear, just go ahead.

Thank you in advance!

Ps: It comes from ealonso#938 and antonio-ortega#36