### PR TITLE
J cords lps 73925 revised

### DIFF
--- a/modules/apps/foundation/server/.gitrepo
+++ b/modules/apps/foundation/server/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 78051be6b02f993210ba6deee49187fdffe8b31b
+	commit = fccbd69115b348adab8ec3703b8c25f1f2c8bf44
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b989326ed2b0088a823a07d14dc9e984ccd41a39
+	parent = 06b78845cd6c31470479f4f228808a8448ff51de
 	remote = git@github.com:liferay/com-liferay-server.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 46761a756d2f26677b2cdb7a673009f567b404f6
+	commit = 8a8b8f2e18cc25546fadd62ccc4b166b792069b5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 31069a6eadf89bcb5ffcd5021722a894bbe6081f
+	parent = b893ae8c5b159031755825c37fff8eb52ed59268
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 9f775a5456939ed5fac5342a2ea8db9186a1a5cf
+	commit = 90bd3a3a7c3d39efc7950db341ab5c0bc210c5c5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = becaf1f9306c4be89bb79f68c199a9fccacd5c0d
+	parent = 75b81087f4204ee3b2f6b5c5b3b1115351e9cb37
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 3d592d6c974f809f58a3d7c5677618bccb1e0a86
+	commit = 53129b8ca0cb9909e11bf4906b8bb9b3ff819b02
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7f6ce4becb65a5a8f0a81424a6fe3528b07b232b
+	parent = 7b51b5eaf71f32ad5f2dc0ffe654c882a24c97f5
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
@@ -203,12 +203,17 @@ public class JournalArticleIndexer
 
 		boolean head = GetterUtil.getBoolean(
 			searchContext.getAttribute("head"), Boolean.TRUE);
+		boolean latest = GetterUtil.getBoolean(
+			searchContext.getAttribute("latest"));
 		boolean relatedClassName = GetterUtil.getBoolean(
 			searchContext.getAttribute("relatedClassName"));
 		boolean showNonindexable = GetterUtil.getBoolean(
 			searchContext.getAttribute("showNonindexable"));
 
-		if (head && !relatedClassName && !showNonindexable) {
+		if (latest && !relatedClassName && !showNonindexable) {
+			contextBooleanFilter.addRequiredTerm("latest", Boolean.TRUE);
+		}
+		else if (head && !relatedClassName && !showNonindexable) {
 			contextBooleanFilter.addRequiredTerm("head", Boolean.TRUE);
 		}
 

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/search/JournalArticleIndexer.java
@@ -524,6 +524,10 @@ public class JournalArticleIndexer
 
 		document.addKeyword("headListable", headListable);
 
+		boolean latestArticle = JournalUtil.isLatestArticle(journalArticle);
+
+		document.addKeyword("latest", latestArticle);
+
 		// Scheduled listable articles should be visible in asset browser
 
 		if (journalArticle.isScheduled() && headListable) {

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
@@ -837,6 +837,20 @@ public class JournalUtil {
 		return false;
 	}
 
+	public static boolean isLatestArticle(JournalArticle article) {
+		JournalArticle latestArticle =
+			JournalArticleLocalServiceUtil.fetchLatestArticle(
+				article.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
+
+		if ((latestArticle != null) &&
+			(article.getId() == latestArticle.getId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public static boolean isSubscribedToArticle(
 		long companyId, long groupId, long userId, long articleId) {
 

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/util/impl/JournalUtil.java
@@ -840,7 +840,8 @@ public class JournalUtil {
 	public static boolean isLatestArticle(JournalArticle article) {
 		JournalArticle latestArticle =
 			JournalArticleLocalServiceUtil.fetchLatestArticle(
-				article.getResourcePrimKey(), WorkflowConstants.STATUS_ANY);
+				article.getResourcePrimKey(), WorkflowConstants.STATUS_ANY,
+				false);
 
 		if ((latestArticle != null) &&
 			(article.getId() == latestArticle.getId())) {

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1265,7 +1265,6 @@ public class JournalDisplayContext {
 		attributes.put("ddmStructureKey", ddmStructureKey);
 		attributes.put("ddmTemplateKey", ddmTemplateKey);
 		attributes.put("params", params);
-
 		searchContext.setAttributes(attributes);
 
 		searchContext.setCompanyId(companyId);

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1284,6 +1284,7 @@ public class JournalDisplayContext {
 		}
 
 		searchContext.setAttribute("head", !showVersions);
+		searchContext.setAttribute("latest", !showVersions);
 		searchContext.setAttribute("params", params);
 		searchContext.setEnd(end);
 		searchContext.setFolderIds(folderIds);

--- a/modules/apps/web-experience/trash/.gitrepo
+++ b/modules/apps/web-experience/trash/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e90c7518cbc178f783178ca8ef747a8958216fe4
+	commit = 509f50088f5aa7f804c1cd9e8c75d89ad5b14db7
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b2252128ce4dd451bcbbfe44d72d3385b29c0475
+	parent = 60350c0dc1e2004fa07cdead91b3d2703ee5be71
 	remote = git@github.com:liferay/com-liferay-trash.git


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73925
https://issues.liferay.com/browse/LPP-26392

This is continued from here: https://github.com/liferay/com-liferay-journal/pull/430
I've changed the logic to keep the isHead logic, but added "latest" for isLatestArticle. 

The expected behavior for search in the Web Content Portlet is:
A User can search for latest version of the article if it is Approved, Pending, Draft, Expired, ... but not In-Trash.