### PR TITLE
LPS-74575 Shortcut icon does not display for sites with long names

### DIFF
--- a/modules/apps/web-experience/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
+++ b/modules/apps/web-experience/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
@@ -145,12 +145,12 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 								>
 									<liferay-frontend:vertical-card-header>
 										<h5>
-											<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
+											<aui:a cssClass="selector-button truncate-text" data="<%= data %>" href="javascript:;">
 												<%= HtmlUtil.escape(siteItemSelectorViewDisplayContext.getGroupName(group)) %>
 											</aui:a>
-
-											<aui:a href="<%= groupURLProvider.getGroupURL(group, liferayPortletRequest) %>" target="_blank" />
 										</h5>
+
+										<aui:a href="<%= groupURLProvider.getGroupURL(group, liferayPortletRequest) %>" target="_blank" />
 									</liferay-frontend:vertical-card-header>
 
 									<c:if test="<%= siteItemSelectorViewDisplayContext.isShowChildSitesLink() %>">
@@ -171,12 +171,12 @@ GroupSearch groupSearch = siteItemSelectorViewDisplayContext.getGroupSearch();
 								>
 									<liferay-frontend:vertical-card-header>
 										<h5>
-											<aui:a cssClass="selector-button" data="<%= data %>" href="javascript:;">
+											<aui:a cssClass="selector-button truncate-text" data="<%= data %>" href="javascript:;">
 												<%= HtmlUtil.escape(siteItemSelectorViewDisplayContext.getGroupName(group)) %>
 											</aui:a>
-
-											<aui:a href="<%= groupURLProvider.getGroupURL(group, liferayPortletRequest) %>" target="_blank" />
 										</h5>
+
+										<aui:a href="<%= groupURLProvider.getGroupURL(group, liferayPortletRequest) %>" target="_blank" />
 									</liferay-frontend:vertical-card-header>
 
 									<liferay-frontend:vertical-card-footer>


### PR DESCRIPTION
Hi @ealonso,

Here is a fix for https://issues.liferay.com/browse/LPS-74575.

This is what it looks like currently:

![current](https://user-images.githubusercontent.com/2080476/30134167-0523c18e-930b-11e7-9a4a-0537539a8443.jpeg)

And this is what my proposed fix looks like:

![proposedfix](https://user-images.githubusercontent.com/2080476/30134182-136c54cc-930b-11e7-8d58-2e44bdf1192c.jpeg)

Please let me know if you have any questions.

Thanks!