### PR TITLE
LPS-75073 Simulation panel does not display on IE11 or Edge

### DIFF
--- a/modules/apps/web-experience/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
+++ b/modules/apps/web-experience/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
@@ -1,5 +1,5 @@
 .lfr-simulation-panel {
-	&.open-admin-panel {
+	&.open-admin-panel.sidenav-menu-slider {
 		visibility: visible;
 		width: 320px;
 	}


### PR DESCRIPTION
Hey @ealonso,

This is an update for https://issues.liferay.com/browse/LPS-75073. The bug is closely related to https://issues.liferay.com/browse/LPS-73789, which was merged here: https://github.com/brianchandotcom/liferay-portal/pull/51449

Please let me know if you have any questions.

Thanks!