### PR TITLE
LPS-75108 Moved from encodeURI to encodeURIComponent on FragmentPreview

### DIFF
--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.js
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.js
@@ -91,7 +91,7 @@ class FragmentPreview extends Component {
 	_updatePreview() {
 		this._previewContent =
 			'data:text/html;charset=utf-8,' +
-			encodeURI(`
+			encodeURIComponent(`
 			<!DOCTYPE html>
 			<html>
 			<head>


### PR DESCRIPTION
There are some characters (like the '#') that are not encoded using
encodeURI, and that information was lost on the preview generation.

The preview content is part of a URL, not a URL, so
encodeURIComponent is the correct function.

https://stackoverflow.com/questions/75980/when-are-you-supposed-to-use-escape-instead-of-encodeuri-encodeuricomponent