### PR TITLE
[TECHNICAL-SUPPORT] LPS-75793

### DIFF
--- a/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupFinderTest.java
+++ b/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupFinderTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -255,6 +256,23 @@ public class GroupFinderTest {
 		groups = findByLayouts(childGroup1.getGroupId());
 
 		Assert.assertTrue(groups.isEmpty());
+
+		GroupLocalServiceUtil.updateGroup(
+			parentGroup.getGroupId(), parentGroup.getParentGroupId(),
+			parentGroup.getNameMap(), parentGroup.getDescriptionMap(),
+			parentGroup.getType(), parentGroup.isManualMembership(),
+			parentGroup.getMembershipRestriction(),
+			parentGroup.getFriendlyURL(), parentGroup.isInheritContent(), false,
+			ServiceContextTestUtil.getServiceContext());
+
+		groups = findByLayouts(GroupConstants.DEFAULT_PARENT_GROUP_ID);
+
+		Assert.assertEquals(
+			groups.toString(), initialGroupCount, groups.size());
+
+		groups = findByLayouts(parentGroup.getGroupId());
+
+		Assert.assertEquals(groups.toString(), 2, groups.size());
 	}
 
 	protected static ResourceAction getModelResourceAction()

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -159,7 +159,8 @@
 			WHERE
 				(Group_.companyId = ?) AND
 				(Group_.parentGroupId = ?) AND
-				(Group_.site = ?)
+				(Group_.site = ?) AND
+				(Group_.active_ = [$TRUE$])
 		]]>
 	</sql>
 	<sql id="com.liferay.portal.kernel.service.persistence.GroupFinder.findByLiveGroups">


### PR DESCRIPTION
From @mbowerman 

>With this fix, if you have an inactive site that has an active child site, neither the parent nor child will be displayed. I thought this behavior made more sense than displaying the child site unattached to its parent. Also, the same behavior already exists if you have a site without layouts that has a child site with layouts.

>I thought we should fix it in the GroupFinder, rather than in page.jsp, because the GroupFinder method seems like it is supposed to be used to find sites whose layouts can be visited, so inactive sites should not be returned by it. Everything I could find that called this method seemed like it would benefit from not returning inactive sites.