### PR TITLE
LPS-75444 adding regularURL to layoutsTree's data attributes

### DIFF
--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/panel/app/layouts_tree.jsp
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/panel/app/layouts_tree.jsp
@@ -244,7 +244,7 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 	</c:if>
 
 	<liferay-util:buffer var="linkTemplate">
-		<a class="{cssClass}" data-plid="{plid}" data-url="{url}" data-uuid="{uuid}" href="{regularURL}" id="{id}" title="{label}">{label}</a>
+		<a class="{cssClass}" data-plid="{plid}" data-regularurl="{regularURL}" data-url="{url}" data-uuid="{uuid}" href="{regularURL}" id="{id}" title="{label}">{label}</a>
 
 		<div class="dropdown dropdown-menu-no-arrow layout-tree-options" data-deleteable="{deleteable}" data-parentable="{parentable}" data-updateable="{updateable}">
 			<a aria-expanded="false" class="dropdown-toggle icon-monospaced" data-qa-id="pageOptions" data-toggle="dropdown" href="javascript:;">

--- a/modules/apps/web-experience/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/js/layouts_tree.js
+++ b/modules/apps/web-experience/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/js/layouts_tree.js
@@ -9,7 +9,7 @@ AUI.add(
 
 		var NODE_ID_SELECTOR_TPL = '[id^="{treeId}_{layoutId}"]';
 
-		var NODE_LINK_TPL = '<a class="{cssClass}" data-url="{url}" data-uuid="{uuid}" href="{layoutURL}" id="{id}" title="{title}">{label}</a>';
+		var NODE_LINK_TPL = '<a class="{cssClass}" data-regularurl="{regularURL}" data-url="{url}" data-uuid="{uuid}" href="{layoutURL}" id="{id}" title="{title}">{label}</a>';
 
 		var STR_BOUNDING_BOX = 'boundingBox';
 


### PR DESCRIPTION
Hi @ealonso ,

I thought through your [commet ](https://github.com/brianchandotcom/liferay-portal/pull/52852#issuecomment-343431580) on the previous PR.

I think that using a friendly URL instead of the layoutURL would be better from a user perspective.
Maybe my naming of "fullURL" was a bit confusing. The aim was to create a fully qualifying URL instead of the Layout's "friendlyURL", which is basically just a slash and the Layout's name, not a URL. 

I found, that regularURL property of the Layout JSONObject is the same as the fullURL I wanted to introduce, so I'd only like to add that param to the layout tree's data attributes.

The next step will be to backport the changes to 7.0.x, where this data-regularurl could be processed by JS in the layouts.jsp.

What do you think?

Best Regards,
Balazs