### PR TITLE
LPS-76010

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/display_settings.jsp
@@ -46,7 +46,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 
 <aui:input cssClass="hidden-field show-extra-info" name="preferences--showExtraInfo--" type="toggle-switch" value="<%= assetPublisherDisplayContext.isShowExtraInfo() %>" />
 
-<aui:select cssClass="asset-link-behavior hidden-field" name="preferences--assetLinkBehavior--">
+<aui:select cssClass="asset-link-behavior" name="preferences--assetLinkBehavior--">
 	<aui:option label="show-full-content" selected="<%= assetPublisherDisplayContext.isAssetLinkBehaviorShowFullContent() %>" value="showFullContent" />
 	<aui:option label="view-in-context" selected="<%= assetPublisherDisplayContext.isAssetLinkBehaviorViewInPortlet() %>" value="viewInPortlet" />
 </aui:select>
@@ -90,12 +90,8 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 			showParent('.show-context-link');
 			showParent('.show-extra-info');
 		}
-		else {
-			if (displayStyle == 'abstracts') {
-				showParent('.abstract-length');
-			}
-
-			showParent('.asset-link-behavior');
+		else if (displayStyle == 'abstracts') {
+			showParent('.abstract-length');
 		}
 	}
 

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
@@ -46,6 +46,9 @@ String languageId = LanguageUtil.getLanguageId(request);
 String title = assetRenderer.getTitle(LocaleUtil.fromLanguageId(languageId));
 
 boolean print = ((Boolean)request.getAttribute("view.jsp-print")).booleanValue();
+
+boolean viewInContext = ((Boolean)request.getAttribute("view.jsp-viewInContext")).booleanValue();
+
 boolean workflowEnabled = WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(assetEntry.getCompanyId(), assetEntry.getGroupId(), assetEntry.getClassName());
 
 assetPublisherDisplayContext.setLayoutAssetEntry(assetEntry);
@@ -211,6 +214,7 @@ request.setAttribute("view.jsp-showIconLabel", true);
 			<liferay-asset:asset-links
 				assetEntryId="<%= assetEntry.getEntryId() %>"
 				portletURL="<%= assetLingsURL %>"
+				viewInContext="<%= viewInContext %>"
 			/>
 		</c:if>
 

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -69,6 +69,8 @@ else {
 
 		request.setAttribute("view.jsp-print", Boolean.valueOf(print));
 
+		request.setAttribute("view.jsp-viewInContext", assetPublisherDisplayContext.isAssetLinkBehaviorViewInPortlet());
+
 		PortalUtil.addPortletBreadcrumbEntry(request, title, currentURL);
 		%>
 

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/com/liferay/asset/publisher/web/portlet/template/dependencies/portlet_display_template_rich_summary.ftl
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/com/liferay/asset/publisher/web/portlet/template/dependencies/portlet_display_template_rich_summary.ftl
@@ -193,7 +193,10 @@
 
 <#macro getRelatedAssets>
 	<#if getterUtil.getBoolean(enableRelatedAssets)>
-		<@liferay_ui["asset-links"] assetEntryId=entry.getEntryId() />
+		<@liferay_ui["asset-links"]
+			assetEntryId=entry.getEntryId()
+			viewInContext=!stringUtil.equals(assetLinkBehavior, "showFullContent")
+		/>
 	</#if>
 </#macro>
 

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/com/liferay/asset/publisher/web/portlet/template/dependencies/portlet_display_template_rich_summary.ftl
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/com/liferay/asset/publisher/web/portlet/template/dependencies/portlet_display_template_rich_summary.ftl
@@ -125,7 +125,7 @@
 			<#if stringUtil.equals(fieldName, "author")>
 				<@liferay.language key="by" /> ${htmlUtil.escape(portalUtil.getUserName(assetRenderer.getUserId(), assetRenderer.getUserName()))}
 			<#elseif stringUtil.equals(fieldName, "categories")>
-				<@liferay_ui["asset-categories-summary"]
+				<@liferay_asset["asset-categories-summary"]
 					className=entry.getClassName()
 					classPK=entry.getClassPK()
 					portletURL=renderResponse.createRenderURL()
@@ -141,7 +141,7 @@
 			<#elseif stringUtil.equals(fieldName, "publish-date")>
 				${dateUtil.getDate(entry.getPublishDate(), dateFormat, locale)}
 			<#elseif stringUtil.equals(fieldName, "tags")>
-				<@liferay_ui["asset-tags-summary"]
+				<@liferay_asset["asset-tags-summary"]
 					className=entry.getClassName()
 					classPK=entry.getClassPK()
 					portletURL=renderResponse.createRenderURL()
@@ -193,7 +193,7 @@
 
 <#macro getRelatedAssets>
 	<#if getterUtil.getBoolean(enableRelatedAssets)>
-		<@liferay_ui["asset-links"]
+		<@liferay_asset["asset-links"]
 			assetEntryId=entry.getEntryId()
 			viewInContext=!stringUtil.equals(assetLinkBehavior, "showFullContent")
 		/>

--- a/modules/apps/web-experience/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetLinksTag.java
+++ b/modules/apps/web-experience/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetLinksTag.java
@@ -54,6 +54,10 @@ public class AssetLinksTag extends IncludeTag {
 		return _portletURL;
 	}
 
+	public boolean getViewInContext() {
+		return _viewInContext;
+	}
+
 	public void setAssetEntryId(long assetEntryId) {
 		_assetEntryId = assetEntryId;
 	}
@@ -77,6 +81,10 @@ public class AssetLinksTag extends IncludeTag {
 		_portletURL = portletURL;
 	}
 
+	public void setViewInContext(boolean viewInContext) {
+		_viewInContext = viewInContext;
+	}
+
 	@Override
 	protected void cleanUp() {
 		_assetEntryId = 0;
@@ -84,6 +92,7 @@ public class AssetLinksTag extends IncludeTag {
 		_classPK = 0;
 		_page = _PAGE;
 		_portletURL = null;
+		_viewInContext = true;
 	}
 
 	@Override
@@ -140,6 +149,9 @@ public class AssetLinksTag extends IncludeTag {
 
 		request.setAttribute(
 			"liferay-asset:asset-links:portletURL", _portletURL);
+
+		request.setAttribute(
+			"liferay-asset:asset-links:viewInContext", _viewInContext);
 	}
 
 	private static final String _PAGE = "/asset_links/page.jsp";
@@ -151,5 +163,6 @@ public class AssetLinksTag extends IncludeTag {
 	private long _classPK;
 	private String _page = _PAGE;
 	private PortletURL _portletURL;
+	private boolean _viewInContext = true;
 
 }

--- a/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/liferay-asset.tld
+++ b/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/liferay-asset.tld
@@ -299,6 +299,11 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<name>viewInContext</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 	<tag>
 		<name>asset-metadata</name>

--- a/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
+++ b/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
@@ -20,6 +20,7 @@
 long assetEntryId = GetterUtil.getLong((String)request.getAttribute("liferay-asset:asset-links:assetEntryId"));
 List<AssetLink> assetLinks = (List<AssetLink>)request.getAttribute("liferay-asset:asset-links:assetLinks");
 PortletURL portletURL = (PortletURL)request.getAttribute("liferay-asset:asset-links:portletURL");
+boolean viewInContext = GetterUtil.getBoolean(request.getAttribute("liferay-asset:asset-links:viewInContext"), true);
 %>
 
 <div class="taglib-asset-links">
@@ -94,18 +95,28 @@ PortletURL portletURL = (PortletURL)request.getAttribute("liferay-asset:asset-li
 					viewAssetURL.setParameter("urlTitle", assetRenderer.getUrlTitle());
 				}
 
-				String noSuchEntryRedirect = viewAssetURL.toString();
+				String viewURL = null;
 
-				String urlViewInContext = assetRenderer.getURLViewInContext((LiferayPortletRequest)portletRequest, (LiferayPortletResponse)portletResponse, noSuchEntryRedirect);
+				if (viewInContext) {
+					String noSuchEntryRedirect = viewAssetURL.toString();
 
-				if (Validator.isNotNull(urlViewInContext) && !Objects.equals(urlViewInContext, noSuchEntryRedirect)) {
-					urlViewInContext = HttpUtil.setParameter(urlViewInContext, "inheritRedirect", Boolean.TRUE);
-					urlViewInContext = HttpUtil.setParameter(urlViewInContext, "redirect", currentURL);
+					String urlViewInContext = assetRenderer.getURLViewInContext((LiferayPortletRequest)portletRequest, (LiferayPortletResponse)portletResponse, noSuchEntryRedirect);
+
+					if (Validator.isNotNull(urlViewInContext) && !Objects.equals(urlViewInContext, noSuchEntryRedirect)) {
+						urlViewInContext = HttpUtil.setParameter(urlViewInContext, "inheritRedirect", Boolean.TRUE);
+						urlViewInContext = HttpUtil.setParameter(urlViewInContext, "redirect", currentURL);
+					}
+
+					viewURL = urlViewInContext;
+				}
+
+				if (Validator.isNull(viewURL)) {
+					viewURL = viewAssetURL.toString();
 				}
 		%>
 
 				<li class="asset-links-list-item">
-					<aui:a href="<%= urlViewInContext %>" target='<%= themeDisplay.isStatePopUp() ? "_blank" : "_self" %>'>
+					<aui:a href="<%= viewURL %>" target='<%= themeDisplay.isStatePopUp() ? "_blank" : "_self" %>'>
 						<%= HtmlUtil.escape(assetLinkEntry.getTitle(locale)) %>
 					</aui:a>
 				</li>

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/adt_asset_publisher_rich_summary.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/adt_asset_publisher_rich_summary.ftl
@@ -127,7 +127,7 @@
 			<#if stringUtil.equals(fieldName, "author")>
 				<@liferay.language key="by" /> ${portalUtil.getUserName(assetRenderer.getUserId(), assetRenderer.getUserName())}
 			<#elseif stringUtil.equals(fieldName, "categories")>
-				<@liferay_ui["asset-categories-summary"]
+				<@liferay_asset["asset-categories-summary"]
 					className=entry.getClassName()
 					classPK=entry.getClassPK()
 					portletURL=renderResponse.createRenderURL()
@@ -143,7 +143,7 @@
 			<#elseif stringUtil.equals(fieldName, "publish-date")>
 				${dateUtil.getDate(entry.getPublishDate(), dateFormat, locale)}
 			<#elseif stringUtil.equals(fieldName, "tags")>
-				<@liferay_ui["asset-tags-summary"]
+				<@liferay_asset["asset-tags-summary"]
 					className=entry.getClassName()
 					classPK=entry.getClassPK()
 					portletURL=renderResponse.createRenderURL()
@@ -195,7 +195,10 @@
 
 <#macro getRelatedAssets>
 	<#if getterUtil.getBoolean(enableRelatedAssets)>
-		<@liferay_ui["asset-links"] assetEntryId=entry.getEntryId() />
+		<@liferay_asset["asset-links"]
+			assetEntryId=entry.getEntryId()
+			viewInContext=!stringUtil.equals(assetLinkBehavior, "showFullContent")
+		/>
 	</#if>
 </#macro>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-76010

About https://github.com/ealonso/liferay-portal/pull/1249/commits/5935ee93aa2a281c9f7790939e9497055b611d0c commit, I am changing the taglib because my changes are only applied to liferay-asset and liferay-ui seems to be some kind of compatibility taglib that uses a old version of modules.
If I am missing something about that, please let me know

After my changes, in **resources/asset_links/page.jsp** the code that generates the URLs, is almost identical to a fragment of **AssetPublisherHelperImpl.getAssetViewURL**:
  - https://github.com/jorgediaz-lr/liferay-portal/blob/0535d618cbbbbdbf070092d64756219679afb832/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp#L87-L115
  - https://github.com/jorgediaz-lr/liferay-portal/blob/0535d618cbbbbdbf070092d64756219679afb832/modules/apps/web-experience/asset/asset-publisher-impl/src/main/java/com/liferay/asset/publisher/internal/util/AssetPublisherHelperImpl.java#L529-L574

Perhaps we should move it to a common place, but they belong to different modules. 
What do you think?