### PR TITLE
LPS-76629 Updats loading indicator markup

### DIFF
--- a/modules/apps/web-experience/fragment/fragment-api/src/main/java/com/liferay/fragment/util/FragmentRenderUtil.java
+++ b/modules/apps/web-experience/fragment/fragment-api/src/main/java/com/liferay/fragment/util/FragmentRenderUtil.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.util;
+
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import java.util.Optional;
+
+/**
+ * @author Pablo Molina
+ */
+public class FragmentRenderUtil {
+
+	public static String renderFragment(
+			long fragmentInstanceId, long fragmentEntryId, String css,
+			String html, String js)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(15);
+
+		sb.append("<div class=\"fragment-");
+		sb.append(fragmentEntryId);
+		sb.append("\" id=\"fragment-");
+		sb.append(fragmentEntryId);
+		sb.append("-");
+		sb.append(fragmentInstanceId);
+		sb.append("\">");
+
+		sb.append("<style>");
+		sb.append(css);
+		sb.append("</style>");
+
+		Optional<ServiceContext> serviceContextOptional = Optional.ofNullable(
+			ServiceContextThreadLocal.getServiceContext());
+
+		ServiceContext serviceContext = serviceContextOptional.orElse(
+			new ServiceContext());
+
+		String sanitizedHtml = SanitizerUtil.sanitize(
+			serviceContext.getCompanyId(), serviceContext.getScopeGroupId(),
+			serviceContext.getUserId(), FragmentEntry.class.getName(),
+			fragmentEntryId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, html,
+			null);
+
+		sb.append(sanitizedHtml);
+
+		sb.append("<script>(function(){");
+		sb.append(js);
+		sb.append(";}());</script>");
+
+		sb.append("</div>");
+
+		return sb.toString();
+	}
+
+	public static String renderFragment(
+		long fragmentEntryId, String css, String html,
+		String js) throws PortalException {
+
+		return renderFragment(0, fragmentEntryId, css, html, js);
+	}
+
+}

--- a/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryImpl.java
+++ b/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryImpl.java
@@ -20,7 +20,6 @@ import com.liferay.html.preview.service.HtmlPreviewEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.xml.simple.Element;
 import com.liferay.portal.kernel.zip.ZipWriter;
 

--- a/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryImpl.java
+++ b/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryImpl.java
@@ -14,22 +14,15 @@
 
 package com.liferay.fragment.model.impl;
 
-import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.util.FragmentRenderUtil;
 import com.liferay.html.preview.model.HtmlPreviewEntry;
 import com.liferay.html.preview.service.HtmlPreviewEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.sanitizer.Sanitizer;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.xml.simple.Element;
 import com.liferay.portal.kernel.zip.ZipWriter;
-
-import java.util.Optional;
 
 /**
  * @author Eudaldo Alonso
@@ -38,31 +31,8 @@ public class FragmentEntryImpl extends FragmentEntryBaseImpl {
 
 	@Override
 	public String getContent() throws PortalException {
-		StringBundler sb = new StringBundler(7);
-
-		sb.append("<html><head><style>");
-		sb.append(getCss());
-		sb.append("</style><script>");
-		sb.append(getJs());
-		sb.append("</script></head><body>");
-
-		Optional<ServiceContext> serviceContextOptional = Optional.ofNullable(
-			ServiceContextThreadLocal.getServiceContext());
-
-		ServiceContext serviceContext = serviceContextOptional.orElse(
-			new ServiceContext());
-
-		String html = SanitizerUtil.sanitize(
-			serviceContext.getCompanyId(), serviceContext.getScopeGroupId(),
-			serviceContext.getUserId(), FragmentEntry.class.getName(),
-			getPrimaryKey(), ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
-			getHtml(), null);
-
-		sb.append(html);
-
-		sb.append("</body></html>");
-
-		return sb.toString();
+		return FragmentRenderUtil.renderFragment(
+			getFragmentEntryId(), getCss(), getHtml(), getJs());
 	}
 
 	@Override

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/RenderFragmentEntryMVCActionCommand.java
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/RenderFragmentEntryMVCActionCommand.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.web.internal.portlet.action;
+
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.service.FragmentEntryService;
+import com.liferay.fragment.util.FragmentRenderUtil;
+import com.liferay.fragment.web.internal.handler.FragmentEntryExceptionRequestHandler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.ResourceBundle;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pablo Molina
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + FragmentPortletKeys.FRAGMENT,
+		"mvc.command.name=/fragment/render_fragment_entry"
+	},
+	service = MVCActionCommand.class
+)
+public class RenderFragmentEntryMVCActionCommand extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		long fragmentEntryId = ParamUtil.getLong(
+			actionRequest, "fragmentEntryId");
+
+		String css = ParamUtil.getString(actionRequest, "css");
+		String html = ParamUtil.getString(actionRequest, "html");
+		String js = ParamUtil.getString(actionRequest, "js");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		try {
+			String content = FragmentRenderUtil.renderFragment(
+				fragmentEntryId, css, html, js);
+
+			jsonObject.put("content", content);
+		}
+		catch (PortalException pe) {
+			ServiceContext serviceContext = ServiceContextFactory.getInstance(
+				actionRequest);
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
+			ResourceBundle resourceBundle =
+				_resourceBundleLoader.loadResourceBundle(
+					themeDisplay.getLocale());
+
+			hideDefaultSuccessMessage(actionRequest);
+
+			jsonObject.put(
+				"error",
+				LanguageUtil.get(
+					resourceBundle, "an-unexpected-error-occurred"));
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			actionRequest, actionResponse, jsonObject);
+	}
+
+	@Reference
+	private FragmentEntryExceptionRequestHandler
+		_fragmentEntryExceptionRequestHandler;
+
+	@Reference
+	private FragmentEntryService _fragmentEntryService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference(
+		target = "(bundle.symbolic.name=com.liferay.fragment.web)", unbind = "-"
+	)
+	private ResourceBundleLoader _resourceBundleLoader;
+
+}

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/css/FragmentPreview.scss
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/css/FragmentPreview.scss
@@ -19,13 +19,13 @@
 		background-color: white;
 		border: none;
 		border-top: solid thin #DDD;
-		height: calc(100% - 2.5em);
+		height: calc(100% - 2em);
 		left: 0;
 		margin-top: calc(2em - 1px);
+		overflow: auto;
 		position: absolute;
 		top: 0;
 		width: 100%;
-		z-index: -1;
 
 		&--resized {
 			border-top: none;
@@ -39,6 +39,20 @@
 				width ease 0.2s,
 				height ease 0.3s
 			;
+		}
+
+		&--loading {
+			overflow: hidden;
+		}
+
+		&__loading-indicator {
+			background-color: rgba(255, 255, 255, 0.9);
+			height: 100%;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+			z-index: 1;
 		}
 	}
 

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_entry.jsp
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_entry.jsp
@@ -79,6 +79,10 @@ renderResponse.setTitle(title);
 	</aui:button-row>
 </aui:form>
 
+<portlet:actionURL name="/fragment/render_fragment_entry" var="renderFragmentEntryURL">
+	<portlet:param name="fragmentEntryId" value="<%= String.valueOf(fragmentDisplayContext.getFragmentEntryId()) %>" />
+</portlet:actionURL>
+
 <aui:script require="fragment-web/js/FragmentEditor.es as FragmentEditor, metal-dom/src/all/dom as dom">
 	var cssInput = document.getElementById('<portlet:namespace />cssContent');
 	var htmlInput = document.getElementById('<portlet:namespace />htmlContent');
@@ -98,6 +102,7 @@ renderResponse.setTitle(title);
 			initialHTML: '<%= HtmlUtil.escapeJS(fragmentDisplayContext.getHtmlContent()) %>',
 			initialJS: '<%= HtmlUtil.escapeJS(fragmentDisplayContext.getJsContent()) %>',
 			namespace: '<portlet:namespace />',
+			renderFragmentEntryURL: '<%= renderFragmentEntryURL %>',
 			spritemap: '<%= themeDisplay.getPathThemeImages() %>/lexicon/icons.svg'
 		},
 		wrapper

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEditor.es.js
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEditor.es.js
@@ -105,6 +105,15 @@ FragmentEditor.STATE = {
 	namespace: Config.string().required(),
 
 	/**
+	 * Render fragment entry URL
+	 * @default undefined
+	 * @instance
+	 * @memberOf FragmentEditor
+	 * @type {!string}
+	 */
+	renderFragmentEntryURL: Config.string().required(),
+
+	/**
 	 * Path of the available icons.
 	 * @instance
 	 * @memberOf FragmentEditor

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEditor.soy
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEditor.soy
@@ -7,6 +7,8 @@
 	{@param initialCSS: string}
 	{@param initialHTML: string}
 	{@param initialJS: string}
+	{@param namespace: string}
+	{@param renderFragmentEntryURL: string}
 	{@param spritemap: string}
 	{@param? _css: string}
 	{@param? _handleCSSChanged: any}
@@ -38,6 +40,8 @@
 			{param css: $_css /}
 			{param html: $_html /}
 			{param js: $_js /}
+			{param namespace: $namespace /}
+			{param renderFragmentEntryURL: $renderFragmentEntryURL /}
 			{param spritemap: $spritemap /}
 		{/call}
 	</div>

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.es.js
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.es.js
@@ -65,14 +65,17 @@ class FragmentPreview extends Component {
 	 */
 	rendered() {
 		if (this.refs.preview) {
-			this.refs.preview.querySelectorAll('script').forEach((script) => {
-				const parentNode = script.parentNode;
-				const newScript = document.createElement('script');
+			this.refs.preview.querySelectorAll('script').forEach(
+				(script) => {
+					const parentNode = script.parentNode;
+					const newScript = document.createElement('script');
 
-				newScript.innerHTML = script.innerHTML;
-				parentNode.removeChild(script);
-				parentNode.appendChild(newScript);
-			});
+					newScript.innerHTML = script.innerHTML;
+
+					parentNode.removeChild(script);
+					parentNode.appendChild(newScript);
+				}
+			);
 		}
 	}
 
@@ -120,16 +123,23 @@ class FragmentPreview extends Component {
 			formData.append(`${this.namespace}html`, this.html);
 			formData.append(`${this.namespace}js`, this.js);
 
-			fetch(this.renderFragmentEntryURL, {
-				body: formData,
-				credentials: 'include',
-				method: 'post'
-			})
-				.then(response => response.json())
-				.then(response => {
+			fetch(
+				this.renderFragmentEntryURL,
+				{
+					body: formData,
+					credentials: 'include',
+					method: 'post'
+				}
+			)
+			.then(
+				response => response.json()
+			)
+			.then(
+				response => {
 					this._loading = false;
 					this._previewContent = Soy.toIncDom(response.content);
-				});
+				}
+			);
 		}
 	}
 
@@ -221,6 +231,21 @@ FragmentPreview.STATE = {
 	spritemap: Config.string().required(),
 
 	/**
+	 * Ratio of the preview being rendered.
+	 * This property is modified internally with the ui buttons
+	 * presented to the user, but it can be safely altered externally.
+	 * @default 'full'
+	 * @instance
+	 * @memberOf FragmentPreview
+	 * @protected
+	 * @type {?string}
+	 */
+	_currentPreviewSize: Config.oneOf(PREVIEW_SIZES)
+		.internal()
+		.value(null)
+		.setter('_setPreviewSize'),
+
+	/**
 	 * Flag for checking if the preview content is being loaded
 	 * @default false
 	 * @instance
@@ -243,21 +268,6 @@ FragmentPreview.STATE = {
 	_previewContent: Config.func()
 		.internal()
 		.value(Soy.toIncDom('')),
-
-	/**
-	 * Ratio of the preview being rendered.
-	 * This property is modified internally with the ui buttons
-	 * presented to the user, but it can be safely altered externally.
-	 * @default 'full'
-	 * @instance
-	 * @memberOf FragmentPreview
-	 * @protected
-	 * @type {?string}
-	 */
-	_currentPreviewSize: Config.oneOf(PREVIEW_SIZES)
-		.internal()
-		.value(null)
-		.setter('_setPreviewSize'),
 
 	/**
 	 * List of available sizes

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.soy
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.soy
@@ -7,7 +7,8 @@
 	{@param spritemap: string}
 	{@param? _currentPreviewSize: string}
 	{@param? _handlePreviewSizeButtonClick: any}
-	{@param? _previewContent: string}
+	{@param? _loading: bool}
+	{@param? _previewContent: html}
 	{@param? _previewSizes: list<string>}
 
 	<div class="fragment-preview" ref="wrapper">
@@ -58,19 +59,30 @@
 			</button>
 		</div>
 
-		{let $iframeClasses kind="text"}
+		{let $previewClasses kind="text"}
 			fragment-preview__frame
 			{if $_currentPreviewSize}
 				{sp}fragment-preview__frame--resized
 			{/if}
+			{if $_loading}
+				{sp}fragment-preview__frame--loading
+			{/if}
 		{/let}
 
-		<iframe
-			class="{$iframeClasses}"
+		<div
+			class="{$previewClasses}"
 			ref="preview"
 			sandbox="allow-scripts"
-			src="{$_previewContent}"
 		>
-		</iframe>
+			{if $_loading}
+				<div class="fragment-preview__frame__loading-indicator">
+					<span class="loading-icon loading-icon-dotted">
+						<span class="loading-indicator"></span>
+					</span>
+				</div>
+			{/if}
+
+			{$_previewContent}
+		</div>
 	</div>
 {/template}

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.soy
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.soy
@@ -69,11 +69,7 @@
 			{/if}
 		{/let}
 
-		<div
-			class="{$previewClasses}"
-			ref="preview"
-			sandbox="allow-scripts"
-		>
+		<div class="{$previewClasses}" ref="preview">
 			{if $_loading}
 				<div class="fragment-preview__frame__loading-indicator">
 					<span class="loading-icon loading-icon-dotted">

--- a/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.soy
+++ b/modules/apps/web-experience/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentPreview.soy
@@ -72,9 +72,7 @@
 		<div class="{$previewClasses}" ref="preview">
 			{if $_loading}
 				<div class="fragment-preview__frame__loading-indicator">
-					<span class="loading-icon loading-icon-dotted">
-						<span class="loading-indicator"></span>
-					</span>
+					<span aria-hidden="true" class="loading-animation"></span>
 				</div>
 			{/if}
 

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_entry.jsp
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_entry.jsp
@@ -31,16 +31,16 @@ renderResponse.setTitle(layoutPageTemplateDisplayContext.getLayoutPageTemplateEn
 	<portlet:param name="mvcPath" value="/edit_layout_page_template_entry.jsp" />
 </portlet:actionURL>
 
-<portlet:actionURL name="/layout/fragment_entry" var="fragmentEntryURL" />
+<portlet:actionURL name="/layout/render_fragment_entry" var="renderFragmentEntryURL" />
 
 <%
 Map<String, Object> layoutPageTemplateEditorContext = new HashMap<>();
 
 layoutPageTemplateEditorContext.put("fragments", layoutPageTemplateDisplayContext.getFragmentEntryInstanceLinksJSONArray());
 layoutPageTemplateEditorContext.put("fragmentCollections", layoutPageTemplateDisplayContext.getFragmentCollectionsJSONArray());
-layoutPageTemplateEditorContext.put("fragmentEntryURL", fragmentEntryURL);
 layoutPageTemplateEditorContext.put("layoutPageTemplateEntryId", layoutPageTemplateDisplayContext.getLayoutPageTemplateEntryId());
 layoutPageTemplateEditorContext.put("portletNamespace", renderResponse.getNamespace());
+layoutPageTemplateEditorContext.put("renderFragmentEntryURL", renderFragmentEntryURL);
 layoutPageTemplateEditorContext.put("spritemap", themeDisplay.getPathThemeImages() + "/lexicon/icons.svg");
 layoutPageTemplateEditorContext.put("updatePageTemplateURL", String.valueOf(editLayoutPageTemplateFragmentsURL));
 %>

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/Layout.es.js
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/Layout.es.js
@@ -19,30 +19,34 @@ class Layout extends Component {
 	attached() {
 		const A = new AUI();
 
-		A.use('liferay-search-container', 'liferay-search-container-select', A => {
-			const plugins = [];
+		A.use(
+			'liferay-search-container',
+			'liferay-search-container-select',
+			A => {
+				const plugins = [];
 
-			plugins.push({
-				cfg: {
-					rowSelector: '.layout-column',
-				},
-				fn: A.Plugin.SearchContainerSelect,
-			});
+				plugins.push({
+					cfg: {
+						rowSelector: '.layout-column',
+					},
+					fn: A.Plugin.SearchContainerSelect,
+				});
 
-			const searchContainer = new Liferay.SearchContainer({
-				contentBox: A.one(this.refs.layout),
-				id:
-					this.getInitialConfig().portletNamespace +
-					this.getInitialConfig().searchContainerId,
-				plugins: plugins,
-			});
+				const searchContainer = new Liferay.SearchContainer({
+					contentBox: A.one(this.refs.layout),
+					id:
+						this.getInitialConfig().portletNamespace +
+						this.getInitialConfig().searchContainerId,
+					plugins: plugins,
+				});
 
-			this.searchContainer_ = searchContainer;
+				this.searchContainer_ = searchContainer;
 
-			Liferay.fire('search-container:registered', {
-				searchContainer: searchContainer,
-			});
-		});
+				Liferay.fire('search-container:registered', {
+					searchContainer: searchContainer,
+				});
+			}
+		);
 	}
 
 	/**
@@ -50,8 +54,7 @@ class Layout extends Component {
 	 */
 	rendered() {
 		requestAnimationFrame(() => {
-			this.refs.layoutColumns.scrollLeft =
-				this.refs.layoutColumns.scrollWidth;
+			this.refs.layoutColumns.scrollLeft = this.refs.layoutColumns.scrollWidth;
 		});
 	}
 }

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutColumn.es.js
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutColumn.es.js
@@ -8,7 +8,6 @@ import templates from './LayoutColumn.soy';
  * LayoutColumn
  */
 class LayoutColumn extends Component {
-
 	/**
 	 * Handle permission item click in order to open the target href
 	 * in a dialog.
@@ -18,12 +17,12 @@ class LayoutColumn extends Component {
 	_handlePermissionLinkClick(event) {
 		Liferay.Util.openInDialog(event, {
 			dialog: {
-				destroyOnHide: true
+				destroyOnHide: true,
 			},
 			dialogIframe: {
-				bodyCssClass: 'dialog-with-footer'
+				bodyCssClass: 'dialog-with-footer',
 			},
-			uri: event.delegateTarget.href
+			uri: event.delegateTarget.href,
 		});
 	}
 
@@ -34,9 +33,11 @@ class LayoutColumn extends Component {
 	 * @private
 	 */
 	_handleDeleteItemClick(event) {
-		if (!confirm(Liferay.Language.get(
-			'are-you-sure-you-want-to-delete-this'
-		))) {
+		if (
+			!confirm(
+				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
+			)
+		) {
 			event.preventDefault();
 		}
 	}

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEditor.es.js
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEditor.es.js
@@ -168,19 +168,10 @@ LayoutPageTemplateEditor.STATE = {
 	).value([]),
 
 	/**
-	 * URL for getting a fragment entry information.
-	 * @default undefined
-	 * @instance
-	 * @memberOf LayoutPageTemplateEditor
-	 * @type {!string}
-	 */
-	fragmentEntryURL: Config.string().required(),
-
-	/**
 	 * Layout page template entry id used for storing changes.
 	 * @default undefined
 	 * @instance
-	 * @memberOf PageTemplateEditor
+	 * @memberOf LayoutPageTemplateEditor
 	 * @type {!string}
 	 */
 	layoutPageTemplateEntryId: Config.string().required(),
@@ -193,6 +184,15 @@ LayoutPageTemplateEditor.STATE = {
 	 * @type {!string}
 	 */
 	portletNamespace: Config.string().required(),
+
+	/**
+	 * URL for getting a fragment content.
+	 * @default undefined
+	 * @instance
+	 * @memberOf LayoutPageTemplateEditor
+	 * @type {!string}
+	 */
+	renderFragmentEntryURL: Config.string().required(),
 
 	/**
 	 * Path of the available icons.
@@ -226,7 +226,7 @@ LayoutPageTemplateEditor.STATE = {
 	 * When true, it indicates that are changes pending to save.
 	 * @default false
 	 * @instance
-	 * @memberOf PageTemplateEditor
+	 * @memberOf LayoutPageTemplateEditor
 	 * @private
 	 * @type {bool}
 	 */
@@ -238,7 +238,7 @@ LayoutPageTemplateEditor.STATE = {
 	 * Last data when the autosave has been executed.
 	 * @default ''
 	 * @instance
-	 * @memberOf PageTemplateEditor
+	 * @memberOf LayoutPageTemplateEditor
 	 * @private
 	 * @type {string}
 	 */

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEditor.es.js
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEditor.es.js
@@ -220,7 +220,9 @@ LayoutPageTemplateEditor.STATE = {
 	 * @private
 	 * @type {boolean}
 	 */
-	_contextualSidebarVisible: Config.bool().internal().value(true),
+	_contextualSidebarVisible: Config.bool()
+		.internal()
+		.value(true),
 
 	/**
 	 * When true, it indicates that are changes pending to save.

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEditor.soy
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEditor.soy
@@ -5,8 +5,8 @@
  */
 {template .render}
 	{@param fragmentCollections: list<?>}
-	{@param fragmentEntryURL: string}
 	{@param portletNamespace: string}
+	{@param renderFragmentEntryURL: string}
 	{@param spritemap: string}
 	{@param? _contextualSidebarVisible: bool}
 	{@param? _dirty: bool}
@@ -54,10 +54,10 @@
 								{call LayoutPageTemplateFragment.render}
 									{param events: ['fragmentRemoveButtonClick': $_handleFragmentRemoveButtonClick] /}
 									{param fragmentEntryId: $fragment.fragmentEntryId /}
-									{param fragmentEntryURL: $fragmentEntryURL /}
 									{param index: index($fragment) /}
 									{param name: $fragment.name /}
 									{param portletNamespace: $portletNamespace /}
+									{param renderFragmentEntryURL: $renderFragmentEntryURL /}
 									{param spritemap: $spritemap /}
 								{/call}
 							</div>

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateFragment.es.js
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateFragment.es.js
@@ -22,7 +22,7 @@ class LayoutPageTemplateFragment extends Component {
 	 */
 	rendered() {
 		if (this.refs.content) {
-			this.refs.content.querySelectorAll('script').forEach((script) => {
+			this.refs.content.querySelectorAll('script').forEach(script => {
 				const parentNode = script.parentNode;
 				const newScript = document.createElement('script');
 
@@ -163,7 +163,9 @@ LayoutPageTemplateFragment.STATE = {
 	 * @private
 	 * @type {function}
 	 */
-	_content: Config.func().internal().value(Soy.toIncDom('')),
+	_content: Config.func()
+		.internal()
+		.value(Soy.toIncDom('')),
 
 	/**
 	 * Flag indicating that fragment information is being loaded
@@ -173,7 +175,7 @@ LayoutPageTemplateFragment.STATE = {
 	 * @private
 	 * @type {boolean}
 	 */
-	_loading: Config.bool().value(false)
+	_loading: Config.bool().value(false),
 };
 
 Soy.register(LayoutPageTemplateFragment, templates);

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateFragment.soy
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateFragment.soy
@@ -7,7 +7,7 @@
 	{@param name: string}
 	{@param spritemap: string}
 	{@param? _handleFragmentRemoveButtonClick: any}
-	{@param? _html: html}
+	{@param? _content: html}
 	{@param? _loading: bool}
 
 	<div class="layout-page-template-fragment-wrapper">
@@ -29,14 +29,10 @@
 
 		{if $_loading}
 			<div class="loading-icon linear loading-icon-lg"></div>
-		{else}
-			<style ref="style"></style>
-
-			<div>
-				{$_html ?: ''}
+		{elseif $_content}
+			<div ref="content">
+				{$_content}
 			</div>
-
-			<script ref="script"></script>
 		{/if}
 	</div>
 {/template}

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/contextual_sidebar/ContextualSidebar.es.js
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/resources/js/contextual_sidebar/ContextualSidebar.es.js
@@ -21,7 +21,10 @@ class ContextualSidebar extends Component {
 
 		this._handleOpenProductMenu = this._handleOpenProductMenu.bind(this);
 
-		this._productMenu.on('openStart.lexicon.sidenav', this._handleOpenProductMenu);
+		this._productMenu.on(
+			'openStart.lexicon.sidenav',
+			this._handleOpenProductMenu
+		);
 	}
 
 	/**
@@ -31,7 +34,10 @@ class ContextualSidebar extends Component {
 	disposed() {
 		document.body.classList.remove('has-contextual-sidebar');
 
-		this._productMenu.off('openStart.lexicon.sidenav', this._handleOpenProductMenu);
+		this._productMenu.off(
+			'openStart.lexicon.sidenav',
+			this._handleOpenProductMenu
+		);
 	}
 
 	/**
@@ -39,8 +45,7 @@ class ContextualSidebar extends Component {
 	 * @inheritDoc
 	 * @review
 	 */
-	syncVisible() {
-	}
+	syncVisible() {}
 
 	/**
 	 * @inheritDoc
@@ -51,7 +56,8 @@ class ContextualSidebar extends Component {
 			document.body.classList.add('contextual-sidebar-visible');
 
 			this._productMenuToggle.sideNavigation('hide');
-		} else {
+		}
+		else {
 			document.body.classList.remove('contextual-sidebar-visible');
 		}
 	}

--- a/modules/apps/web-experience/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/init.jsp
@@ -15,10 +15,10 @@
 --%>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.fragment.model.FragmentEntryInstanceLink" %><%@
+page import="com.liferay.fragment.util.FragmentRenderUtil" %><%@
 page import="com.liferay.layout.page.template.model.LayoutPageTemplateCollection" %><%@
 page import="com.liferay.layout.page.template.model.LayoutPageTemplateEntry" %><%@
 page import="com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalServiceUtil" %><%@
@@ -29,7 +29,6 @@ page import="com.liferay.portal.kernel.dao.orm.QueryUtil" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>
 
 <%@ page import="java.util.List" %>

--- a/modules/apps/web-experience/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/view/content.jsp
+++ b/modules/apps/web-experience/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/view/content.jsp
@@ -17,30 +17,16 @@
 <%@ include file="/layout/view/init.jsp" %>
 
 <%
-String randomNamespace = PortalUtil.generateRandomKey(request, "layout_type_controller_content_page") + StringPool.UNDERLINE;
-
 for (FragmentEntryInstanceLink fragmentEntryInstanceLink : fragmentEntryInstanceLinks) {
-	String fragmentEntryInstanceLinkNamespace = randomNamespace + fragmentEntryInstanceLink.getPosition();
 %>
 
-	<liferay-util:html-top outputKey="<%= fragmentEntryInstanceLinkNamespace %>">
-		<style type="text/css">
-			<%= fragmentEntryInstanceLink.getCss() %>
-		</style>
-	</liferay-util:html-top>
+	<%= FragmentRenderUtil.renderFragment(
+		fragmentEntryInstanceLink.getPosition(),
+		fragmentEntryInstanceLink.getFragmentEntryId(),
+		fragmentEntryInstanceLink.getCss(),
+		fragmentEntryInstanceLink.getHtml(),
+		fragmentEntryInstanceLink.getJs()) %>
 
-	<div id="<%= fragmentEntryInstanceLinkNamespace %>">
-		<%= fragmentEntryInstanceLink.getHtml() %>
-	</div>
-
-	<aui:script>
-		(function() {
-		var fragment = document.getElementById("<%= fragmentEntryInstanceLinkNamespace %>");
-
-		<%= fragmentEntryInstanceLink.getJs() %>
-		}());
-	</aui:script>
-
-<%
+	<%
 }
-%>
+	%>


### PR DESCRIPTION
@p2kmgcl, @ealonso, no estoy del todo seguro de qué cambios se deberían ver con esta PR, pero tanto fragments como page templates parecen seguir funcionando bien después de los cambios, así que deduzco que al menos no se rompe nada.

Igual que en https://github.com/ealonso/liferay-portal/pull/1391, hay un commit de SF general en `layout-admin-web` que podemos descartar para hacer más tarde. 

El cambio más importante es el marcado del icono de loading, que cambió en la última versión de Clay para poder adaptarse al existente en el Portal.

La última cosa, que no he cambiado en esta PR ni en la anterior es el uso de BEM para el CSS. Creo que esto lo hablamos @p2kmgcl y yo hace algún tiempo y aunque no lo recuerdo bien, es posible que dijéramos que podíamos usarlo en este proyecto. Viendo las PRs, me surgen algunas dudas con eso ya que es el único sitio donde lo usamos, y puede acabar dándonos problemas con el resto de CSS que tenemos alrededor, así que creo que deberíamos intentar cambiarlo a SASS normal. Si os parece el lunes lo hablamos y Marcos podría ayudarnos a actualizar lo que hay si acordamos hacerlo. No hay necesidad de cambiarlo para esta PR