### PR TITLE
LPS-77901 JournalServiceVerifyProcess.verifyURLTitle() logic should only be executed in 6.1 to 6.2 upgrade

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
@@ -816,7 +816,7 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 							normalizeWithPeriodsAndSlashes(urlTitle);
 
 					if (urlTitle.equals(normalizedURLTitle)) {
-						return;
+						continue;
 					}
 
 					normalizedURLTitle = _getUniqueUrlTitle(

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
@@ -799,6 +799,8 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 					"JournalArticle");
 			ResultSet rs = ps1.executeQuery()) {
 
+			Map<String, String> normalizedURLTitleCache = new HashMap<>();
+
 			try (PreparedStatement ps2 =
 					AutoBatchPreparedStatementUtil.autoBatch(
 						connection.prepareStatement(
@@ -820,7 +822,8 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 					}
 
 					normalizedURLTitle = _getUniqueUrlTitle(
-						groupId, articleId, normalizedURLTitle);
+						groupId, articleId, normalizedURLTitle,
+						normalizedURLTitleCache);
 
 					ps2.setString(1, normalizedURLTitle);
 
@@ -835,11 +838,21 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 	}
 
 	private String _getUniqueUrlTitle(
-			long groupId, String articleId, String urlTitle)
+			long groupId, String articleId, String urlTitle,
+			Map<String, String> normalizedURLTitleCache)
 		throws Exception {
 
 		for (int i = 1;; i++) {
-			if (_isValidUrlTitle(groupId, articleId, urlTitle)) {
+			String key = groupId + "_" + urlTitle;
+
+			String articleIdCache = normalizedURLTitleCache.get(key);
+
+			if (((articleIdCache == null) ||
+				 articleIdCache.equals(articleId)) &&
+				_isValidUrlTitle(groupId, articleId, urlTitle)) {
+
+				normalizedURLTitleCache.put(key, articleId);
+
 				return urlTitle;
 			}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.upgrade.BaseUpgradePortletPreferences;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
@@ -212,6 +213,7 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 		updateStructures();
 		updateTemplates();
+		upgradeURLTitle();
 
 		updateAssetEntryClassTypeId();
 
@@ -788,6 +790,49 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 		}
 
 		return PortletPreferencesFactoryUtil.toXML(preferences);
+	}
+
+	protected void upgradeURLTitle() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement ps1 = connection.prepareStatement(
+				"select distinct groupId, articleId, urlTitle from " +
+					"JournalArticle");
+			ResultSet rs = ps1.executeQuery()) {
+
+			try (PreparedStatement ps2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection.prepareStatement(
+							"update JournalArticle set urlTitle = ? where " +
+								"urlTitle = ?"))) {
+
+				while (rs.next()) {
+					long groupId = rs.getLong("groupId");
+					String articleId = rs.getString("articleId");
+					String urlTitle = GetterUtil.getString(
+						rs.getString("urlTitle"));
+
+					String normalizedURLTitle =
+						FriendlyURLNormalizerUtil.
+							normalizeWithPeriodsAndSlashes(urlTitle);
+
+					if (urlTitle.equals(normalizedURLTitle)) {
+						return;
+					}
+
+					normalizedURLTitle =
+						_journalArticleLocalService.getUniqueUrlTitle(
+							groupId, articleId, normalizedURLTitle);
+
+					ps2.setString(1, normalizedURLTitle);
+
+					ps2.setString(2, urlTitle);
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+		}
 	}
 
 	private static final int _DDM_STRUCTURE_TYPE_DEFAULT = 0;


### PR DESCRIPTION
Hi @ealonso,

We have a question regarding this. Do we need to normalize URL title in 7.1? If we allow all kind of UNICODE chars in 7.1 maybe we can even remove the upgrade process. What do you think?

Thanks.
cc/@jorgediaz-lr