### PR TITLE
LPS-79309

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -98,9 +98,19 @@ public class I18nServlet extends HttpServlet {
 			if ((i18nData == null) ||
 				!PortalUtil.isValidResourceId(i18nData.getPath())) {
 
-				PortalUtil.sendError(
-					HttpServletResponse.SC_NOT_FOUND,
-					new NoSuchLayoutException(), request, response);
+				if (PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE) {
+					StringBuilder redirect = new StringBuilder(2);
+
+					redirect.append(PortalUtil.getPortalURL(request));
+					redirect.append(request.getPathInfo());
+
+					response.sendRedirect(redirect.toString());
+				}
+				else {
+					PortalUtil.sendError(
+						HttpServletResponse.SC_NOT_FOUND,
+						new NoSuchLayoutException(), request, response);
+				}
 			}
 			else {
 				request.setAttribute(


### PR DESCRIPTION
CC @jonathanmccann

https://issues.liferay.com/browse/LPS-79309

Resent so I don't break any tests, but the functionality is the same.

My solution to ensure the URL was correct as well as many of the params in the request is to redirect to the default locale's version of the page. For example, the following URL would go from this:
http://localhost:8080/badLocale/web/guest/home
to this:
http://localhost:8080/web/guest/home
Then the I18nServlet can figure out the default locale to serve as it normally would when excluding the locale code.

If I based my solution around not redirecting, but rather placing the default locale where needed, the URL wouldn't change (although the page would be the correct locale). But in my opinion, the real problem with this is sometimes the servlet wouldn't know what's a locale and what's the URL path, so i'd get path infos like this:
web/guest/badLocale/web/differentSite
and I'm not sure how to resolve that without tinkering with the request in a hacky way.

Let me know if you have any ideas for a better solution, or if you have other questions. Thanks!