### PR TITLE
LPS-80132 buildLang

### DIFF
--- a/modules/apps/asset/asset-taglib/build.gradle
+++ b/modules/apps/asset/asset-taglib/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/init.jsp
@@ -14,6 +14,8 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
@@ -24,7 +26,9 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.asset.kernel.model.AssetEntry" %><%@
 page import="com.liferay.asset.taglib.internal.display.context.InputAssetLinksDisplayContext" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
-page import="com.liferay.portal.kernel.util.UnicodeFormatter" %>
+page import="com.liferay.portal.kernel.util.UnicodeFormatter" %><%@
+page import="com.liferay.staging.StagingGroupHelper" %><%@
+page import="com.liferay.staging.StagingGroupHelperUtil" %>
 
 <%@ page import="java.util.Map" %>
 
@@ -32,4 +36,6 @@ page import="com.liferay.portal.kernel.util.UnicodeFormatter" %>
 
 <%
 InputAssetLinksDisplayContext inputAssetLinksDisplayContext = new InputAssetLinksDisplayContext(pageContext);
+
+StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHelper();
 %>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
@@ -73,6 +73,12 @@
 	/>
 </liferay-ui:search-container>
 
+<c:if test="<%= stagingGroupHelper.isLiveGroup(themeDisplay.getScopeGroupId()) %>">
+	<div>
+		<liferay-ui:message key="related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site" />
+	</div>
+</c:if>
+
 <liferay-ui:icon-menu
 	cssClass="select-existing-selector"
 	direction="right"

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site.

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ar.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_bg.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ca.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_cs.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_da.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_da.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_de.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_de.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_el.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_el.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_en.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_en.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site.

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_es.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_es.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_et.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_et.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_eu.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_fa.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_fi.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_fr.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_gl.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_hi_IN.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_hr.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_hu.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_in.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_in.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_it.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_it.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_iw.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ja.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ko.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_lo.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_lt.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_nb.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_nl.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_nl_BE.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_pl.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_pt_BR.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_pt_PT.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ro.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_ru.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sk.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sl.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sr_RS.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_sv.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_th.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_th.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_tr.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_uk.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_vi.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_zh_CN.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)

--- a/modules/apps/asset/asset-taglib/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/asset/asset-taglib/src/main/resources/content/Language_zh_TW.properties
@@ -1,0 +1,1 @@
+related-assets-for-staged-asset-types-can-be-managed-on-the-staging-site=Related assets for staged asset types can be managed on the staging site. (Automatic Copy)


### PR DESCRIPTION
Hey @ealonso this is a customer issue.

It's quite complicated but the main problem here is the following:
1) if staging is turned on for an asset (ie.: web content)
2) and turned off for a different asset (ie.: bookmarks)
3) it does matter if you are linking them together from bookmarks or web content. 
4) if you are linking them from bookmarks, it means the link will be created in live (wc's asset group id will be live)
5) if you are linking from web content it mean the link will be created in stage (wc's asset group id will be stage)

This is the basic problem. A support solution provided a fix but caused other regressions, so I think the best approach in this case is:
1) if one end of the relationship is staged, we should only allow linking from there. 
2) if both staged, it's allowed from both end
3) if both live, it's allowed from both end

The solution itself is simple. please let me know what do you think.