### PR TITLE
LPS-82963 User will not see translated DDM field labels or tips when changing site language. Use the implicit 'locale' variable instead

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/edit_record.jsp
@@ -186,7 +186,7 @@ else {
 							classPK="<%= classPK %>"
 							ddmFormValues="<%= ddmFormValues %>"
 							repeatable="<%= translating ? false : true %>"
-							requestedLocale="<%= LocaleUtil.fromLanguageId(languageId) %>"
+							requestedLocale="<%= locale %>"
 						/>
 					</c:when>
 					<c:otherwise>
@@ -197,7 +197,7 @@ else {
 									classPK="<%= classPK %>"
 									ddmFormValues="<%= ddmFormValues %>"
 									repeatable="<%= translating ? false : true %>"
-									requestedLocale="<%= LocaleUtil.fromLanguageId(languageId) %>"
+									requestedLocale="<%= locale %>"
 								/>
 							</aui:fieldset>
 						</aui:fieldset-group>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/content.jsp
@@ -151,7 +151,7 @@ if (!searchRestriction) {
 			classPK="<%= ddmStructure.getStructureId() %>"
 			ddmFormValues="<%= journalDisplayContext.getDDMFormValues(ddmStructure) %>"
 			ignoreRequestValue="<%= changeStructure %>"
-			requestedLocale="<%= LocaleUtil.fromLanguageId(defaultLanguageId) %>"
+			requestedLocale="<%= locale %>"
 		/>
 	</div>
 


### PR DESCRIPTION
Hi @ealonso , how is it going?

Can you take a look on this change we've made to Journal Web? 

If you are good with it, please, forward to BChan.

Thanks a lot! :)