### PR TITLE
LPS-85472

### DIFF
--- a/modules/apps/headless-apio/structured-content/structured-content-apio-impl/src/main/java/com/liferay/structured/content/apio/internal/architect/filter/BaseSingleEntitySchemaBasedEdmProvider.java
+++ b/modules/apps/headless-apio/structured-content/structured-content-apio-impl/src/main/java/com/liferay/structured/content/apio/internal/architect/filter/BaseSingleEntitySchemaBasedEdmProvider.java
@@ -133,7 +133,7 @@ public abstract class BaseSingleEntitySchemaBasedEdmProvider
 				EdmPrimitiveTypeKind.Date.getFullQualifiedName();
 		}
 		else if (Objects.equals(
-					entityField.getType(), EntityField.Type.STRING)) {
+					 entityField.getType(), EntityField.Type.STRING)) {
 
 			fullQualifiedName =
 				EdmPrimitiveTypeKind.String.getFullQualifiedName();

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PredicateFilter;
+import com.liferay.portal.kernel.util.PrefsParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -197,6 +198,18 @@ public class JournalContentDisplayContext {
 		ThemeDisplay themeDisplay = (ThemeDisplay)_portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		String ddmTemplateKey = PrefsParamUtil.getString(
+			_portletRequest.getPreferences(), _portletRequest,
+			"ddmTemplateKey");
+
+		if (Validator.isNull(ddmTemplateKey)) {
+			ddmTemplateKey = article.getDDMTemplateKey();
+		}
+
+		String viewMode = ParamUtil.getString(
+			_portletRequest, "viewMode", null);
+		int page = ParamUtil.getInteger(_portletRequest, "page", 1);
+
 		if (article.isApproved()) {
 			JournalContent journalContent =
 				(JournalContent)_portletRequest.getAttribute(
@@ -208,15 +221,17 @@ public class JournalContentDisplayContext {
 
 			_articleDisplay = journalContent.getDisplay(
 				article.getGroupId(), article.getArticleId(),
-				article.getVersion(), null, null, themeDisplay.getLanguageId(),
-				1, new PortletRequestModel(_portletRequest, _portletResponse),
+				article.getVersion(), ddmTemplateKey, viewMode,
+				themeDisplay.getLanguageId(), page,
+				new PortletRequestModel(_portletRequest, _portletResponse),
 				themeDisplay);
 		}
 		else {
 			try {
 				_articleDisplay =
 					JournalArticleLocalServiceUtil.getArticleDisplay(
-						article, null, null, themeDisplay.getLanguageId(), 1,
+						article, ddmTemplateKey, viewMode,
+						themeDisplay.getLanguageId(), page,
 						new PortletRequestModel(
 							_portletRequest, _portletResponse),
 						themeDisplay);


### PR DESCRIPTION
@ealonso,

I wasn't sure about https://github.com/ealonso/liferay-portal/compare/master...jonathanmccann:LPS-85472?expand=1#diff-bca2f6bb6ea8efb46878d26b70105e96R201 since I do not know if the template set in the configuration of the Web Content Display widget will ever be different from the template set on the article itself.

If they will never be different, we can remove this block and make the same change here https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/JournalContentPortlet.java#L113-L114

If there is a reason we need to pass in `null` and `1` for the parameters here, please let me know and I will investigate a different solution.

Thanks.