### PR TITLE
LPS-85695 Adding default value for ddmTemplateKey parameter if defaul…

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_resources.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_resources.jsp
@@ -20,9 +20,16 @@
 String refererPortletName = ParamUtil.getString(request, "refererPortletName");
 
 JournalArticle article = journalContentDisplayContext.getArticle();
+
+
+String ddmTemplateKey = "";
+
+if (!journalContentDisplayContext.isDefaultTemplate()) {
+	ddmTemplateKey = journalContentDisplayContext.getDDMTemplateKey();
+}
 %>
 
-<aui:input id='<%= refererPortletName + "ddmTemplateKey" %>' name='<%= refererPortletName + "preferences--ddmTemplateKey--" %>' type="hidden" useNamespace="<%= false %>" value="<%= journalContentDisplayContext.getDDMTemplateKey() %>" />
+<aui:input id='<%= refererPortletName + "ddmTemplateKey" %>' name='<%= refererPortletName + "preferences--ddmTemplateKey--" %>' type="hidden" useNamespace="<%= false %>" value="<%= ddmTemplateKey %>" />
 
 <div class="sheet-section">
 	<div class="sheet-subtitle">


### PR DESCRIPTION
…t template is used

Hi @ealonso ,
The journalContentDisplayContext.getDDMTemplateKey() call would always result in a non "" value, so an unmodified form would always have the journal article's default ddmTemplateKey set and would change the radio options from default to custom.

Another option would have been to rework how getDDMTemplateKey() works, but I felt that change could have caused more problems.

Thanks,