### PR TITLE
LPS-85996 Use all ancestor groups to validate asset vocabularies

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/validator/CardinalityAssetEntryValidator.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/validator/CardinalityAssetEntryValidator.java
@@ -25,10 +25,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.util.List;
@@ -52,22 +49,8 @@ public class CardinalityAssetEntryValidator implements AssetEntryValidator {
 		throws PortalException {
 
 		List<AssetVocabulary> assetVocabularies =
-			_assetVocabularyLocalService.getGroupVocabularies(groupId, false);
-
-		Group group = _groupLocalService.getGroup(groupId);
-
-		if (!group.isCompany()) {
-			Group companyGroup = _groupLocalService.fetchCompanyGroup(
-				group.getCompanyId());
-
-			if (companyGroup != null) {
-				assetVocabularies = ListUtil.copy(assetVocabularies);
-
-				assetVocabularies.addAll(
-					_assetVocabularyLocalService.getGroupVocabularies(
-						companyGroup.getGroupId()));
-			}
-		}
+			_assetVocabularyLocalService.getGroupsVocabularies(
+				_portal.getCurrentAndAncestorSiteGroupIds(groupId));
 
 		long classNameId = _classNameLocalService.getClassNameId(className);
 
@@ -147,11 +130,6 @@ public class CardinalityAssetEntryValidator implements AssetEntryValidator {
 		_classNameLocalService = classNameLocalService;
 	}
 
-	@Reference(unbind = "-")
-	protected void setGroupLocalService(GroupLocalService groupLocalService) {
-		_groupLocalService = groupLocalService;
-	}
-
 	protected void validate(
 			long classNameId, long classTypePK, final long[] categoryIds,
 			AssetVocabulary assetVocabulary)
@@ -183,7 +161,6 @@ public class CardinalityAssetEntryValidator implements AssetEntryValidator {
 
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
 	private ClassNameLocalService _classNameLocalService;
-	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
Hi @ealonso ,

In the original code, the validation only ran for the vocabularies of the current and the Global groups (and no parent groups between them in the hierarchy).

For this fix, I used the same method to load all relevant AssetVocabularies as in: https://github.com/liferay/liferay-portal/blob/65059440dfaf2b8b365a20f99e83e4cdb15478aa/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java#L234

Please review my changes.

Thanks,
Vendel