### PR TITLE
[TECHNICAL SUPPORT] LPS-86744 Fix relative menu level calculation on navigation portlet

### DIFF
--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
@@ -108,9 +108,23 @@ public class NavItemUtil {
 		}
 		else if (rootLayoutType.equals("relative")) {
 			if ((rootLayoutLevel >= 0) &&
-				(rootLayoutLevel < branchNavItems.size())) {
+				(rootLayoutLevel <= (branchNavItems.size() + 1))) {
 
-				rootNavItem = branchNavItems.get(rootLayoutLevel);
+				int absoluteLevel = _getAbsoluteLevel(
+					rootLayoutLevel, branchNavItems, themeDisplay);
+
+				if (absoluteLevel == 0) {
+					navItems = NavItem.fromLayouts(request, themeDisplay, null);
+				}
+				else if ((absoluteLevel > 0) &&
+						 (absoluteLevel <= branchNavItems.size())) {
+
+					rootNavItem = branchNavItems.get(absoluteLevel - 1);
+				}
+				else if (absoluteLevel == (branchNavItems.size() + 1)) {
+					rootNavItem = new NavItem(
+						request, themeDisplay, themeDisplay.getLayout(), null);
+				}
 			}
 		}
 		else if (rootLayoutType.equals("select")) {
@@ -162,6 +176,21 @@ public class NavItemUtil {
 
 		_siteNavigationMenuItemTypeRegistry =
 			siteNavigationMenuItemTypeRegistry;
+	}
+
+	private static int _getAbsoluteLevel(
+		int rootLayoutLevel, List<NavItem> branchNavItems,
+		ThemeDisplay themeDisplay) {
+
+		int absoluteLevel = branchNavItems.size() - (rootLayoutLevel - 1);
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isFirstParent()) {
+			absoluteLevel -= 1;
+		}
+
+		return absoluteLevel;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(NavItemUtil.class);


### PR DESCRIPTION
Hi @ealonso ,

The relative menu item level calculation did not work correctly. When relative level is configured in the navigation portlet, then the value needs to be subtracted (going upwards in the hierarchy).

Based on LPS-82709:
* Relative level 0: show the child Layouts of the current Layout (if none, then display nothing)
* Relative level 1: show the siblings of the current Layout.
* Relative level 2: show the siblings of the parent Layout.
* Etc.
* When it goes above the top level, display nothing

The  `_getAbsoluteLevel()` method calculates the absolute level from the relative.

The list `branchNavItems` contains the "path" from the top to the parent of current node, although when it's one level below the top, it contains the same elements as on the top level. That's why `_getAbsoluteLevel()` method subtracts 1, when the portlet is placed on a Layout on the top level.

When relative level = 0, then it should display the children of the current node. Since the menu item of current one is not included in `branchNavItems` list, it has to create a new one.

Please review my changes.

Thanks,
Vendel