### PR TITLE
LPS-84514 Align dynamic-uploader and navbar avoiding overlapping

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/css/main.scss
@@ -9,7 +9,3 @@
 @import "SourceEditor";
 
 @import "SourceEditorToolbar";
-
-.dialog-iframe-popup .portlet-fragment-web .lfr-dynamic-uploader {
-	top: 0;
-}


### PR DESCRIPTION
Hi @ealonso ,
This CSS style was causing [LPS-84514](https://issues.liferay.com/browse/LPS-84514). It was added in [LPS-81515](https://issues.liferay.com/browse/LPS-81515) but I've followed the reproduction steps explained in the LPS' description and everything seems fine so I ended up deleting it. Hope I didn't overlook anything.

Could you take a look at this?
Thanks!