### PR TITLE
LPS-87401 Control Panel modified, to display PanelApps as well

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/servlet/taglib/PanelTag.java
+++ b/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/servlet/taglib/PanelTag.java
@@ -14,6 +14,7 @@
 
 package com.liferay.application.list.taglib.servlet.taglib;
 
+import com.liferay.application.list.PanelAppRegistry;
 import com.liferay.application.list.PanelCategory;
 import com.liferay.application.list.PanelCategoryRegistry;
 import com.liferay.application.list.RootPanelCategory;
@@ -62,6 +63,10 @@ public class PanelTag extends BasePanelTag {
 			(PanelCategoryRegistry)request.getAttribute(
 				ApplicationListWebKeys.PANEL_CATEGORY_REGISTRY);
 
+		PanelAppRegistry panelAppRegistry =
+			(PanelAppRegistry)request.getAttribute(
+				ApplicationListWebKeys.PANEL_APP_REGISTRY);
+
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -73,6 +78,10 @@ public class PanelTag extends BasePanelTag {
 		request.setAttribute(
 			"liferay-application-list:panel:childPanelCategories",
 			childPanelCategories);
+
+		request.setAttribute(
+			"liferay-application-list:panel:childPanelApps",
+			panelAppRegistry.getPanelApps(_panelCategory));
 
 		request.setAttribute(
 			"liferay-application-list:panel:panelCategory", _panelCategory);

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel/page.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel/page.jsp
@@ -17,6 +17,7 @@
 <%@ include file="/panel/init.jsp" %>
 
 <%
+List<PanelApp> childPanelApps = (List<PanelApp>)request.getAttribute("liferay-application-list:panel:childPanelApps");
 List<PanelCategory> childPanelCategories = (List<PanelCategory>)request.getAttribute("liferay-application-list:panel:childPanelCategories");
 %>
 
@@ -31,6 +32,18 @@ List<PanelCategory> childPanelCategories = (List<PanelCategory>)request.getAttri
 				panelCategory="<%= childPanelCategory %>"
 				showOpen="<%= childPanelCategories.size() == 1 %>"
 			/>
+
+		<%
+		}
+
+		for (PanelApp childPanelApp : childPanelApps) {
+		%>
+
+			<ul class="nav nav-equal-height nav-stacked panel-app" role="menu">
+				<liferay-application-list:panel-app
+					panelApp="<%= childPanelApp %>"
+				/>
+			</ul>
 
 		<%
 		}

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -319,3 +319,7 @@
 		margin-right: -1px;
 	}
 }
+
+.panel-app > li > a {
+	padding-left: 24px;
+}


### PR DESCRIPTION
Hey Eudaldo,

I think you can review this, as the WEM owns the product menu too.

We have a UX design for the Change list feature that includes a menu item in the control panel section. Previously it was not possible to add a menu only to the control panel, only categories, this pull request makes it possible.

You can check the UX design in the ticket: https://issues.liferay.com/browse/LPS-87401

Let us know if you have any question.