### PR TITLE
[TECHNICAL-SUPPORT] LPS-88901

### DIFF
--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/internal/upgrade/AssetEntryRelServiceUpgrade.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/internal/upgrade/AssetEntryRelServiceUpgrade.java
@@ -15,7 +15,6 @@
 package com.liferay.asset.entry.rel.internal.upgrade;
 
 import com.liferay.asset.entry.rel.internal.upgrade.v1_0_0.UpgradeAssetEntryAssetCategoryRel;
-import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -23,15 +22,11 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Eudaldo Alonso
  */
-@Component(
-	enabled = false, immediate = true, service = UpgradeStepRegistrator.class
-)
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
 public class AssetEntryRelServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
-
 		registry.register(
 			"0.0.1", "1.0.0", new UpgradeAssetEntryAssetCategoryRel());
 	}

--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/internal/upgrade/v1_0_0/UpgradeAssetEntryAssetCategoryRel.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/internal/upgrade/v1_0_0/UpgradeAssetEntryAssetCategoryRel.java
@@ -17,6 +17,7 @@ package com.liferay.asset.entry.rel.internal.upgrade.v1_0_0;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -57,7 +58,17 @@ public class UpgradeAssetEntryAssetCategoryRel extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		upgradeSchema();
+
 		addAssetEntryAssetCategoryRels();
+	}
+
+	protected void upgradeSchema() throws Exception {
+		String template = StringUtil.read(
+			UpgradeAssetEntryAssetCategoryRel.class.getResourceAsStream(
+				"dependencies/update.sql"));
+
+		runSQLTemplateString(template, false, false);
 	}
 
 }

--- a/modules/apps/asset/asset-entry-rel-service/src/main/resources/com/liferay/asset/entry/rel/internal/upgrade/v1_0_0/dependencies/update.sql
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/resources/com/liferay/asset/entry/rel/internal/upgrade/v1_0_0/dependencies/update.sql
@@ -1,0 +1,11 @@
+create table AssetEntryAssetCategoryRel (
+	assetEntryAssetCategoryRelId LONG not null primary key,
+	assetEntryId LONG,
+	assetCategoryId LONG,
+	priority INTEGER
+);
+
+create index IX_19EC1746 on AssetEntryAssetCategoryRel (assetCategoryId);
+create index IX_E597E5D5 on AssetEntryAssetCategoryRel (assetEntryId, assetCategoryId);
+
+COMMIT_TRANSACTION;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeModules.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeModules.java
@@ -32,6 +32,7 @@ public class UpgradeModules
 
 	private static final String[] _BUNDLE_SYMBOLIC_NAMES = {
 		"com.liferay.asset.category.property.service",
+		"com.liferay.asset.entry.rel.service",
 		"com.liferay.asset.tag.stats.service", "com.liferay.blogs.service",
 		"com.liferay.document.library.content.service",
 		"com.liferay.document.library.file.rank.service",


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPS-88901

Hi @ealonso,

This fix enables the UpgradeAssetEntryAssetCategoryRel upgrade class. There is an issue in 7.1.x where customers are losing their categories assigned to web content because we now use the AssetEntryAssetCategoryRel modules to look for what should be associated with content and categories. 

This issue was already addressed in [LPS-85783](https://issues.liferay.com/browse/LPS-85783), however, I do not believe that is the right fix as the upgrade itself still does not run, it merely adds the relation when content is first accessed post upgrade. While this may not be a huge issue performance wise, I think we should still try to use the upgrade process if at all possible.

After enabling the upgrade class, the AssetEntryAssetCategoryRel table was not being created, so I am implementing an upgradeSchema similar to what [Layout-Page-Template-Service](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java#L113-L119) does when an upgrade needs to be run, but the table does not yet exist. Working with @holatuwol we determined this is really the only way we have currently to do an upgrade for a table that does not exist but needs to use existing data to pre-populate the table.

Thank you,
Sam Ziemer