### PR TITLE
LPS-89622 SF

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DisplayPageFriendlyURLResolver.java
@@ -90,10 +90,8 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 		String urlTitle = friendlyURL.substring(
 			JournalArticleConstants.CANONICAL_URL_SEPARATOR.length());
 
-		String decodedUrlTitle = _http.decodePath(urlTitle);
-
 		String normalizedUrlTitle =
-			FriendlyURLNormalizerUtil.normalizeWithEncoding(decodedUrlTitle);
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(urlTitle);
 
 		JournalArticle journalArticle =
 			_journalArticleLocalService.fetchLatestArticleByUrlTitle(
@@ -175,10 +173,8 @@ public class DisplayPageFriendlyURLResolver implements FriendlyURLResolver {
 		String urlTitle = friendlyURL.substring(
 			JournalArticleConstants.CANONICAL_URL_SEPARATOR.length());
 
-		String decodedUrlTitle = _http.decodePath(urlTitle);
-
 		String normalizedUrlTitle =
-			FriendlyURLNormalizerUtil.normalizeWithEncoding(decodedUrlTitle);
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(urlTitle);
 
 		JournalArticle journalArticle =
 			_journalArticleLocalService.fetchLatestArticleByUrlTitle(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -501,8 +501,8 @@ public class FriendlyURLEntryLocalServiceImpl
 		}
 
 		for (Map.Entry<String, String> entry : urlTitleMap.entrySet()) {
-			String urlTitle = FriendlyURLNormalizerUtil.normalize(
-				entry.getValue());
+			String urlTitle = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+				HttpUtil.decodePath(entry.getValue()));
 
 			if (!urlTitle.equals(existUrlTitleMap.get(entry.getKey()))) {
 				return false;

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -350,10 +350,8 @@ public class FriendlyURLEntryLocalServiceImpl
 				Math.min(
 					maxLength - suffix.length(), normalizedUrlTitle.length()));
 
-			String decodedUrlTitle = HttpUtil.decodePath(prefix + suffix);
-
 			curUrlTitle = FriendlyURLNormalizerUtil.normalizeWithEncoding(
-				decodedUrlTitle);
+				prefix + suffix);
 		}
 
 		return curUrlTitle;
@@ -502,7 +500,7 @@ public class FriendlyURLEntryLocalServiceImpl
 
 		for (Map.Entry<String, String> entry : urlTitleMap.entrySet()) {
 			String urlTitle = FriendlyURLNormalizerUtil.normalizeWithEncoding(
-				HttpUtil.decodePath(entry.getValue()));
+				entry.getValue());
 
 			if (!urlTitle.equals(existUrlTitleMap.get(entry.getKey()))) {
 				return false;
@@ -518,14 +516,13 @@ public class FriendlyURLEntryLocalServiceImpl
 		throws PortalException {
 
 		for (Map.Entry<String, String> entry : urlTitleMap.entrySet()) {
-			String urlTitle = HttpUtil.decodePath(entry.getValue());
+			String normalizedUrlTitle =
+				FriendlyURLNormalizerUtil.normalizeWithEncoding(
+					entry.getValue());
 
-			if (Validator.isNull(urlTitle)) {
+			if (Validator.isNull(normalizedUrlTitle)) {
 				continue;
 			}
-
-			String normalizedUrlTitle =
-				FriendlyURLNormalizerUtil.normalizeWithEncoding(urlTitle);
 
 			FriendlyURLEntryLocalization existingFriendlyURLEntryLocalization =
 				friendlyURLEntryLocalizationPersistence.fetchByG_C_U(

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.spring.extender.service.ServiceReference;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -277,7 +277,7 @@ public class JournalArticleLocalServiceImpl
 	 * @param  neverExpire whether the web content article is not set to auto
 	 *         expire
 	 * @param  reviewDateMonth the month the web content article is set for
-	 *         review
+	 *         reviewaddArticle
 	 * @param  reviewDateDay the calendar day the web content article is set for
 	 *         review
 	 * @param  reviewDateYear the year the web content article is set for review
@@ -459,6 +459,17 @@ public class JournalArticleLocalServiceImpl
 		journalArticlePersistence.update(article);
 
 		// Friendly URLs
+
+		List<FriendlyURLEntry> friendlyURLEntries =
+			friendlyURLEntryLocalService.getFriendlyURLEntries(
+				groupId,
+				classNameLocalService.getClassNameId(JournalArticle.class),
+				article.getResourcePrimKey());
+
+		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
+			friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+				friendlyURLEntry);
+		}
 
 		friendlyURLEntryLocalService.addFriendlyURLEntry(
 			groupId, classNameLocalService.getClassNameId(JournalArticle.class),

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8531,19 +8531,26 @@ public class JournalArticleLocalServiceImpl
 				classNameLocalService.getClassNameId(JournalArticle.class),
 				article.getResourcePrimKey());
 
-		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
-			friendlyURLEntryLocalService.deleteFriendlyURLEntry(
-				friendlyURLEntry);
-		}
-
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setUuid(article.getUuid());
 
-		friendlyURLEntryLocalService.addFriendlyURLEntry(
-			article.getGroupId(),
-			classNameLocalService.getClassNameId(JournalArticle.class),
-			article.getResourcePrimKey(), urlTitleMap, serviceContext);
+		FriendlyURLEntry newFriendlyURLEntry =
+			friendlyURLEntryLocalService.addFriendlyURLEntry(
+				article.getGroupId(),
+				classNameLocalService.getClassNameId(JournalArticle.class),
+				article.getResourcePrimKey(), urlTitleMap, serviceContext);
+
+		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
+			if (newFriendlyURLEntry.getFriendlyURLEntryId() ==
+					friendlyURLEntry.getFriendlyURLEntryId()) {
+
+				continue;
+			}
+
+			friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+				friendlyURLEntry);
+		}
 	}
 
 	protected void updatePreviousApprovedArticle(JournalArticle article)

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8521,7 +8521,7 @@ public class JournalArticleLocalServiceImpl
 		}
 	}
 
-	protected void updateFriendlyURLs (
+	protected void updateFriendlyURLs(
 			JournalArticle article, Map<String, String> urlTitleMap)
 		throws PortalException {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -460,20 +460,7 @@ public class JournalArticleLocalServiceImpl
 
 		// Friendly URLs
 
-		List<FriendlyURLEntry> friendlyURLEntries =
-			friendlyURLEntryLocalService.getFriendlyURLEntries(
-				groupId,
-				classNameLocalService.getClassNameId(JournalArticle.class),
-				article.getResourcePrimKey());
-
-		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
-			friendlyURLEntryLocalService.deleteFriendlyURLEntry(
-				friendlyURLEntry);
-		}
-
-		friendlyURLEntryLocalService.addFriendlyURLEntry(
-			groupId, classNameLocalService.getClassNameId(JournalArticle.class),
-			resourcePrimKey, urlTitleMap, serviceContext);
+		updateFriendlyURLs(article, urlTitleMap);
 
 		// Article localization
 
@@ -5729,20 +5716,7 @@ public class JournalArticleLocalServiceImpl
 
 		// Friendly URLs
 
-		List<FriendlyURLEntry> friendlyURLEntries =
-			friendlyURLEntryLocalService.getFriendlyURLEntries(
-				groupId,
-				classNameLocalService.getClassNameId(JournalArticle.class),
-				article.getResourcePrimKey());
-
-		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
-			friendlyURLEntryLocalService.deleteFriendlyURLEntry(
-				friendlyURLEntry);
-		}
-
-		friendlyURLEntryLocalService.addFriendlyURLEntry(
-			groupId, classNameLocalService.getClassNameId(JournalArticle.class),
-			article.getResourcePrimKey(), urlTitleMap, serviceContext);
+		updateFriendlyURLs(article, urlTitleMap);
 
 		// Asset
 
@@ -8545,6 +8519,31 @@ public class JournalArticleLocalServiceImpl
 		finally {
 			serviceContext.setIndexingEnabled(indexingEnabled);
 		}
+	}
+
+	protected void updateFriendlyURLs (
+			JournalArticle article, Map<String, String> urlTitleMap)
+		throws PortalException {
+
+		List<FriendlyURLEntry> friendlyURLEntries =
+			friendlyURLEntryLocalService.getFriendlyURLEntries(
+				article.getGroupId(),
+				classNameLocalService.getClassNameId(JournalArticle.class),
+				article.getResourcePrimKey());
+
+		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
+			friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+				friendlyURLEntry);
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUuid(article.getUuid());
+
+		friendlyURLEntryLocalService.addFriendlyURLEntry(
+			article.getGroupId(),
+			classNameLocalService.getClassNameId(JournalArticle.class),
+			article.getResourcePrimKey(), urlTitleMap, serviceContext);
 	}
 
 	protected void updatePreviousApprovedArticle(JournalArticle article)

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8531,15 +8531,12 @@ public class JournalArticleLocalServiceImpl
 				classNameLocalService.getClassNameId(JournalArticle.class),
 				article.getResourcePrimKey());
 
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setUuid(article.getUuid());
-
 		FriendlyURLEntry newFriendlyURLEntry =
 			friendlyURLEntryLocalService.addFriendlyURLEntry(
 				article.getGroupId(),
 				classNameLocalService.getClassNameId(JournalArticle.class),
-				article.getResourcePrimKey(), urlTitleMap, serviceContext);
+				article.getResourcePrimKey(), urlTitleMap,
+				new ServiceContext());
 
 		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
 			if (newFriendlyURLEntry.getFriendlyURLEntryId() ==

--- a/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
+import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.util.Normalizer;
@@ -88,6 +89,8 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 			return friendlyURL;
 		}
 
+		String decodedFriendlyURL = HttpUtil.decodePath(friendlyURL);
+
 		StringBuilder sb = new StringBuilder(friendlyURL.length());
 
 		boolean modified = false;
@@ -97,8 +100,8 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 		CharsetEncoder charsetEncoder = null;
 
-		for (int i = 0; i < friendlyURL.length(); i++) {
-			char c = friendlyURL.charAt(i);
+		for (int i = 0; i < decodedFriendlyURL.length(); i++) {
+			char c = decodedFriendlyURL.charAt(i);
 
 			if ((CharPool.UPPER_CASE_A <= c) && (c <= CharPool.UPPER_CASE_Z)) {
 				sb.append((char)(c + 32));
@@ -142,14 +145,14 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 				boolean endOfInput = false;
 
-				if ((friendlyURL.length() - 1) == i) {
+				if ((decodedFriendlyURL.length() - 1) == i) {
 					endOfInput = true;
 				}
 
 				if (Character.isHighSurrogate(c) &&
-					((i + 1) < friendlyURL.length())) {
+					((i + 1) < decodedFriendlyURL.length())) {
 
-					c = friendlyURL.charAt(i + 1);
+					c = decodedFriendlyURL.charAt(i + 1);
 
 					if (Character.isLowSurrogate(c)) {
 						charBuffer.put(c);

--- a/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
@@ -91,7 +91,7 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 		String decodedFriendlyURL = HttpUtil.decodePath(friendlyURL);
 
-		StringBuilder sb = new StringBuilder(friendlyURL.length());
+		StringBuilder sb = new StringBuilder(decodedFriendlyURL.length());
 
 		boolean modified = false;
 


### PR DESCRIPTION
Hi @ealonso, @matethurzo,

When we publish articles to live we always create new FriendlyURLEntryLocalization records instead of updating current ones in Live. This is causing a lot of problem with duplicated friendlyURLs.

I have made some changes to reuse FriendlyURL records having just one record per resourcePrimKey in JournalArticle (with mutiple localizations).

Other possible solutions are:

- Use updateArticle (this method works well for staging) instead of addArticle when we publish a new version of an existing article.
- Since we publish friendlyURLs in two points (journal service and friendlyUrl staged handler), unifiy that logic.

Let me know if you have any question.

Thanks.

PS: I have also fixed issues comparing friendlyURLs (due wrong decode/encoding)