### PR TITLE
[TECHNICAL-SUPPORT] LPS-91279 Handle embedded date fields in Web Content templates

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/date.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/date.ftl
@@ -1,19 +1,21 @@
 <#include "init.ftl">
 
+<#assign tempVarName = stringUtil.replace(name, ".", "_") />
+
 <#if stringUtil.equals(language, "ftl")>
-${r"<#assign"} ${name}_Data = getterUtil.getString(${variableName})>
+${r"<#assign"} ${tempVarName}_Data = getterUtil.getString(${variableName})>
 
-${r"<#if"} validator.isNotNull(${name}_Data)>
-	${r"<#assign"} ${name}_DateObj = dateUtil.parseDate("yyyy-MM-dd", ${name}_Data, locale)>
+${r"<#if"} validator.isNotNull(${tempVarName}_Data)>
+	${r"<#assign"} ${tempVarName}_DateObj = dateUtil.parseDate("yyyy-MM-dd", ${tempVarName}_Data, locale)>
 
-	${r"${"}dateUtil.getDate(${name}_DateObj, "dd MMM yyyy - HH:mm:ss", locale)}
+	${r"${"}dateUtil.getDate(${tempVarName}_DateObj, "dd MMM yyyy - HH:mm:ss", locale)}
 ${r"</#if>"}
 <#else>
-#set ($${name}_Data = $getterUtil.getString($${variableName}))
+#set ($${tempVarName}_Data = $getterUtil.getString($${variableName}))
 
-#if ($validator.isNotNull($${name}_Data))
-	#set ($${name}_DateObj = $dateUtil.parseDate("yyyy-MM-dd",$${name}_Data, $locale))
+#if ($validator.isNotNull($${tempVarName}_Data))
+	#set ($${tempVarName}_DateObj = $dateUtil.parseDate("yyyy-MM-dd",$${tempVarName}_Data, $locale))
 
-	$dateUtil.getDate($${name}_DateObj, "dd MMM yyyy - HH:mm:ss", $locale)
+	$dateUtil.getDate($${tempVarName}_DateObj, "dd MMM yyyy - HH:mm:ss", $locale)
 #end
 </#if>


### PR DESCRIPTION
Hi @ealonso ,

When a template has a Date type field, which is embedded into another field, the template generates a pattern with invalid variable names, e.g.: `Field1.Field2_Data`. Since "." is only allowed in variable names from FreeMarker 2.3.22, and only when escaped with "\\" ([link](https://freemarker.apache.org/docs/dgui_template_exp.html#dgui_template_exp_var)), my thought was to replace all "." with "_" in the temporary variable name.
This will result in names like `Field1_Field2_Data`.

Please review my changes.

Thanks,
Vendel