### PR TITLE
LPS-90864 Let users see groups they belong to

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
@@ -1109,8 +1109,7 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 
 		for (Group group : groups) {
 			if (GroupPermissionUtil.contains(
-					permissionChecker, group, ActionKeys.VIEW) ||
-				permissionChecker.isGroupMember(group.getGroupId())) {
+					permissionChecker, group, ActionKeys.VIEW)) {
 
 				filteredGroups.add(group);
 			}

--- a/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
@@ -200,7 +200,9 @@ public class GroupPermissionImpl
 					 ActionKeys.ASSIGN_USER_ROLES) ||
 				  permissionChecker.hasPermission(
 					  originalGroup, Group.class.getName(), groupId,
-					  ActionKeys.MANAGE_LAYOUTS))) {
+					  ActionKeys.MANAGE_LAYOUTS) ||
+				  permissionChecker.isGroupMember(
+					  originalGroup.getGroupId()))) {
 
 			return true;
 		}


### PR DESCRIPTION
The previous fix (adding a special case when filtering) is not enough.
Unless we extend the permission check, creating shortcuts between sites
fails.