### PR TITLE
LPS-92517

### DIFF
--- a/modules/apps/staging/staging-configuration-web/src/main/java/com/liferay/staging/configuration/web/internal/portlet/StagingConfigurationPortlet.java
+++ b/modules/apps/staging/staging-configuration-web/src/main/java/com/liferay/staging/configuration/web/internal/portlet/StagingConfigurationPortlet.java
@@ -19,6 +19,7 @@ import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.kernel.staging.StagingConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
+import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.NoSuchBackgroundTaskException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -258,6 +259,15 @@ public class StagingConfigurationPortlet extends MVCPortlet {
 		actionRequest.setAttribute(WebKeys.REDIRECT, redirect);
 
 		sendRedirect(actionRequest, actionResponse);
+	}
+
+	@Override
+	protected boolean isSessionErrorException(Throwable cause) {
+		if (cause instanceof LocaleException) {
+			return true;
+		}
+
+		return super.isSessionErrorException(cause);
 	}
 
 	@Reference

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_exceptions.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_exceptions.jspf
@@ -118,8 +118,12 @@
 	LocaleException le = (LocaleException)errorException;
 	%>
 
-	<c:if test="<%= le.getType() == LocaleException.TYPE_EXPORT_IMPORT %>">
+	<c:if test="<%= (le.getType() == LocaleException.TYPE_EXPORT_IMPORT) || (le.getType() == LocaleException.TYPE_DEFAULT) %>">
 		<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-default-language-x-does-not-match-the-portal's-available-languages-x" translateArguments="<%= false %>" />
+	</c:if>
+
+	<c:if test="<%= le.getType() == LocaleException.TYPE_DISPLAY_SETTINGS %>">
+		<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-available-languages-x-do-not-match-the-site's-available-languages-x" translateArguments="<%= false %>" />
 	</c:if>
 </liferay-ui:error>
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/PortalUpgradeProcessRegistryImpl.java
@@ -40,6 +40,8 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeProcesses.put(new Version(5, 0, 1), new UpgradePersonalMenu());
 
 		upgradeProcesses.put(new Version(5, 0, 2), new UpgradeCountry());
+
+		upgradeProcesses.put(new Version(5, 0, 3), new UpgradeGroup());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_2_x/UpgradeGroup.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_2_x;
+
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Zoltan Csaszi
+ */
+public class UpgradeGroup extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		updateLanguageSettings();
+	}
+
+	protected void updateLanguageSettings() throws Exception {
+		try (PreparedStatement selectStatement = connection.prepareStatement(
+				"select groupId, typeSettings from Group_")) {
+
+			try (ResultSet rs = selectStatement.executeQuery()) {
+				while (rs.next()) {
+					String typeSettings = rs.getString("typeSettings");
+
+					UnicodeProperties typeSettingsProperties =
+						new UnicodeProperties(true);
+
+					typeSettingsProperties.load(typeSettings);
+
+					if (!GetterUtil.getBoolean(
+							typeSettingsProperties.getProperty(
+								"inheritLocales"))) {
+
+						continue;
+					}
+
+					long groupId = rs.getLong("groupId");
+
+					String[] languageIdsArray = StringUtil.split(
+						typeSettingsProperties.getProperty("locales"));
+
+					List<String> languageIds = new ArrayList<>();
+
+					for (String languageId : languageIdsArray) {
+						if (!LanguageUtil.isAvailableLocale(
+								LocaleUtil.fromLanguageId(languageId))) {
+
+							languageIds.add(languageId);
+						}
+					}
+
+					typeSettingsProperties.put(
+						"locales", StringUtil.merge(languageIds));
+
+					try (PreparedStatement updateStatement =
+							connection.prepareStatement(
+								"update Group_ set typeSettings = ? where " +
+									"groupId = ?")) {
+
+						updateStatement.setString(
+							1, typeSettingsProperties.toString());
+						updateStatement.setLong(2, groupId);
+
+						updateStatement.executeUpdate();
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -4771,6 +4771,7 @@ the-application-was-added-to-the-page=The application was added to the page.
 the-array-of-all-form-values-indexed-by-name=The array of all form values indexed by name
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}).
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}.
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}.
 the-blog-entry-content=The blog entry content

--- a/portal-impl/src/content/Language_ar.properties
+++ b/portal-impl/src/content/Language_ar.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=تمت إضافة التطبيق إلى ا
 the-array-of-all-form-values-indexed-by-name=صفيف كافة قيم الطلب مفهرسة حسب الاسم
 the-audio-preview-is-not-yet-ready.-please-try-again-later=معاينة الصوت ليست جاهزة بعد. يُرجى المحاولة مرة أخرى لاحقاً.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=اللغات المتوفرة في ملف LAR (<em>{0}</em>) لا تتطابق مع اللغات المتوفرة في الموقع (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=متوسط التقييم {0} من {1} نجوم.
 the-average-rating-is-x-stars-out-of-x=متوسط التقييم {0} من {1} نجوم.
 the-blog-entry-content=محتوى إدخال المدونة

--- a/portal-impl/src/content/Language_bg.properties
+++ b/portal-impl/src/content/Language_bg.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Приложението е добавен
 the-array-of-all-form-values-indexed-by-name=Масив от всички стойности на формата, индексирани по име
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Аудио визуализация не е готова. Моля, опитайте отново по-късно. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=Съдържанието на блог записа (Automatic Translation)

--- a/portal-impl/src/content/Language_ca.properties
+++ b/portal-impl/src/content/Language_ca.properties
@@ -4770,6 +4770,7 @@ the-application-was-added-to-the-page=S'ha afegit l'aplicació a la pàgina.
 the-array-of-all-form-values-indexed-by-name=La matriu de tots els valors del formulari indexats per nom
 the-audio-preview-is-not-yet-ready.-please-try-again-later=La vista prèvia del só no està llesta. Torneu-ho a provar més tard.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Els idiomes disponibles al fitxer LAR (<em>{0}</em>) no coincideixen amb els idiomes disponibles al lloc (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=La classificació mitjana és de {0} estrelles de {1}.
 the-average-rating-is-x-stars-out-of-x=La classificació mitjana és de {0} estrelles de {1}.
 the-blog-entry-content=El contingut de l'entrada del blog

--- a/portal-impl/src/content/Language_cs.properties
+++ b/portal-impl/src/content/Language_cs.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Aplikace byla přidána na stránku. (Auto
 the-array-of-all-form-values-indexed-by-name=Pole všech formulářových hodnot indexovaných podle jména
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Zvuková ukázka není ještě připravena. Prosím zkuste to později.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Jazyky dostupné v LAR souboru (<em>{0}</em>) neodpovídají dostupným jazykům webu (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Průměrné hodnocení je {0} hvězdiček z {1}.
 the-average-rating-is-x-stars-out-of-x=Průměrné hodnocení je {0} hvězdiček z {1}.
 the-blog-entry-content=Obsah příspěvku blogu

--- a/portal-impl/src/content/Language_da.properties
+++ b/portal-impl/src/content/Language_da.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=The array of all form values indexed by name (Automatic Copy)
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_de.properties
+++ b/portal-impl/src/content/Language_de.properties
@@ -4770,6 +4770,7 @@ the-application-was-added-to-the-page=Die Anwendung wurde der Seite hinzugefügt
 the-array-of-all-form-values-indexed-by-name=Alle Formwerte als Array, indiziert durch Namen
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Die Audiovorschau ist noch nicht verfügbar. Bitte versuchen Sie es später erneut.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Die verfügbaren Sprachen der LAR-Datei (<em>{0}</em>) stimmen nicht mit den verfügbaren Sprachen der Site überein (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Die durchschnittliche Bewertung ist {0} von {1} Sternen.
 the-average-rating-is-x-stars-out-of-x=Die durchschnittliche Bewertung ist {0} von {1} Sternen.
 the-blog-entry-content=Der Inhalt des Blogartikels

--- a/portal-impl/src/content/Language_el.properties
+++ b/portal-impl/src/content/Language_el.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Η εφαρμογή έχει προστε�
 the-array-of-all-form-values-indexed-by-name=Ο πίνακας όλων των τιμών της φόρμας με δείκτη το όνομά τους
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Η προεπισκόπηση του ήχου δεν είναι ακόμη έτοιμη. Παρακαλώ προσπαθήστε ξανά αργότερα. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Η μέση βαθμολογία είναι {0} αστέρια από {1}.
 the-average-rating-is-x-stars-out-of-x=Η μέση βαθμολογία είναι {0} αστέρια από {1}.
 the-blog-entry-content=Το περιεχόμενο του blog εισόδου (Automatic Translation)

--- a/portal-impl/src/content/Language_en.properties
+++ b/portal-impl/src/content/Language_en.properties
@@ -4771,6 +4771,7 @@ the-application-was-added-to-the-page=The application was added to the page.
 the-array-of-all-form-values-indexed-by-name=The array of all form values indexed by name
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}).
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}.
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}.
 the-blog-entry-content=The blog entry content

--- a/portal-impl/src/content/Language_es.properties
+++ b/portal-impl/src/content/Language_es.properties
@@ -4770,6 +4770,7 @@ the-application-was-added-to-the-page=La aplicación se ha añadido a la página
 the-array-of-all-form-values-indexed-by-name=El array de todos los valores del formulario, indexados por nombre
 the-audio-preview-is-not-yet-ready.-please-try-again-later=La previsualización del audio aún no está disponible. Por favor inténtelo de nuevo más tarde.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Los idiomas disponibles en el fichero LAR (<em>{0}</em>) no coinciden con los idiomas disponibles del sitio (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=La valoración media es de {0} estrellas de {1}.
 the-average-rating-is-x-stars-out-of-x=La valoración media es de {0} estrellas de {1}.
 the-blog-entry-content=El contenido de la entrada del blog

--- a/portal-impl/src/content/Language_et.properties
+++ b/portal-impl/src/content/Language_et.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Taotluse oli lisatud lehele. (Automatic Tr
 the-array-of-all-form-values-indexed-by-name=Kõikide vormi väärtuste massiiv, mis on indekseeritud nime järgi
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Heli eelvaade pole veel valmis. Proovige hiljem uuesti. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=Blog kande sisu (Automatic Translation)

--- a/portal-impl/src/content/Language_eu.properties
+++ b/portal-impl/src/content/Language_eu.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=Inprimakiko balio guztien array-a izenez indexatuta
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Batazbesteko balorazioa {0} izar, guztira {1}.
 the-average-rating-is-x-stars-out-of-x=Batazbesteko balorazioa {0} izar, guztira {1}.
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_fa.properties
+++ b/portal-impl/src/content/Language_fa.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=برنامه کاربردی به صفحه 
 the-array-of-all-form-values-indexed-by-name=آرایه‌ی تمام مقادیر فرم با نام کاربر مشخص شده است.
 the-audio-preview-is-not-yet-ready.-please-try-again-later=پیش نمایش های صوتی هنوز آماده نیست. لطفا دوباره تلاش کنید
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=زبان موجود در فایل LAR (<em>{0}</em>) با زبان موجود در سایت همخوانی ندارد.
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=امتیاز متوسط {0} ستاره از {1} است.
 the-average-rating-is-x-stars-out-of-x=امتیاز متوسط {0} ستاره از {1} است.
 the-blog-entry-content=محتوا ورودی بلاگ

--- a/portal-impl/src/content/Language_fi.properties
+++ b/portal-impl/src/content/Language_fi.properties
@@ -4763,6 +4763,7 @@ the-application-was-added-to-the-page=Sovellus lisättiin sivulle.
 the-array-of-all-form-values-indexed-by-name=Taulukko lomakkeen arvoista indeksoituna nimen perusteella.
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Audion esikuuntelu ei ole vielä valmis. Yritä myöhemmin uudestaan.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Saatavilla olevat kielet LAR tiedostossa (<em>{0}</em>) eivät vastaa sivuston saatavilla olevia kieliä (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Keskimääräinen arvosana on {0} tähteä {1}:stä.
 the-average-rating-is-x-stars-out-of-x=Keskimääräinen arvosana on {0} tähteä {1}:stä.
 the-blog-entry-content=Blogin sisältö

--- a/portal-impl/src/content/Language_fr.properties
+++ b/portal-impl/src/content/Language_fr.properties
@@ -4770,6 +4770,7 @@ the-application-was-added-to-the-page=Cette application a été ajoutée à la p
 the-array-of-all-form-values-indexed-by-name=Le choix de toutes les valeurs de forme a indexé de nom
 the-audio-preview-is-not-yet-ready.-please-try-again-later=La prévisualisation de l'audio n'est pas encore prête. Veuillez essayer plus tard.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Les langues disponibles dans le fichier LAR (<em>{0}</em>) ne correspondent pas aux langues disponibles sur le site (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=L'estimation moyenne est de {0} étoiles sur {1}.
 the-average-rating-is-x-stars-out-of-x=L'estimation moyenne est de {0} étoiles sur {1}.
 the-blog-entry-content=Le contenu du ticket de blog

--- a/portal-impl/src/content/Language_gl.properties
+++ b/portal-impl/src/content/Language_gl.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=A ristra de todos os valores do formulario indexados polo nome
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=A media de puntuación é {0} empezando fora de {1}.
 the-average-rating-is-x-stars-out-of-x=A media de puntuación é {0} empezando fora de {1}.
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_hi_IN.properties
+++ b/portal-impl/src/content/Language_hi_IN.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=अनुप्रयोग पृष्�
 the-array-of-all-form-values-indexed-by-name=सभी प्रपत्र नाम से अनुक्रमित मानों की सरणी (Automatic Translation)
 the-audio-preview-is-not-yet-ready.-please-try-again-later=ऑडियो पूर्वावलोकन अभी तक तैयार नहीं है। कृपया बाद में पुन: प्रयास करें। (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=ब्लॉग प्रविष्टि की सामग्री (Automatic Translation)

--- a/portal-impl/src/content/Language_hr.properties
+++ b/portal-impl/src/content/Language_hr.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=Niz svih oblika vrijednosti indeksirane po imenu
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Prosjek ocjena je {0} zvijezde iz {1}.
 the-average-rating-is-x-stars-out-of-x=Prosjek ocjena je {0} zvijezde iz {1}.
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_hu.properties
+++ b/portal-impl/src/content/Language_hu.properties
@@ -4770,6 +4770,7 @@ the-application-was-added-to-the-page=Az alkalmazás hozzáadódott az oldalhoz.
 the-array-of-all-form-values-indexed-by-name=űrlap összes értékét tartalmazó tömb, pozíció szerint indexelve.
 the-audio-preview-is-not-yet-ready.-please-try-again-later=A hang előnézet még nincs kész. Próbáld újra később!
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=A LAR fájlban (<em>{0}</em>) rendelkezésre álló nyelvek nem egyeznek a webhely rendelkezésre álló nyelveivel (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Az átlagos minősítés {0} csillag a lehetséges {1}-ből.
 the-average-rating-is-x-stars-out-of-x=Az átlagos minősítés {0} csillag a lehetséges {1}-ből.
 the-blog-entry-content=A blog bejegyzés tartalma

--- a/portal-impl/src/content/Language_in.properties
+++ b/portal-impl/src/content/Language_in.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Aplikasi telah ditambahkan ke halaman. (Au
 the-array-of-all-form-values-indexed-by-name=Susunan dari semua nilai Formulir diindeks oleh nama
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Audio preview masih belum siap. Harap coba lagi nanti. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Peringkat rata-rata adalah {0} bintang dari {1}.
 the-average-rating-is-x-stars-out-of-x=Peringkat rata-rata adalah {0} bintang dari {1}.
 the-blog-entry-content=Isi entri blog (Automatic Translation)

--- a/portal-impl/src/content/Language_it.properties
+++ b/portal-impl/src/content/Language_it.properties
@@ -4768,6 +4768,7 @@ the-application-was-added-to-the-page=L'applicazione è stata aggiunto alla pagi
 the-array-of-all-form-values-indexed-by-name=L'allineamento di tutti i valori della forma ha spostato ad incrementi per nome
 the-audio-preview-is-not-yet-ready.-please-try-again-later=L'anteprima dell'audio non è ancora disponibile. Prego riprovare più tardi.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Le lingue presenti nel file LAR (<em>{0}</em>) non corrispondono con le lingue disponibili per il sito (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=La media del punteggio è {0} stelle su {1}.
 the-average-rating-is-x-stars-out-of-x=La media del punteggio è {0} stelle su {1}.
 the-blog-entry-content=Contenuto dell'articolo del blog

--- a/portal-impl/src/content/Language_iw.properties
+++ b/portal-impl/src/content/Language_iw.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=היישום התווסף לדף.
 the-array-of-all-form-values-indexed-by-name=מערך של כל ערכי הטפסים ממופתח לפי שם
 the-audio-preview-is-not-yet-ready.-please-try-again-later=תצוגת השמע המקדימה עדיין לא מוכנה. אנא נסה שנית מאוחר יותר.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=השפות הזמינות בקובץ ה-LAR (<em>{0}</em>) לא תואמות את השפות הזמינות באתר (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=הדירוג הממוצע הוא {0} כוכבים מתוך {1}.
 the-average-rating-is-x-stars-out-of-x=הדירוג הממוצע הוא {0} כוכבים מתוך {1}.
 the-blog-entry-content=תוכן רשומת הבלוג

--- a/portal-impl/src/content/Language_ja.properties
+++ b/portal-impl/src/content/Language_ja.properties
@@ -4768,6 +4768,7 @@ the-application-was-added-to-the-page=アプリケーションがページに追
 the-array-of-all-form-values-indexed-by-name=名前によって指定されたすべてのフォーム値の配列
 the-audio-preview-is-not-yet-ready.-please-try-again-later=音声試聴はまだ準備が出来ていません。しばらくしてからアクセスしてみてください
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=LARファイル内の使用可能な言語(<em>{0}</em>)がサイトで使用可能な言語(<em>{1}</em>)と一致しません
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=平均評価は{0}星中の{1}です。
 the-average-rating-is-x-stars-out-of-x=平均評価は{0}星中の{1}です。
 the-blog-entry-content=ブログの内容

--- a/portal-impl/src/content/Language_kk.properties
+++ b/portal-impl/src/content/Language_kk.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=The array of all form values indexed by name (Automatic Copy)
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_ko.properties
+++ b/portal-impl/src/content/Language_ko.properties
@@ -4764,6 +4764,7 @@ the-application-was-added-to-the-page=응용 프로그램 페이지에 추가 �
 the-array-of-all-form-values-indexed-by-name=모든 형성 가치의 배열은 이름으로 색인을 붙였다
 the-audio-preview-is-not-yet-ready.-please-try-again-later=오디오 미리 아직 준비 되지 않습니다. 나중에 다시 시도 하십시오. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=블로그 항목 내용 (Automatic Translation)

--- a/portal-impl/src/content/Language_lo.properties
+++ b/portal-impl/src/content/Language_lo.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=ລັກສະນະຕ່າງຂອງມູນຄ່າລວມທັງໝົດແມ່ນຈັດຕາມຊື່
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=ອັດຕາສະເລ່ຍແມ່ນ{0} ເລີ້ມຈາກຂອງ {1}.
 the-average-rating-is-x-stars-out-of-x=ອັດຕາສະເລ່ຍແມ່ນ{0} ເລີ້ມຈາກຂອງ {1}.
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_lt.properties
+++ b/portal-impl/src/content/Language_lt.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Paraiškos buvo įtraukta į puslapį. (Au
 the-array-of-all-form-values-indexed-by-name=Visus indeksuojami pagal pavadinimą formos reikšmių masyvą (Automatic Translation)
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Garso peržiūra dar neparuošta. Bandykite dar kartą vėliau. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=Dienoraščio įrašo turinys (Automatic Translation)

--- a/portal-impl/src/content/Language_nb.properties
+++ b/portal-impl/src/content/Language_nb.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Programmet ble lagt til siden. (Automatic 
 the-array-of-all-form-values-indexed-by-name=Rekken av alle skjemaverdier indeksert etter navn
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Audioforhåndsvisningen er ikke klar. Vennligst prøv igjen senere.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Språkene tilgjengelig i LAR-filen (<em>{0}</em>) samsvarer ikke med nettstedets tilgjengelige språk (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Den gjennomsnittlige rangeringen er {0} stjerner utav {1}.
 the-average-rating-is-x-stars-out-of-x=Den gjennomsnittlige rangeringen er {0} stjerner utav {1}.
 the-blog-entry-content=Blogginnlegginnhold

--- a/portal-impl/src/content/Language_nl.properties
+++ b/portal-impl/src/content/Language_nl.properties
@@ -4771,6 +4771,7 @@ the-application-was-added-to-the-page=De toepassing is toegevoegd aan de pagina.
 the-array-of-all-form-values-indexed-by-name=Matrix van alle formulierwaarden, geïndexeerd op naam
 the-audio-preview-is-not-yet-ready.-please-try-again-later=De audiopreview is nog niet klaar. Probeer het later nog eens.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=De beschikbare talen in het LAR-bestand (<em>{0}</em>) komen niet overeen met de beschikbare talen van de site (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=De gemiddelde waardering is {0} sterren van de {1}.
 the-average-rating-is-x-stars-out-of-x=De gemiddelde waardering is {0} sterren van de {1}.
 the-blog-entry-content=De inhoud van de blog

--- a/portal-impl/src/content/Language_nl_BE.properties
+++ b/portal-impl/src/content/Language_nl_BE.properties
@@ -4771,6 +4771,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=De serie van alle formulierwaarden geïndexeerd op naam
 the-audio-preview-is-not-yet-ready.-please-try-again-later=De audio preview is nog niet klaar. Probeer het later nog eens. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=De gemiddelde waardering is {0} sterren van de {1}.
 the-average-rating-is-x-stars-out-of-x=De gemiddelde waardering is {0} sterren van de {1}.
 the-blog-entry-content=De blog post inhoud (Automatic Translation)

--- a/portal-impl/src/content/Language_pl.properties
+++ b/portal-impl/src/content/Language_pl.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Wniosek został dodany do strony. (Automat
 the-array-of-all-form-values-indexed-by-name=Tablica wszystkich wartości formularza indeksowane po nazwie
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Próbka nagrania nie jest jeszcze gotowa. Spróbuj później.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Dostępne języki w pliku LAR (<em>{0}</em>) nie odpowiadają dostępnym językom witryny (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Średnia ocena to {0} gwiazdek z {1}.
 the-average-rating-is-x-stars-out-of-x=Średnia ocena to {0} gwiazdek z {1}.
 the-blog-entry-content=Zawartość wpisu w blogu

--- a/portal-impl/src/content/Language_pt_BR.properties
+++ b/portal-impl/src/content/Language_pt_BR.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=A aplicação foi adicionada à página.
 the-array-of-all-form-values-indexed-by-name=O grupo todos os valores do formulário indexados pelo nome
 the-audio-preview-is-not-yet-ready.-please-try-again-later=A pré-visualização do áudio não esta pronto ainda. Por favor, tente novamente mais tarde.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Os idiomas disponíveis no arquivo LAR (<em>{0}</em>) não correspondem com os idiomas disponíveis no site (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=A média da avaliação é {0} estrelas de {1}.
 the-average-rating-is-x-stars-out-of-x=A média da avaliação é {0} estrelas de {1}.
 the-blog-entry-content=Conteúdo de uma entrada de blog

--- a/portal-impl/src/content/Language_pt_PT.properties
+++ b/portal-impl/src/content/Language_pt_PT.properties
@@ -4770,6 +4770,7 @@ the-application-was-added-to-the-page=A aplicação foi adicionada à página.
 the-array-of-all-form-values-indexed-by-name=O array de todos os valores do formulário, indexados pelo nome.
 the-audio-preview-is-not-yet-ready.-please-try-again-later=A pré-visualização de áudio ainda não está pronta. Por favor, tente novamente mais tarde.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Os idiomas disponíveis no arquivo LAR (<em>{0}</em>) não correspondem com os idiomas disponíveis no site (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=A média da classificação é {0} estrela de {1}.
 the-average-rating-is-x-stars-out-of-x=A média da classificação é {0} estrelas de {1}.
 the-blog-entry-content=Conteúdo de uma entrada de blog

--- a/portal-impl/src/content/Language_ro.properties
+++ b/portal-impl/src/content/Language_ro.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Cererea a fost adăugat la pagina. (Automa
 the-array-of-all-form-values-indexed-by-name=Lista a tuturor valorilor indexate dupa nume
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Audio preview nu este încă gata. Vă rugăm să încercaţi din nou mai târziu. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Media evaluarii este de {0} stele din {1}.
 the-average-rating-is-x-stars-out-of-x=Media evaluarii este de {0} stele din {1}.
 the-blog-entry-content=Conținutul de intrare blog (Automatic Translation)

--- a/portal-impl/src/content/Language_ru.properties
+++ b/portal-impl/src/content/Language_ru.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Приложения был добавле
 the-array-of-all-form-values-indexed-by-name=Массив всех значений формы, индексированный по названию
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Просмотр аудио пока не готов. Пожалуйста, повторите попытку позже. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Доступные языки в LAR файле (<em>{0}</em>) не соотвествуют доступным языкам сайта (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Средний рейтинг {0} звезд из {1}.
 the-average-rating-is-x-stars-out-of-x=Средний рейтинг {0} звезд из {1}.
 the-blog-entry-content=Содержание записи блога (Automatic Translation)

--- a/portal-impl/src/content/Language_sk.properties
+++ b/portal-impl/src/content/Language_sk.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Žiadosť bola pridaná na stránku. (Auto
 the-array-of-all-form-values-indexed-by-name=Pole všetkých formulárových hodnôt indexovaných podľa mena
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Náhľad audia ešte nie je hotový. Skúste neskôr, prosím.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=Dostupné jazyky v LAR súbore (<em>{0}</em>) nesúhlasia s jazykmi dostupnými pre sídlo (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Priemerné hodnotenie je {0} hviezdičiek z {1}.
 the-average-rating-is-x-stars-out-of-x=Priemerné hodnotenie je {0} hviezdičiek z {1}.
 the-blog-entry-content=Obsah blogového príspevku

--- a/portal-impl/src/content/Language_sl.properties
+++ b/portal-impl/src/content/Language_sl.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Program je bil dodan na stran. (Automatic 
 the-array-of-all-form-values-indexed-by-name=Niz vseh vrednosti obrazca urejen po imenu
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Zvočni predogled še ni pripravljen. Poskusite znova pozneje. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=Blog vnos vsebine (Automatic Translation)

--- a/portal-impl/src/content/Language_sr_RS.properties
+++ b/portal-impl/src/content/Language_sr_RS.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=Низ свих облика вредности индексирани по имену
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Просечна оцена је {0} звезда од {1}.
 the-average-rating-is-x-stars-out-of-x=Просечна оцена је {0} звезда од {1}.
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_sr_RS_latin.properties
+++ b/portal-impl/src/content/Language_sr_RS_latin.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=The application was added to the page. (Au
 the-array-of-all-form-values-indexed-by-name=Niz svih oblika vrednosti indeksirani po imenu
 the-audio-preview-is-not-yet-ready.-please-try-again-later=The audio preview is not yet ready. Please try again later. (Automatic Copy)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=Prosečna ocena je {0} zvezda od {1}.
 the-blog-entry-content=The blog entry content (Automatic Copy)

--- a/portal-impl/src/content/Language_sv.properties
+++ b/portal-impl/src/content/Language_sv.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Applikationen har lags till på sidan.
 the-array-of-all-form-values-indexed-by-name=En array med alla fältvärden indexerad på namn.
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Förhandslyssning av ljudet är inte redo än. Försök igen senare.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=De tillgängliga språken i LAR-filen (<em>{0}</em>) matchar inte de tillgängliga språken på webbplatsen (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Snittbetyget är {0} stjärnor av {1}.
 the-average-rating-is-x-stars-out-of-x=Snittbetyget är {0} stjärnor av {1}.
 the-blog-entry-content=Blogginläggets innehåll

--- a/portal-impl/src/content/Language_th.properties
+++ b/portal-impl/src/content/Language_th.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=โปรแกรมประยุกต
 the-array-of-all-form-values-indexed-by-name=อาร์เรย์ของค่าแบบฟอร์มการจัดทำดัชนีตามชื่อ (Automatic Translation)
 the-audio-preview-is-not-yet-ready.-please-try-again-later=ตัวอย่างเสียงยังไม่พร้อม โปรดลองอีกครั้ง (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=เนื้อหารายการของบล็อก (Automatic Translation)

--- a/portal-impl/src/content/Language_tr.properties
+++ b/portal-impl/src/content/Language_tr.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Uygulama sayfasına eklendi. (Automatic Tr
 the-array-of-all-form-values-indexed-by-name=Ada göre sıralanan tüm form değerleri dizisi (Automatic Translation)
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Ses Önizleme henüz hazır değil. Lütfen daha sonra yeniden deneyin. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=Blog giriş içeriği (Automatic Translation)

--- a/portal-impl/src/content/Language_uk.properties
+++ b/portal-impl/src/content/Language_uk.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Застосунок було додано
 the-array-of-all-form-values-indexed-by-name=Масив всіх значень форми, індексований по назві
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Аудіо preview він ще не готовий. Будь ласка, спробуйте ще раз пізніше. (Automatic Translation)
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>). (Automatic Copy)
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=The average rating is {0} star out of {1}. (Automatic Copy)
 the-average-rating-is-x-stars-out-of-x=The average rating is {0} stars out of {1}. (Automatic Copy)
 the-blog-entry-content=Зміст блогу запис (Automatic Translation)

--- a/portal-impl/src/content/Language_vi.properties
+++ b/portal-impl/src/content/Language_vi.properties
@@ -4765,6 +4765,7 @@ the-application-was-added-to-the-page=Các ứng dụng đã được thêm vào
 the-array-of-all-form-values-indexed-by-name=Mảng của toàn bộ giá trị được sắp xếp theo tên
 the-audio-preview-is-not-yet-ready.-please-try-again-later=Nghe trước tập tin âm thanh chưa có sẵn, mời bạn thử lại sau.
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=The available languages in the LAR file (<em>{0}</em>) do not match the site's available languages (<em>{1}</em>).
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=Tỷ lệ trung bình là {0} ngôi sao trên mức cao nhất {1} sao.
 the-average-rating-is-x-stars-out-of-x=Tỷ lệ trung bình là {0} ngôi sao trên mức cao nhất {1} sao.
 the-blog-entry-content=Nội dung nhật ký (blog).

--- a/portal-impl/src/content/Language_zh_CN.properties
+++ b/portal-impl/src/content/Language_zh_CN.properties
@@ -4768,6 +4768,7 @@ the-application-was-added-to-the-page=应用程序已添加到页面。
 the-array-of-all-form-values-indexed-by-name=按名称索引的所有表单值的数组
 the-audio-preview-is-not-yet-ready.-please-try-again-later=视频预览未就绪。请稍后重试。
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=在LAR文件(<em>{0}</em>)中的可用语言不能和站点的可用语言(<em>{1}</em>)相匹配。
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=满分为{1}，平均得分为{0}。
 the-average-rating-is-x-stars-out-of-x=满分为{1}，平均得分为{0}。
 the-blog-entry-content=博客条目内容

--- a/portal-impl/src/content/Language_zh_TW.properties
+++ b/portal-impl/src/content/Language_zh_TW.properties
@@ -4766,6 +4766,7 @@ the-application-was-added-to-the-page=應用程式添加到頁。 (Automatic Tra
 the-array-of-all-form-values-indexed-by-name=所有表單值陣列以名稱索引
 the-audio-preview-is-not-yet-ready.-please-try-again-later=聲音預覽尚未準備好。請稍候再試。
 the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x=在LAR檔(<em>{0}</em>)的可用語系不符合站台可用語系 (<em>{1}</em>)。
+the-available-languages-x-do-not-match-the-site's-available-languages-x=The available languages ({0}) do not match the site's available languages ({1}). (Automatic Copy)
 the-average-rating-is-x-star-out-of-x=平均評等是{1}星之{0}。
 the-average-rating-is-x-stars-out-of-x=平均評等是{1}星之{0}。
 the-blog-entry-content=部落格條目內容


### PR DESCRIPTION
Hey Eudaldo,

I am sending this pr to you because however the bug was causing a staging issue, but the main fix affects site management/localisation are. The problem was that if you had staging enabled on 6.2 and you upgraded to 7+ the portal default locales have changed, but the group type settings did not. And when you wanted to turn off staging after the upgrade, behind the scenes it invoked a group service update which failed, because the group's original locales did not match with the actual portal local, so it did not allowed to turn off staging for example.
The proposed solution is to update the groups locales if inherit locales option was checked. Or display a proper error message on the staging UI if inherit locales was off.

Could you please help me with double checking the upgrade process part of the fix?

p.s.: there was another staging issue related to the ticket, but it has been fixed previously, now what we have is the locale issue only.

thanks,
Daniel