### PR TITLE
LPS-96225 Overriding email templates for asset publisher in system settings is not working correctly in the actual portlets.

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerUtil.java
@@ -123,6 +123,9 @@ public class AssetEntriesCheckerUtil {
 				portletPreferencesModel.getPortletId(),
 				portletPreferencesModel.getPreferences());
 
+		_assetPublisherWebUtil.
+			refreshAssetPublisherPortletInstanceConfiguration();
+
 		if (!_assetPublisherWebUtil.getEmailAssetEntryAddedEnabled(
 				portletPreferences)) {
 

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherWebUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherWebUtil.java
@@ -515,6 +515,14 @@ public class AssetPublisherWebUtil {
 		}
 	}
 
+	public void refreshAssetPublisherPortletInstanceConfiguration()
+		throws ConfigurationException {
+
+		_assetPublisherPortletInstanceConfiguration =
+			ConfigurationProviderUtil.getSystemConfiguration(
+				AssetPublisherPortletInstanceConfiguration.class);
+	}
+
 	public void subscribe(
 			PermissionChecker permissionChecker, long groupId, long plid,
 			String portletId)

--- a/modules/apps/portal/portal-upgrade-api/src/main/resources/com/liferay/portal/upgrade/step/util/packageinfo
+++ b/modules/apps/portal/portal-upgrade-api/src/main/resources/com/liferay/portal/upgrade/step/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Hey @ealonso 

Could you please review this pull request?

This change ensures that the latest Asset Publisher Portlet Instance Configurations are fetched from the DB when they are referenced.

Thank you and best regards,
István