### PR TITLE
LPS-96139 Get selected languageId from the localized_input component

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -106,8 +106,10 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 
 					var languageId = '<%= themeDisplay.getLanguageId() %>';
 
-					if (document.<portlet:namespace />fm1.<portlet:namespace />languageId.value != '') {
-						languageId = document.<portlet:namespace />fm1.<portlet:namespace />languageId.value;
+					var inputComponent = Liferay.component('<portlet:namespace />titleMapAsXML');
+
+					if (inputComponent) {
+						languageId = inputComponent.getSelectedLanguageId();
 					}
 
 					uri = Liferay.Util.addParams('<portlet:namespace />languageId=' + languageId, uri);


### PR DESCRIPTION
Hi @ealonso ,
@victorg1991 helped me catch up with the latest changes while I was trying to backport LPS-96139 and he noticed that this fix no longer works on master. He proposed this addition, which I've tested as well.
(might have been lost during the soy migration)

Can you please review?
https://issues.liferay.com/browse/LPS-96139

Thanks,

ps cheers Victor