### PR TITLE
LPS-98549 | Asset publisher filtering and ordering by non-localizable structure field will show incorrect results for non-default languages

### DIFF
--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -546,6 +546,22 @@ public class AssetHelperImpl implements AssetHelper {
 		return assetSearcher;
 	}
 
+	private boolean _getDDMFormFieldLocalizable(String sortField)
+		throws PortalException {
+
+		String[] sortFields = sortField.split(
+			DDMStructureManager.STRUCTURE_INDEXER_FIELD_SEPARATOR);
+
+		long ddmStructureId = GetterUtil.getLong(sortFields[2]);
+		String fieldName = sortFields[3];
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+			ddmStructureId);
+
+		return GetterUtil.getBoolean(
+			ddmStructure.getFieldProperty(fieldName, "localizable"));
+	}
+
 	private String _getDDMFormFieldType(String sortField)
 		throws PortalException {
 
@@ -562,7 +578,8 @@ public class AssetHelperImpl implements AssetHelper {
 	}
 
 	private String _getOrderByCol(
-		String sortField, String fieldType, int sortType, Locale locale) {
+		String sortField, String fieldType, boolean fieldLocalizable,
+		int sortType, Locale locale) {
 
 		if (sortField.startsWith(
 				DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX)) {
@@ -571,8 +588,11 @@ public class AssetHelperImpl implements AssetHelper {
 
 			sb.append(sortField);
 			sb.append(StringPool.UNDERLINE);
-			sb.append(LocaleUtil.toLanguageId(locale));
-			sb.append(StringPool.UNDERLINE);
+
+			if (fieldLocalizable) {
+				sb.append(LocaleUtil.toLanguageId(locale));
+				sb.append(StringPool.UNDERLINE);
+			}
 
 			String suffix = "String";
 
@@ -602,10 +622,13 @@ public class AssetHelperImpl implements AssetHelper {
 	private Sort _getSort(String orderByType, String sortField, Locale locale)
 		throws Exception {
 
+		boolean ddmFormFieldLocalizable = true;
 		String ddmFormFieldType = sortField;
 
 		if (ddmFormFieldType.startsWith(
 				DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX)) {
+
+			ddmFormFieldLocalizable = _getDDMFormFieldLocalizable(sortField);
 
 			ddmFormFieldType = _getDDMFormFieldType(ddmFormFieldType);
 		}
@@ -614,7 +637,9 @@ public class AssetHelperImpl implements AssetHelper {
 
 		return SortFactoryUtil.getSort(
 			AssetEntry.class, sortType,
-			_getOrderByCol(sortField, ddmFormFieldType, sortType, locale),
+			_getOrderByCol(
+				sortField, ddmFormFieldType, ddmFormFieldLocalizable, sortType,
+				locale),
 			!sortField.startsWith(
 				DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX),
 			orderByType);

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -931,6 +931,22 @@ public class AssetUtil {
 		return assetSearcher;
 	}
 
+	protected static boolean getDDMFormFieldLocalizable(String sortField)
+		throws PortalException {
+
+		String[] sortFields = sortField.split(
+			DDMStructureManager.STRUCTURE_INDEXER_FIELD_SEPARATOR);
+
+		long ddmStructureId = GetterUtil.getLong(sortFields[2]);
+		String fieldName = sortFields[3];
+
+		DDMStructure ddmStructure = DDMStructureManagerUtil.getStructure(
+			ddmStructureId);
+
+		return GetterUtil.getBoolean(
+			ddmStructure.getFieldProperty(fieldName, "localizable"));
+	}
+
 	protected static String getDDMFormFieldType(String sortField)
 		throws PortalException {
 
@@ -947,17 +963,21 @@ public class AssetUtil {
 	}
 
 	protected static String getOrderByCol(
-		String sortField, String fieldType, int sortType, Locale locale) {
+		String sortField, String fieldType, boolean fieldLocalizable,
+		int sortType, Locale locale) {
 
 		if (sortField.startsWith(
-				DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX)) {
+			DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX)) {
 
 			StringBundler sb = new StringBundler(5);
 
 			sb.append(sortField);
 			sb.append(StringPool.UNDERLINE);
-			sb.append(LocaleUtil.toLanguageId(locale));
-			sb.append(StringPool.UNDERLINE);
+
+			if (fieldLocalizable) {
+				sb.append(LocaleUtil.toLanguageId(locale));
+				sb.append(StringPool.UNDERLINE);
+			}
 
 			String suffix = "String";
 
@@ -984,14 +1004,23 @@ public class AssetUtil {
 		return sortField;
 	}
 
+	protected static String getOrderByCol(
+		String sortField, String fieldType, int sortType, Locale locale) {
+
+		return getOrderByCol(sortField, fieldType, true, sortType, locale);
+	}
+
 	protected static Sort getSort(
 			String orderByType, String sortField, Locale locale)
 		throws Exception {
 
+		boolean ddmFormFieldLocalizable = true;
 		String ddmFormFieldType = sortField;
 
 		if (ddmFormFieldType.startsWith(
 				DDMStructureManager.STRUCTURE_INDEXER_FIELD_PREFIX)) {
+
+			ddmFormFieldLocalizable = getDDMFormFieldLocalizable(sortField);
 
 			ddmFormFieldType = getDDMFormFieldType(ddmFormFieldType);
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -815,6 +815,14 @@ definition {
 			pageName = "Page Revision Page",
 			workflowStatus = "Pending (Review)");
 
+		Navigator.gotoStagedSitePage(
+			pageName = "Page Revision Page",
+			siteName = "Site Name");
+
+		Page.viewWithWorkflowPG(
+			pageName = "Page Revision Page",
+			workflowStatus = "Draft");
+
 		UserBar.gotoDropdownItem(dropdownItem = "My Workflow Tasks");
 
 		Workflow.approveTaskByActions(
@@ -822,9 +830,16 @@ definition {
 			workflowAssetType = "Page Revision",
 			workflowTask = "Review");
 
-		Navigator.gotoStagedSitePage(
-			pageName = "Page Revision Page",
-			siteName = "Site Name");
+		UserBar.gotoDropdownItem(dropdownItem = "My Workflow Tasks");
+
+		Workflow.viewCompletedTask(
+			workflowAssetTitle = "Page Revision Page",
+			workflowAssetType = "Page Revision",
+			workflowTask = "Review");
+
+		Workflow.gotoAssetViaTableTitle(workflowAssetTitle = "Page Revision Page");
+
+		Workflow.gotoPreviewView();
 
 		Page.viewWithWorkflowPG(
 			pageName = "Page Revision Page",


### PR DESCRIPTION
Hi @ealonso. 

This issue was reported by a customer. 

The solution makes sure that no locale references are included for structure fields that are not localizable. For that we have to modify how these entries are being indexed correctly via `DDMIndexerImpl`, and then making sure that the Asset Publisher is preparing the correct query (not including the locale reference if not needed). 

Please let me know if you have any questions. 

Thanks! 

/cc @dacousalr