### PR TITLE
[TECHNICAL SUPPORT] LPS-98890 Don't use default locale (en_US) in case language_id is not valid

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -499,7 +499,11 @@ public class JournalConverterImpl implements JournalConverter {
 				"language-id");
 
 			if (Validator.isNotNull(languageId)) {
-				locale = LocaleUtil.fromLanguageId(languageId);
+				locale = LocaleUtil.fromLanguageId(languageId, true, false);
+
+				if (locale == null) {
+					continue;
+				}
 
 				missingLanguageIds.remove(languageId);
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-98890

This is problematic in case a customer upgrades from 6.1 and older versions and customer ends with invalid language-id values, but it can also reproduced in case you do some changes in locale configuration

Reviewed with @dacousalr