### PR TITLE
[TS] LPS-99420 Make sure correct referenceElement is used

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LinksToLayoutsExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LinksToLayoutsExportImportContentProcessor.java
@@ -209,6 +209,13 @@ public class LinksToLayoutsExportImportContentProcessor
 						continue;
 					}
 
+					long plid = GetterUtil.getLong(
+						element.attributeValue("class-pk"));
+
+					if (oldPlid != plid) {
+						continue;
+					}
+
 					String uuid = element.attributeValue("uuid");
 					String privateLayout = element.attributeValue(
 						"private-layout");


### PR DESCRIPTION
Hi @ealonso ,

The issue is that if a structure has multiple link-to-page fields and a content based on this structure is published to live with all linked pages being missing references (single content publish for example) LinksToLayoutsExportImportContentProcessor will set the first available Layout typed missing reference for all fields.

Can you please review?
https://issues.liferay.com/browse/LPS-99420

Thanks,
Balázs