### PR TITLE
[TS] LPS-99231

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalValidatorImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalValidatorImpl.java
@@ -71,7 +71,10 @@ public final class JournalValidatorImpl implements JournalValidator {
 		throws FolderNameException {
 
 		if (!isValidName(folderName)) {
-			throw new FolderNameException(folderName);
+			throw new FolderNameException(
+				folderName +
+					" contains characters that are not allowed in web " +
+						"content folder names");
 		}
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalValidatorImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalValidatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.internal.util;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.exception.FolderNameException;
 import com.liferay.journal.util.JournalValidator;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
 import org.apache.commons.lang.StringEscapeUtils;
@@ -71,10 +73,24 @@ public final class JournalValidatorImpl implements JournalValidator {
 		throws FolderNameException {
 
 		if (!isValidName(folderName)) {
-			throw new FolderNameException(
-				folderName +
-					" contains characters that are not allowed in web " +
-						"content folder names");
+			String message =
+				" contains characters that are not allowed in web content " +
+					"folder names";
+
+			if (!ExportImportThreadLocal.isImportInProcess()) {
+				throw new FolderNameException(folderName + message);
+			}
+
+			if (_log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append("Imported folder with name: ");
+				sb.append(folderName);
+				sb.append(" that ");
+				sb.append(message);
+
+				_log.warn(sb.toString());
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi @ealonso 

The issue is: During a Staging publication JournalFolders with blacklisted chars in their names will fail their validation. Resulting in the folder not being available for their subfolders and contents as a valid parent folder on the live site.
I've had a discussion about the issue with Daniel Couso on https://issues.liferay.com/browse/PTR-1090 and also with Tamás Molnár. The outcome was that from user perspective, it would be best to not block the publication with a FolderNameException, and bypass the validation during Import time.


Can you please review?
https://issues.liferay.com/browse/LPS-99231

Thanks,
Balázs