### PR TITLE
[TECHNICAL-SUPPORT] LPS-99415 AssetDisplayPageEntry upgrade

### DIFF
--- a/modules/apps/journal/journal-service/build.gradle
+++ b/modules/apps/journal/journal-service/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
+	compileOnly group: "org.hibernate", name: "hibernate-core", version: "3.6.10.Final"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -16,6 +16,7 @@ package com.liferay.journal.internal.exportimport.data.handler;
 
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
+import com.liferay.asset.display.page.service.persistence.AssetDisplayPageEntryUtil;
 import com.liferay.changeset.model.ChangesetCollection;
 import com.liferay.changeset.service.ChangesetCollectionLocalService;
 import com.liferay.changeset.service.ChangesetEntryLocalService;
@@ -92,6 +93,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+
+import org.hibernate.exception.ConstraintViolationException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -1251,6 +1254,24 @@ public class JournalArticleStagedModelDataHandler
 		}
 	}
 
+	private void _deleteConflictingAssetDisplayPageEntryAndRetry(
+		AssetDisplayPageEntry assetDisplayPageEntry) {
+
+		AssetDisplayPageEntryUtil.clearCache(assetDisplayPageEntry);
+
+		AssetDisplayPageEntry conflictingAssetDisplayPageEntry =
+			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+				assetDisplayPageEntry.getGroupId(),
+				assetDisplayPageEntry.getClassNameId(),
+				assetDisplayPageEntry.getClassPK());
+
+		_assetDisplayPageEntryLocalService.deleteAssetDisplayPageEntry(
+			conflictingAssetDisplayPageEntry);
+
+		_assetDisplayPageEntryLocalService.updateAssetDisplayPageEntry(
+			assetDisplayPageEntry);
+	}
+
 	private void _exportAssetDisplayPage(
 			PortletDataContext portletDataContext, JournalArticle article)
 		throws PortletDataException {
@@ -1323,8 +1344,19 @@ public class JournalArticleStagedModelDataHandler
 				existingAssetDisplayPageEntry.setClassPK(
 					importedArticle.getResourcePrimKey());
 
-				_assetDisplayPageEntryLocalService.updateAssetDisplayPageEntry(
-					existingAssetDisplayPageEntry);
+				try {
+					_assetDisplayPageEntryLocalService.
+						updateAssetDisplayPageEntry(
+							existingAssetDisplayPageEntry);
+				}
+				catch (ConstraintViolationException cve) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(cve, cve);
+					}
+
+					_deleteConflictingAssetDisplayPageEntryAndRetry(
+						existingAssetDisplayPageEntry);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi @ealonso ,

This fixes the issue in two ways:
* Upgrade process will generate the same UUIDs for AssetDisplayPageEntry records in live and staging sites: https://github.com/ealonso/liferay-portal/commit/f6c54308fe30ac953d585ca333d7a56a04a19fea
* Actual import will handle the `ConstraintViolationException` and delete the wrong entry, which was created by the upgrade process : https://github.com/ealonso/liferay-portal/commit/1657e6869a6fc69c2b896ba1ab152188ec1d8168 . This will be executed only on the first publication, after that the UUIDs will match. This also solves the problem for remote staging (where it's impossible to generate the same UUIDs for the two distinct databases during upgrade).

Please review my changes.

Thanks,
Vendel