### PR TITLE
LPS-100328 Remove html tags before sending it to the Documents entity

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -9034,12 +9034,14 @@ public class JournalArticleLocalServiceImpl
 			journalArticleLocalization.setCompanyId(companyId);
 			journalArticleLocalization.setArticlePK(articlePK);
 			journalArticleLocalization.setTitle(title);
-			journalArticleLocalization.setDescription(description);
+			journalArticleLocalization.setDescription(
+				HtmlUtil.stripHtml(description));
 			journalArticleLocalization.setLanguageId(languageId);
 		}
 		else {
 			journalArticleLocalization.setTitle(title);
-			journalArticleLocalization.setDescription(description);
+			journalArticleLocalization.setDescription(
+				HtmlUtil.stripHtml(description));
 		}
 
 		return journalArticleLocalizationPersistence.update(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-100328

The issue is the data in summary field is stored as html data, but we should remove all html tags before sending it to the index, as it makes no sense for the final user to search html tags. My fix strips the summary field of its html tags before setting it as the article's localization. 