### PR TITLE
[TECHNICAL-SUPPORT] LPS-100082

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -41,6 +41,7 @@ import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.journal.configuration.JournalGroupServiceConfiguration;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.internal.exportimport.creation.strategy.JournalCreationStrategy;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleConstants;
@@ -74,6 +75,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -1228,13 +1230,6 @@ public class JournalArticleStagedModelDataHandler
 	}
 
 	@Reference(unbind = "-")
-	protected void setJournalGroupServiceConfiguration(
-		JournalGroupServiceConfiguration journalGroupServiceConfiguration) {
-
-		_journalGroupServiceConfiguration = journalGroupServiceConfiguration;
-	}
-
-	@Reference(unbind = "-")
 	protected void setUserLocalService(UserLocalService userLocalService) {
 		_userLocalService = userLocalService;
 	}
@@ -1411,11 +1406,19 @@ public class JournalArticleStagedModelDataHandler
 						(key, value) -> subscriptionSender.setContextAttribute(
 							key, value.get("originalValue")));
 
+					JournalGroupServiceConfiguration
+						journalGroupServiceConfiguration =
+							_configurationProvider.getConfiguration(
+								JournalGroupServiceConfiguration.class,
+								new GroupServiceSettingsLocator(
+									article.getGroupId(),
+									JournalConstants.SERVICE_NAME));
+
 					String fromAddress =
-						_journalGroupServiceConfiguration.emailFromAddress();
+						journalGroupServiceConfiguration.emailFromAddress();
 
 					String fromName =
-						_journalGroupServiceConfiguration.emailFromName();
+						journalGroupServiceConfiguration.emailFromName();
 
 					subscriptionSender.setFrom(fromAddress, fromName);
 
@@ -1530,7 +1533,6 @@ public class JournalArticleStagedModelDataHandler
 	private JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;
 	private JournalCreationStrategy _journalCreationStrategy;
-	private JournalGroupServiceConfiguration _journalGroupServiceConfiguration;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -1423,17 +1424,43 @@ public class JournalArticleStagedModelDataHandler
 					subscriptionSender.setFrom(fromAddress, fromName);
 
 					subscriptionSender.setHtmlFormat(true);
-					subscriptionSender.setLocalizedBodyMap(
+
+					Map<String, String> localizedJsonBodyMap =
 						(Map)JSONFactoryUtil.looseDeserialize(
 							jsonObject.get(
 								"localizedBodyMap"
-							).toString()));
+							).toString());
 
-					subscriptionSender.setLocalizedSubjectMap(
+					Map<Locale, String> localizedBodyMap = new HashMap<>();
+
+					for (Map.Entry<String, String> entry :
+							localizedJsonBodyMap.entrySet()) {
+
+						localizedBodyMap.put(
+							LocaleUtil.fromLanguageId(entry.getKey()),
+							entry.getValue());
+					}
+
+					subscriptionSender.setLocalizedBodyMap(localizedBodyMap);
+
+					Map<String, String> localizedJsonSubjectMap =
 						(Map)JSONFactoryUtil.looseDeserialize(
 							jsonObject.get(
 								"localizedSubjectMap"
-							).toString()));
+							).toString());
+
+					Map<Locale, String> localizedSubjectMap = new HashMap<>();
+
+					for (Map.Entry<String, String> entry :
+							localizedJsonSubjectMap.entrySet()) {
+
+						localizedSubjectMap.put(
+							LocaleUtil.fromLanguageId(entry.getKey()),
+							entry.getValue());
+					}
+
+					subscriptionSender.setLocalizedSubjectMap(
+						localizedSubjectMap);
 
 					subscriptionSender.setMailId(
 						"journal_article", article.getId());

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -50,6 +50,9 @@ import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -60,6 +63,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Image;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -68,6 +72,7 @@ import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.UserNotificationEventLocalServiceUtil;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -990,6 +995,8 @@ public class JournalArticleStagedModelDataHandler
 
 				_importAssetDisplayPage(
 					portletDataContext, article, importedArticle);
+
+				_sendStoredUserNotificationEvents(article);
 			}
 			finally {
 				ServiceContextThreadLocal.popServiceContext();
@@ -1340,6 +1347,46 @@ public class JournalArticleStagedModelDataHandler
 
 				_assetDisplayPageEntryLocalService.updateAssetDisplayPageEntry(
 					existingAssetDisplayPageEntry);
+			}
+		}
+	}
+
+	private void _sendStoredUserNotificationEvents(JournalArticle article) {
+		ActionableDynamicQuery actionableDynamicQuery =
+			UserNotificationEventLocalServiceUtil.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setCompanyId(article.getCompanyId());
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property delivered = PropertyFactoryUtil.forName("delivered");
+
+				dynamicQuery.add(delivered.eq(false));
+
+				Property payload = PropertyFactoryUtil.forName("payload");
+
+				dynamicQuery.add(
+					payload.like(
+						StringPool.PERCENT + article.getId() +
+							StringPool.PERCENT));
+			});
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(ActionableDynamicQuery.PerformActionMethod<UserNotificationEvent>)
+				userNotificationEvent -> {
+					userNotificationEvent.setDelivered(true);
+					UserNotificationEventLocalServiceUtil.
+						updateUserNotificationEvent(userNotificationEvent);
+				});
+
+		try {
+			actionableDynamicQuery.performActions();
+		}
+		catch (Exception e) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to send UserNotificationEvent for article " +
+						article.getArticleId());
 			}
 		}
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -39,6 +39,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.exportimport.kernel.staging.StagingConstants;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.journal.configuration.JournalGroupServiceConfiguration;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.internal.exportimport.creation.strategy.JournalCreationStrategy;
 import com.liferay.journal.model.JournalArticle;
@@ -72,7 +73,7 @@ import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.UserNotificationEventLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -82,6 +83,7 @@ import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StreamUtil;
+import com.liferay.portal.kernel.util.SubscriptionSender;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Element;
@@ -1226,6 +1228,13 @@ public class JournalArticleStagedModelDataHandler
 	}
 
 	@Reference(unbind = "-")
+	protected void setJournalGroupServiceConfiguration(
+		JournalGroupServiceConfiguration journalGroupServiceConfiguration) {
+
+		_journalGroupServiceConfiguration = journalGroupServiceConfiguration;
+	}
+
+	@Reference(unbind = "-")
 	protected void setUserLocalService(UserLocalService userLocalService) {
 		_userLocalService = userLocalService;
 	}
@@ -1353,7 +1362,7 @@ public class JournalArticleStagedModelDataHandler
 
 	private void _sendStoredUserNotificationEvents(JournalArticle article) {
 		ActionableDynamicQuery actionableDynamicQuery =
-			UserNotificationEventLocalServiceUtil.getActionableDynamicQuery();
+			_userNotificationEventLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setCompanyId(article.getCompanyId());
 
@@ -1375,8 +1384,73 @@ public class JournalArticleStagedModelDataHandler
 			(ActionableDynamicQuery.PerformActionMethod<UserNotificationEvent>)
 				userNotificationEvent -> {
 					userNotificationEvent.setDelivered(true);
-					UserNotificationEventLocalServiceUtil.
+
+					_userNotificationEventLocalService.
 						updateUserNotificationEvent(userNotificationEvent);
+
+					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+						userNotificationEvent.getPayload());
+
+					SubscriptionSender subscriptionSender =
+						new SubscriptionSender();
+
+					subscriptionSender.setClassName(
+						jsonObject.getString("className"));
+					subscriptionSender.setClassPK(
+						jsonObject.getLong("classPK"));
+					subscriptionSender.setCompanyId(
+						userNotificationEvent.getCompanyId());
+
+					Map<String, HashMap<String, Object>> contextMap =
+						(Map)JSONFactoryUtil.looseDeserialize(
+							jsonObject.get(
+								"context"
+							).toString());
+
+					contextMap.forEach(
+						(key, value) -> subscriptionSender.setContextAttribute(
+							key, value.get("originalValue")));
+
+					String fromAddress =
+						_journalGroupServiceConfiguration.emailFromAddress();
+
+					String fromName =
+						_journalGroupServiceConfiguration.emailFromName();
+
+					subscriptionSender.setFrom(fromAddress, fromName);
+
+					subscriptionSender.setHtmlFormat(true);
+					subscriptionSender.setLocalizedBodyMap(
+						(Map)JSONFactoryUtil.looseDeserialize(
+							jsonObject.get(
+								"localizedBodyMap"
+							).toString()));
+
+					subscriptionSender.setLocalizedSubjectMap(
+						(Map)JSONFactoryUtil.looseDeserialize(
+							jsonObject.get(
+								"localizedSubjectMap"
+							).toString()));
+
+					subscriptionSender.setMailId(
+						"journal_article", article.getId());
+					subscriptionSender.setNotificationType(
+						jsonObject.getInt("notificationType"));
+					subscriptionSender.setPortletId(
+						jsonObject.getString("portletId"));
+					subscriptionSender.setReplyToAddress(fromAddress);
+
+					try {
+						subscriptionSender.sendEmailNotification(
+							userNotificationEvent.getUserId());
+					}
+					catch (Exception e) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								"Unable to email UserNotificationEvent for " +
+									"article " + article.getArticleId());
+						}
+					}
 				});
 
 		try {
@@ -1456,10 +1530,15 @@ public class JournalArticleStagedModelDataHandler
 	private JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;
 	private JournalCreationStrategy _journalCreationStrategy;
+	private JournalGroupServiceConfiguration _journalGroupServiceConfiguration;
 
 	@Reference
 	private Portal _portal;
 
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private UserNotificationEventLocalService
+		_userNotificationEventLocalService;
 
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/base/JournalArticleLocalServiceBaseImpl.java
@@ -641,6 +641,9 @@ public abstract class JournalArticleLocalServiceBaseImpl
 		counterLocalService;
 
 	@Reference
+	protected com.liferay.exportimport.kernel.staging.Staging staging;
+
+	@Reference
 	protected com.liferay.portal.kernel.service.ClassNameLocalService
 		classNameLocalService;
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6952,7 +6952,12 @@ public class JournalArticleLocalServiceImpl
 			action = "move_from_trash";
 		}
 
-		notifySubscribers(user.getUserId(), article, action, serviceContext);
+		Group group = groupLocalService.getGroup(article.getGroupId());
+
+		if (!group.isStaged() || group.isStagingGroup()) {
+			notifySubscribers(
+				user.getUserId(), article, action, serviceContext);
+		}
 
 		return article;
 	}

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/control/menu/PersonalMenuProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/control/menu/PersonalMenuProductNavigationControlMenuEntry.java
@@ -75,9 +75,10 @@ public class PersonalMenuProductNavigationControlMenuEntry
 			httpServletRequest.setAttribute(
 				PersonalMenuWebKeys.NOTIFICATIONS_COUNT,
 				_userNotificationEventLocalService.
-					getArchivedUserNotificationEventsCount(
+					getUserNotificationEventsCount(
 						themeDisplay.getUserId(),
-						UserNotificationDeliveryConstants.TYPE_WEBSITE, false));
+						UserNotificationDeliveryConstants.TYPE_WEBSITE, true,
+						false));
 		}
 
 		return super.includeIcon(httpServletRequest, httpServletResponse);

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/internal/portlet/ProductNavigationUserPersonalBarPortlet.java
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/internal/portlet/ProductNavigationUserPersonalBarPortlet.java
@@ -92,9 +92,9 @@ public class ProductNavigationUserPersonalBarPortlet extends MVCPortlet {
 		}
 
 		return _userNotificationEventLocalService.
-			getArchivedUserNotificationEventsCount(
+			getUserNotificationEventsCount(
 				themeDisplay.getUserId(),
-				UserNotificationDeliveryConstants.TYPE_WEBSITE, false);
+				UserNotificationDeliveryConstants.TYPE_WEBSITE, true, false);
 	}
 
 	@Reference(unbind = "-")

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
@@ -274,6 +274,16 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
+	public void testCountByU_D_AR() throws Exception {
+		_persistence.countByU_D_AR(
+			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_D_AR(
+			0L, RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByU_D_A() throws Exception {
 		_persistence.countByU_D_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
@@ -284,12 +294,12 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
-	public void testCountByU_A_A() throws Exception {
-		_persistence.countByU_A_A(
+	public void testCountByU_AR_A() throws Exception {
+		_persistence.countByU_AR_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
 			RandomTestUtil.randomBoolean());
 
-		_persistence.countByU_A_A(
+		_persistence.countByU_AR_A(
 			0L, RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
 	}
 
@@ -307,6 +317,17 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
+	public void testCountByU_DT_D_AR() throws Exception {
+		_persistence.countByU_DT_D_AR(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_DT_D_AR(
+			0L, 0, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByU_DT_D_A() throws Exception {
 		_persistence.countByU_DT_D_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
@@ -318,14 +339,37 @@ public class UserNotificationEventPersistenceTest {
 	}
 
 	@Test
-	public void testCountByU_DT_A_A() throws Exception {
-		_persistence.countByU_DT_A_A(
+	public void testCountByU_DT_AR_A() throws Exception {
+		_persistence.countByU_DT_AR_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
 			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
 
-		_persistence.countByU_DT_A_A(
+		_persistence.countByU_DT_AR_A(
 			0L, 0, RandomTestUtil.randomBoolean(),
 			RandomTestUtil.randomBoolean());
+	}
+
+	@Test
+	public void testCountByU_D_AR_A() throws Exception {
+		_persistence.countByU_D_AR_A(
+			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_D_AR_A(
+			0L, RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+	}
+
+	@Test
+	public void testCountByU_DT_D_AR_A() throws Exception {
+		_persistence.countByU_DT_D_AR_A(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean());
+
+		_persistence.countByU_DT_D_AR_A(
+			0L, 0, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2992,12 +2992,17 @@
 			<finder-column name="deliveryType" />
 			<finder-column name="archived" />
 		</finder>
-		<finder name="U_D_A" return-type="Collection">
+		<finder name="U_D_AR" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="delivered" />
 			<finder-column name="actionRequired" />
 		</finder>
-		<finder name="U_A_A" return-type="Collection">
+		<finder name="U_D_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="delivered" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_AR_A" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="actionRequired" />
 			<finder-column name="archived" />
@@ -3008,15 +3013,34 @@
 			<finder-column name="deliveryType" />
 			<finder-column name="delivered" />
 		</finder>
-		<finder name="U_DT_D_A" return-type="Collection">
+		<finder name="U_DT_D_AR" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="deliveryType" />
 			<finder-column name="delivered" />
 			<finder-column name="actionRequired" />
 		</finder>
-		<finder name="U_DT_A_A" return-type="Collection">
+		<finder name="U_DT_D_A" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="deliveryType" />
+			<finder-column name="delivered" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_DT_AR_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="deliveryType" />
+			<finder-column name="actionRequired" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_D_AR_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="delivered" />
+			<finder-column name="actionRequired" />
+			<finder-column name="archived" />
+		</finder>
+		<finder name="U_DT_D_AR_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="deliveryType" />
+			<finder-column name="delivered" />
 			<finder-column name="actionRequired" />
 			<finder-column name="archived" />
 		</finder>

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -217,7 +217,7 @@ public class UserNotificationEventLocalServiceImpl
 	public List<UserNotificationEvent> getArchivedUserNotificationEvents(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return userNotificationEventPersistence.findByU_A_A(
+		return userNotificationEventPersistence.findByU_AR_A(
 			userId, actionRequired, archived);
 	}
 
@@ -226,7 +226,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end) {
 
-		return userNotificationEventPersistence.findByU_A_A(
+		return userNotificationEventPersistence.findByU_AR_A(
 			userId, actionRequired, archived, start, end);
 	}
 
@@ -251,7 +251,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return userNotificationEventPersistence.findByU_DT_A_A(
+		return userNotificationEventPersistence.findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 
@@ -260,7 +260,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end) {
 
-		return userNotificationEventPersistence.findByU_DT_A_A(
+		return userNotificationEventPersistence.findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end);
 	}
 
@@ -269,7 +269,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end, OrderByComparator<UserNotificationEvent> obc) {
 
-		return userNotificationEventPersistence.findByU_DT_A_A(
+		return userNotificationEventPersistence.findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end, obc);
 	}
 
@@ -292,7 +292,7 @@ public class UserNotificationEventLocalServiceImpl
 	public int getArchivedUserNotificationEventsCount(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return userNotificationEventPersistence.countByU_A_A(
+		return userNotificationEventPersistence.countByU_AR_A(
 			userId, actionRequired, archived);
 	}
 
@@ -309,7 +309,7 @@ public class UserNotificationEventLocalServiceImpl
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return userNotificationEventPersistence.countByU_DT_A_A(
+		return userNotificationEventPersistence.countByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
@@ -5153,9 +5153,9 @@ public class UserNotificationEventPersistenceImpl
 	private static final String _FINDER_COLUMN_U_DT_A_ARCHIVED_2 =
 		"userNotificationEvent.archived = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_D_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_D_A;
-	private FinderPath _finderPathCountByU_D_A;
+	private FinderPath _finderPathWithPaginationFindByU_D_AR;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_AR;
+	private FinderPath _finderPathCountByU_D_AR;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63;.
@@ -5166,10 +5166,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return findByU_D_A(
+		return findByU_D_AR(
 			userId, delivered, actionRequired, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -5189,11 +5189,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end) {
 
-		return findByU_D_A(userId, delivered, actionRequired, start, end, null);
+		return findByU_D_AR(
+			userId, delivered, actionRequired, start, end, null);
 	}
 
 	/**
@@ -5203,7 +5204,7 @@ public class UserNotificationEventPersistenceImpl
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_AR(long,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
@@ -5215,12 +5216,12 @@ public class UserNotificationEventPersistenceImpl
 	 */
 	@Deprecated
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return findByU_D_A(
+		return findByU_D_AR(
 			userId, delivered, actionRequired, start, end, orderByComparator);
 	}
 
@@ -5240,7 +5241,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_D_A(
+	public List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
@@ -5252,11 +5253,11 @@ public class UserNotificationEventPersistenceImpl
 			(orderByComparator == null)) {
 
 			pagination = false;
-			finderPath = _finderPathWithoutPaginationFindByU_D_A;
+			finderPath = _finderPathWithoutPaginationFindByU_D_AR;
 			finderArgs = new Object[] {userId, delivered, actionRequired};
 		}
 		else {
-			finderPath = _finderPathWithPaginationFindByU_D_A;
+			finderPath = _finderPathWithPaginationFindByU_D_AR;
 			finderArgs = new Object[] {
 				userId, delivered, actionRequired, start, end, orderByComparator
 			};
@@ -5293,11 +5294,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -5365,12 +5366,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_D_A_First(
+	public UserNotificationEvent findByU_D_AR_First(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_D_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_First(
 			userId, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -5405,11 +5406,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_D_A_First(
+	public UserNotificationEvent fetchByU_D_AR_First(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_D_A(
+		List<UserNotificationEvent> list = findByU_D_AR(
 			userId, delivered, actionRequired, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
@@ -5430,12 +5431,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_D_A_Last(
+	public UserNotificationEvent findByU_D_AR_Last(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_D_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_Last(
 			userId, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -5470,17 +5471,17 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_D_A_Last(
+	public UserNotificationEvent fetchByU_D_AR_Last(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_D_A(userId, delivered, actionRequired);
+		int count = countByU_D_AR(userId, delivered, actionRequired);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_D_A(
+		List<UserNotificationEvent> list = findByU_D_AR(
 			userId, delivered, actionRequired, count - 1, count,
 			orderByComparator);
 
@@ -5503,7 +5504,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -5519,13 +5520,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_D_A_PrevAndNext(
+			array[0] = getByU_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, delivered,
 				actionRequired, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_D_A_PrevAndNext(
+			array[2] = getByU_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, delivered,
 				actionRequired, orderByComparator, false);
 
@@ -5539,7 +5540,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_D_A_PrevAndNext(
+	protected UserNotificationEvent getByU_D_AR_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -5558,11 +5559,11 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_D_AR_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+		query.append(_FINDER_COLUMN_U_D_AR_DELIVERED_2);
 
-		query.append(_FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -5666,11 +5667,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @param actionRequired the action required
 	 */
 	@Override
-	public void removeByU_D_A(
+	public void removeByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_D_A(
+				findByU_D_AR(
 					userId, delivered, actionRequired, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
@@ -5687,10 +5688,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_D_A(
+	public int countByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		FinderPath finderPath = _finderPathCountByU_D_A;
+		FinderPath finderPath = _finderPathCountByU_D_AR;
 
 		Object[] finderArgs = new Object[] {userId, delivered, actionRequired};
 
@@ -5702,11 +5703,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2);
 
 			String sql = query.toString();
 
@@ -5742,18 +5743,611 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
+	private static final String _FINDER_COLUMN_U_D_AR_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_A;
+	private FinderPath _finderPathCountByU_D_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		return findByU_D_A(
+			userId, delivered, archived, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end) {
+
+		return findByU_D_A(userId, delivered, archived, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return findByU_D_A(
+			userId, delivered, archived, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+			finderPath = _finderPathWithoutPaginationFindByU_D_A;
+			finderArgs = new Object[] {userId, delivered, archived};
+		}
+		else {
+			finderPath = _finderPathWithPaginationFindByU_D_A;
+			finderArgs = new Object[] {
+				userId, delivered, archived, start, end, orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list =
+			(List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+		if ((list != null) && !list.isEmpty()) {
+			for (UserNotificationEvent userNotificationEvent : list) {
+				if ((userId != userNotificationEvent.getUserId()) ||
+					(delivered != userNotificationEvent.isDelivered()) ||
+					(archived != userNotificationEvent.isArchived())) {
+
+					list = null;
+
+					break;
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(5);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_A_First(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_A_First(
+			userId, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(8);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_A_First(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_D_A(
+			userId, delivered, archived, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_A_Last(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_A_Last(
+			userId, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(8);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_A_Last(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_D_A(userId, delivered, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_D_A(
+			userId, delivered, archived, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered, archived,
+				orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered, archived,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_D_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(5);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_D_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(delivered);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_D_A(
+					userId, delivered, archived, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_D_A(long userId, boolean delivered, boolean archived) {
+		FinderPath finderPath = _finderPathCountByU_D_A;
+
+		Object[] finderArgs = new Object[] {userId, delivered, archived};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(4);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
 	private static final String _FINDER_COLUMN_U_D_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
 	private static final String _FINDER_COLUMN_U_D_A_DELIVERED_2 =
 		"userNotificationEvent.delivered = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_D_A_ACTIONREQUIRED_2 =
-		"userNotificationEvent.actionRequired = ?";
+	private static final String _FINDER_COLUMN_U_D_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_A_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_A_A;
-	private FinderPath _finderPathCountByU_A_A;
+	private FinderPath _finderPathWithPaginationFindByU_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_AR_A;
+	private FinderPath _finderPathCountByU_AR_A;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -5764,10 +6358,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return findByU_A_A(
+		return findByU_AR_A(
 			userId, actionRequired, archived, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -5787,11 +6381,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end) {
 
-		return findByU_A_A(userId, actionRequired, archived, start, end, null);
+		return findByU_AR_A(userId, actionRequired, archived, start, end, null);
 	}
 
 	/**
@@ -5801,7 +6395,7 @@ public class UserNotificationEventPersistenceImpl
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_A_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_AR_A(long,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param actionRequired the action required
 	 * @param archived the archived
@@ -5813,12 +6407,12 @@ public class UserNotificationEventPersistenceImpl
 	 */
 	@Deprecated
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return findByU_A_A(
+		return findByU_AR_A(
 			userId, actionRequired, archived, start, end, orderByComparator);
 	}
 
@@ -5838,7 +6432,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_A_A(
+	public List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
@@ -5850,11 +6444,11 @@ public class UserNotificationEventPersistenceImpl
 			(orderByComparator == null)) {
 
 			pagination = false;
-			finderPath = _finderPathWithoutPaginationFindByU_A_A;
+			finderPath = _finderPathWithoutPaginationFindByU_AR_A;
 			finderArgs = new Object[] {userId, actionRequired, archived};
 		}
 		else {
-			finderPath = _finderPathWithPaginationFindByU_A_A;
+			finderPath = _finderPathWithPaginationFindByU_AR_A;
 			finderArgs = new Object[] {
 				userId, actionRequired, archived, start, end, orderByComparator
 			};
@@ -5891,11 +6485,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ARCHIVED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -5963,12 +6557,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_A_A_First(
+	public UserNotificationEvent findByU_AR_A_First(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_A_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_AR_A_First(
 			userId, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -6003,11 +6597,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_A_A_First(
+	public UserNotificationEvent fetchByU_AR_A_First(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_A_A(
+		List<UserNotificationEvent> list = findByU_AR_A(
 			userId, actionRequired, archived, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
@@ -6028,12 +6622,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_A_A_Last(
+	public UserNotificationEvent findByU_AR_A_Last(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_A_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_AR_A_Last(
 			userId, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -6068,17 +6662,17 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_A_A_Last(
+	public UserNotificationEvent fetchByU_AR_A_Last(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_A_A(userId, actionRequired, archived);
+		int count = countByU_AR_A(userId, actionRequired, archived);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_A_A(
+		List<UserNotificationEvent> list = findByU_AR_A(
 			userId, actionRequired, archived, count - 1, count,
 			orderByComparator);
 
@@ -6101,7 +6695,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -6117,13 +6711,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_A_A_PrevAndNext(
+			array[0] = getByU_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, actionRequired,
 				archived, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_A_A_PrevAndNext(
+			array[2] = getByU_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, actionRequired,
 				archived, orderByComparator, false);
 
@@ -6137,7 +6731,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_A_A_PrevAndNext(
+	protected UserNotificationEvent getByU_AR_A_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -6156,11 +6750,11 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_A_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_AR_A_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2);
 
-		query.append(_FINDER_COLUMN_U_A_A_ARCHIVED_2);
+		query.append(_FINDER_COLUMN_U_AR_A_ARCHIVED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -6264,11 +6858,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @param archived the archived
 	 */
 	@Override
-	public void removeByU_A_A(
+	public void removeByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_A_A(
+				findByU_AR_A(
 					userId, actionRequired, archived, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
@@ -6285,10 +6879,10 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_A_A(
+	public int countByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		FinderPath finderPath = _finderPathCountByU_A_A;
+		FinderPath finderPath = _finderPathCountByU_AR_A;
 
 		Object[] finderArgs = new Object[] {userId, actionRequired, archived};
 
@@ -6300,11 +6894,11 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_AR_A_ARCHIVED_2);
 
 			String sql = query.toString();
 
@@ -6340,13 +6934,13 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_U_A_A_USERID_2 =
+	private static final String _FINDER_COLUMN_U_AR_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_A_A_ACTIONREQUIRED_2 =
+	private static final String _FINDER_COLUMN_U_AR_A_ACTIONREQUIRED_2 =
 		"userNotificationEvent.actionRequired = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_A_A_ARCHIVED_2 =
+	private static final String _FINDER_COLUMN_U_AR_A_ARCHIVED_2 =
 		"userNotificationEvent.archived = ?";
 
 	private FinderPath _finderPathWithPaginationFindByU_T_DT_D;
@@ -7028,9 +7622,9 @@ public class UserNotificationEventPersistenceImpl
 	private static final String _FINDER_COLUMN_U_T_DT_D_DELIVERED_2 =
 		"userNotificationEvent.delivered = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_DT_D_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_A;
-	private FinderPath _finderPathCountByU_DT_D_A;
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_AR;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_AR;
+	private FinderPath _finderPathCountByU_DT_D_AR;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63;.
@@ -7042,11 +7636,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return findByU_DT_D_A(
+		return findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -7067,11 +7661,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end) {
 
-		return findByU_DT_D_A(
+		return findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end, null);
 	}
 
@@ -7082,7 +7676,7 @@ public class UserNotificationEventPersistenceImpl
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_AR(long,int,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param deliveryType the delivery type
 	 * @param delivered the delivered
@@ -7095,13 +7689,13 @@ public class UserNotificationEventPersistenceImpl
 	 */
 	@Deprecated
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return findByU_DT_D_A(
+		return findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end,
 			orderByComparator);
 	}
@@ -7123,7 +7717,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_D_A(
+	public List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
@@ -7136,13 +7730,13 @@ public class UserNotificationEventPersistenceImpl
 			(orderByComparator == null)) {
 
 			pagination = false;
-			finderPath = _finderPathWithoutPaginationFindByU_DT_D_A;
+			finderPath = _finderPathWithoutPaginationFindByU_DT_D_AR;
 			finderArgs = new Object[] {
 				userId, deliveryType, delivered, actionRequired
 			};
 		}
 		else {
-			finderPath = _finderPathWithPaginationFindByU_DT_D_A;
+			finderPath = _finderPathWithPaginationFindByU_DT_D_AR;
 			finderArgs = new Object[] {
 				userId, deliveryType, delivered, actionRequired, start, end,
 				orderByComparator
@@ -7181,13 +7775,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -7258,13 +7852,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_D_A_First(
+	public UserNotificationEvent findByU_DT_D_AR_First(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_First(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -7303,12 +7897,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_D_A_First(
+	public UserNotificationEvent fetchByU_DT_D_AR_First(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_DT_D_A(
+		List<UserNotificationEvent> list = findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, 0, 1,
 			orderByComparator);
 
@@ -7331,13 +7925,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_D_A_Last(
+	public UserNotificationEvent findByU_DT_D_AR_Last(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_Last(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -7376,19 +7970,19 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_D_A_Last(
+	public UserNotificationEvent fetchByU_DT_D_AR_Last(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_DT_D_A(
+		int count = countByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_DT_D_A(
+		List<UserNotificationEvent> list = findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, count - 1, count,
 			orderByComparator);
 
@@ -7412,7 +8006,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -7428,13 +8022,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_DT_D_A_PrevAndNext(
+			array[0] = getByU_DT_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType, delivered,
 				actionRequired, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_DT_D_A_PrevAndNext(
+			array[2] = getByU_DT_D_AR_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType, delivered,
 				actionRequired, orderByComparator, false);
 
@@ -7448,7 +8042,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_DT_D_A_PrevAndNext(
+	protected UserNotificationEvent getByU_DT_D_AR_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
@@ -7468,13 +8062,13 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERED_2);
 
-		query.append(_FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -7581,12 +8175,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @param actionRequired the action required
 	 */
 	@Override
-	public void removeByU_DT_D_A(
+	public void removeByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_DT_D_A(
+				findByU_DT_D_AR(
 					userId, deliveryType, delivered, actionRequired,
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
 
@@ -7604,11 +8198,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_DT_D_A(
+	public int countByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		FinderPath finderPath = _finderPathCountByU_DT_D_A;
+		FinderPath finderPath = _finderPathCountByU_DT_D_AR;
 
 		Object[] finderArgs = new Object[] {
 			userId, deliveryType, delivered, actionRequired
@@ -7622,13 +8216,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_DELIVERED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2);
 
 			String sql = query.toString();
 
@@ -7666,6 +8260,645 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
+	private static final String _FINDER_COLUMN_U_DT_D_AR_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_DELIVERYTYPE_2 =
+		"userNotificationEvent.deliveryType = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_A;
+	private FinderPath _finderPathCountByU_DT_D_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end) {
+
+		return findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+			finderPath = _finderPathWithoutPaginationFindByU_DT_D_A;
+			finderArgs = new Object[] {
+				userId, deliveryType, delivered, archived
+			};
+		}
+		else {
+			finderPath = _finderPathWithPaginationFindByU_DT_D_A;
+			finderArgs = new Object[] {
+				userId, deliveryType, delivered, archived, start, end,
+				orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list =
+			(List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+		if ((list != null) && !list.isEmpty()) {
+			for (UserNotificationEvent userNotificationEvent : list) {
+				if ((userId != userNotificationEvent.getUserId()) ||
+					(deliveryType != userNotificationEvent.getDeliveryType()) ||
+					(delivered != userNotificationEvent.isDelivered()) ||
+					(archived != userNotificationEvent.isArchived())) {
+
+					list = null;
+
+					break;
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					6 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(6);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_A_First(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_First(
+			userId, deliveryType, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_A_First(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_A_Last(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_A_Last(
+			userId, deliveryType, delivered, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_A_Last(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_DT_D_A(userId, deliveryType, delivered, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_DT_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				archived, orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_DT_D_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				archived, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_DT_D_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(6);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(deliveryType);
+
+		qPos.add(delivered);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_DT_D_A(
+					userId, deliveryType, delivered, archived,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		FinderPath finderPath = _finderPathCountByU_DT_D_A;
+
+		Object[] finderArgs = new Object[] {
+			userId, deliveryType, delivered, archived
+		};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(5);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
 	private static final String _FINDER_COLUMN_U_DT_D_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
@@ -7675,12 +8908,12 @@ public class UserNotificationEventPersistenceImpl
 	private static final String _FINDER_COLUMN_U_DT_D_A_DELIVERED_2 =
 		"userNotificationEvent.delivered = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_D_A_ACTIONREQUIRED_2 =
-		"userNotificationEvent.actionRequired = ?";
+	private static final String _FINDER_COLUMN_U_DT_D_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
 
-	private FinderPath _finderPathWithPaginationFindByU_DT_A_A;
-	private FinderPath _finderPathWithoutPaginationFindByU_DT_A_A;
-	private FinderPath _finderPathCountByU_DT_A_A;
+	private FinderPath _finderPathWithPaginationFindByU_DT_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_AR_A;
+	private FinderPath _finderPathCountByU_DT_AR_A;
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -7692,11 +8925,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return findByU_DT_A_A(
+		return findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -7717,11 +8950,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end) {
 
-		return findByU_DT_A_A(
+		return findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end, null);
 	}
 
@@ -7732,7 +8965,7 @@ public class UserNotificationEventPersistenceImpl
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_A_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_AR_A(long,int,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param deliveryType the delivery type
 	 * @param actionRequired the action required
@@ -7745,13 +8978,13 @@ public class UserNotificationEventPersistenceImpl
 	 */
 	@Deprecated
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return findByU_DT_A_A(
+		return findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end,
 			orderByComparator);
 	}
@@ -7773,7 +9006,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the ordered range of matching user notification events
 	 */
 	@Override
-	public List<UserNotificationEvent> findByU_DT_A_A(
+	public List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
@@ -7786,13 +9019,13 @@ public class UserNotificationEventPersistenceImpl
 			(orderByComparator == null)) {
 
 			pagination = false;
-			finderPath = _finderPathWithoutPaginationFindByU_DT_A_A;
+			finderPath = _finderPathWithoutPaginationFindByU_DT_AR_A;
 			finderArgs = new Object[] {
 				userId, deliveryType, actionRequired, archived
 			};
 		}
 		else {
-			finderPath = _finderPathWithPaginationFindByU_DT_A_A;
+			finderPath = _finderPathWithPaginationFindByU_DT_AR_A;
 			finderArgs = new Object[] {
 				userId, deliveryType, actionRequired, archived, start, end,
 				orderByComparator
@@ -7831,13 +9064,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2);
 
 			if (orderByComparator != null) {
 				appendOrderByComparator(
@@ -7908,13 +9141,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_A_A_First(
+	public UserNotificationEvent findByU_DT_AR_A_First(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_A_A_First(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_AR_A_First(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -7953,11 +9186,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_A_A_First(
+	public UserNotificationEvent fetchByU_DT_AR_A_First(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		List<UserNotificationEvent> list = findByU_DT_A_A(
+		List<UserNotificationEvent> list = findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, 0, 1,
 			orderByComparator);
 
@@ -7980,13 +9213,13 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent findByU_DT_A_A_Last(
+	public UserNotificationEvent findByU_DT_AR_A_Last(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException {
 
-		UserNotificationEvent userNotificationEvent = fetchByU_DT_A_A_Last(
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_AR_A_Last(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 
 		if (userNotificationEvent != null) {
@@ -8025,18 +9258,18 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
 	@Override
-	public UserNotificationEvent fetchByU_DT_A_A_Last(
+	public UserNotificationEvent fetchByU_DT_AR_A_Last(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		int count = countByU_DT_A_A(
+		int count = countByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<UserNotificationEvent> list = findByU_DT_A_A(
+		List<UserNotificationEvent> list = findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, count - 1, count,
 			orderByComparator);
 
@@ -8060,7 +9293,7 @@ public class UserNotificationEventPersistenceImpl
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
 	@Override
-	public UserNotificationEvent[] findByU_DT_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -8076,13 +9309,13 @@ public class UserNotificationEventPersistenceImpl
 
 			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
 
-			array[0] = getByU_DT_A_A_PrevAndNext(
+			array[0] = getByU_DT_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType,
 				actionRequired, archived, orderByComparator, true);
 
 			array[1] = userNotificationEvent;
 
-			array[2] = getByU_DT_A_A_PrevAndNext(
+			array[2] = getByU_DT_AR_A_PrevAndNext(
 				session, userNotificationEvent, userId, deliveryType,
 				actionRequired, archived, orderByComparator, false);
 
@@ -8096,7 +9329,7 @@ public class UserNotificationEventPersistenceImpl
 		}
 	}
 
-	protected UserNotificationEvent getByU_DT_A_A_PrevAndNext(
+	protected UserNotificationEvent getByU_DT_AR_A_PrevAndNext(
 		Session session, UserNotificationEvent userNotificationEvent,
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -8115,13 +9348,13 @@ public class UserNotificationEventPersistenceImpl
 
 		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_USERID_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_USERID_2);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2);
 
-		query.append(_FINDER_COLUMN_U_DT_A_A_ARCHIVED_2);
+		query.append(_FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -8228,12 +9461,12 @@ public class UserNotificationEventPersistenceImpl
 	 * @param archived the archived
 	 */
 	@Override
-	public void removeByU_DT_A_A(
+	public void removeByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
 		for (UserNotificationEvent userNotificationEvent :
-				findByU_DT_A_A(
+				findByU_DT_AR_A(
 					userId, deliveryType, actionRequired, archived,
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
 
@@ -8251,11 +9484,11 @@ public class UserNotificationEventPersistenceImpl
 	 * @return the number of matching user notification events
 	 */
 	@Override
-	public int countByU_DT_A_A(
+	public int countByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		FinderPath finderPath = _finderPathCountByU_DT_A_A;
+		FinderPath finderPath = _finderPathCountByU_DT_AR_A;
 
 		Object[] finderArgs = new Object[] {
 			userId, deliveryType, actionRequired, archived
@@ -8269,13 +9502,13 @@ public class UserNotificationEventPersistenceImpl
 
 			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_USERID_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_USERID_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2);
 
-			query.append(_FINDER_COLUMN_U_DT_A_A_ARCHIVED_2);
+			query.append(_FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2);
 
 			String sql = query.toString();
 
@@ -8313,16 +9546,1352 @@ public class UserNotificationEventPersistenceImpl
 		return count.intValue();
 	}
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_USERID_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_USERID_2 =
 		"userNotificationEvent.userId = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_DELIVERYTYPE_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_DELIVERYTYPE_2 =
 		"userNotificationEvent.deliveryType = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_ACTIONREQUIRED_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_ACTIONREQUIRED_2 =
 		"userNotificationEvent.actionRequired = ? AND ";
 
-	private static final String _FINDER_COLUMN_U_DT_A_A_ARCHIVED_2 =
+	private static final String _FINDER_COLUMN_U_DT_AR_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_D_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_D_AR_A;
+	private FinderPath _finderPathCountByU_D_AR_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		return findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end) {
+
+		return findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_AR_A(long,boolean,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+			finderPath = _finderPathWithoutPaginationFindByU_D_AR_A;
+			finderArgs = new Object[] {
+				userId, delivered, actionRequired, archived
+			};
+		}
+		else {
+			finderPath = _finderPathWithPaginationFindByU_D_AR_A;
+			finderArgs = new Object[] {
+				userId, delivered, actionRequired, archived, start, end,
+				orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list =
+			(List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+		if ((list != null) && !list.isEmpty()) {
+			for (UserNotificationEvent userNotificationEvent : list) {
+				if ((userId != userNotificationEvent.getUserId()) ||
+					(delivered != userNotificationEvent.isDelivered()) ||
+					(actionRequired !=
+						userNotificationEvent.isActionRequired()) ||
+					(archived != userNotificationEvent.isArchived())) {
+
+					list = null;
+
+					break;
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					6 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(6);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_AR_A_First(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_A_First(
+			userId, delivered, actionRequired, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_AR_A_First(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, 0, 1,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_D_AR_A_Last(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_D_AR_A_Last(
+			userId, delivered, actionRequired, archived, orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_D_AR_A_Last(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered,
+				actionRequired, archived, orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, delivered,
+				actionRequired, archived, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_D_AR_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(6);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2);
+
+		query.append(_FINDER_COLUMN_U_D_AR_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(delivered);
+
+		qPos.add(actionRequired);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_D_AR_A(
+					userId, delivered, actionRequired, archived,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		FinderPath finderPath = _finderPathCountByU_D_AR_A;
+
+		Object[] finderArgs = new Object[] {
+			userId, delivered, actionRequired, archived
+		};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(5);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_D_AR_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_D_AR_A_ARCHIVED_2 =
+		"userNotificationEvent.archived = ?";
+
+	private FinderPath _finderPathWithPaginationFindByU_DT_D_AR_A;
+	private FinderPath _finderPathWithoutPaginationFindByU_DT_D_AR_A;
+	private FinderPath _finderPathCountByU_DT_D_AR_A;
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end) {
+
+		return findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_AR_A(long,int,boolean,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	@Override
+	public List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			pagination = false;
+			finderPath = _finderPathWithoutPaginationFindByU_DT_D_AR_A;
+			finderArgs = new Object[] {
+				userId, deliveryType, delivered, actionRequired, archived
+			};
+		}
+		else {
+			finderPath = _finderPathWithPaginationFindByU_DT_D_AR_A;
+			finderArgs = new Object[] {
+				userId, deliveryType, delivered, actionRequired, archived,
+				start, end, orderByComparator
+			};
+		}
+
+		List<UserNotificationEvent> list =
+			(List<UserNotificationEvent>)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+		if ((list != null) && !list.isEmpty()) {
+			for (UserNotificationEvent userNotificationEvent : list) {
+				if ((userId != userNotificationEvent.getUserId()) ||
+					(deliveryType != userNotificationEvent.getDeliveryType()) ||
+					(delivered != userNotificationEvent.isDelivered()) ||
+					(actionRequired !=
+						userNotificationEvent.isActionRequired()) ||
+					(archived != userNotificationEvent.isArchived())) {
+
+					list = null;
+
+					break;
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(
+					7 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(7);
+			}
+
+			query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					query, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else if (pagination) {
+				query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				if (!pagination) {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<UserNotificationEvent>)QueryUtil.list(
+						q, getDialect(), start, end);
+				}
+
+				cacheResult(list);
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_AR_A_First(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_A_First(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(12);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_AR_A_First(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		List<UserNotificationEvent> list = findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, 0, 1,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent findByU_DT_D_AR_A_Last(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = fetchByU_DT_D_AR_A_Last(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+
+		if (userNotificationEvent != null) {
+			return userNotificationEvent;
+		}
+
+		StringBundler msg = new StringBundler(12);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("userId=");
+		msg.append(userId);
+
+		msg.append(", deliveryType=");
+		msg.append(deliveryType);
+
+		msg.append(", delivered=");
+		msg.append(delivered);
+
+		msg.append(", actionRequired=");
+		msg.append(actionRequired);
+
+		msg.append(", archived=");
+		msg.append(archived);
+
+		msg.append("}");
+
+		throw new NoSuchUserNotificationEventException(msg.toString());
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	@Override
+	public UserNotificationEvent fetchByU_DT_D_AR_A_Last(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		int count = countByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<UserNotificationEvent> list = findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived,
+			count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	@Override
+	public UserNotificationEvent[] findByU_DT_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException {
+
+		UserNotificationEvent userNotificationEvent = findByPrimaryKey(
+			userNotificationEventId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			UserNotificationEvent[] array = new UserNotificationEventImpl[3];
+
+			array[0] = getByU_DT_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				actionRequired, archived, orderByComparator, true);
+
+			array[1] = userNotificationEvent;
+
+			array[2] = getByU_DT_D_AR_A_PrevAndNext(
+				session, userNotificationEvent, userId, deliveryType, delivered,
+				actionRequired, archived, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected UserNotificationEvent getByU_DT_D_AR_A_PrevAndNext(
+		Session session, UserNotificationEvent userNotificationEvent,
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean previous) {
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(
+				8 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(7);
+		}
+
+		query.append(_SQL_SELECT_USERNOTIFICATIONEVENT_WHERE);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_USERID_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2);
+
+		query.append(_FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(UserNotificationEventModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(userId);
+
+		qPos.add(deliveryType);
+
+		qPos.add(delivered);
+
+		qPos.add(actionRequired);
+
+		qPos.add(archived);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						userNotificationEvent)) {
+
+				qPos.add(orderByConditionValue);
+			}
+		}
+
+		List<UserNotificationEvent> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	@Override
+	public void removeByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		for (UserNotificationEvent userNotificationEvent :
+				findByU_DT_D_AR_A(
+					userId, deliveryType, delivered, actionRequired, archived,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(userNotificationEvent);
+		}
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	@Override
+	public int countByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		FinderPath finderPath = _finderPathCountByU_DT_D_AR_A;
+
+		Object[] finderArgs = new Object[] {
+			userId, deliveryType, delivered, actionRequired, archived
+		};
+
+		Long count = (Long)FinderCacheUtil.getResult(
+			finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(6);
+
+			query.append(_SQL_COUNT_USERNOTIFICATIONEVENT_WHERE);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_USERID_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2);
+
+			query.append(_FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(userId);
+
+				qPos.add(deliveryType);
+
+				qPos.add(delivered);
+
+				qPos.add(actionRequired);
+
+				qPos.add(archived);
+
+				count = (Long)q.uniqueResult();
+
+				FinderCacheUtil.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				FinderCacheUtil.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_USERID_2 =
+		"userNotificationEvent.userId = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_DELIVERYTYPE_2 =
+		"userNotificationEvent.deliveryType = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_DELIVERED_2 =
+		"userNotificationEvent.delivered = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_ACTIONREQUIRED_2 =
+		"userNotificationEvent.actionRequired = ? AND ";
+
+	private static final String _FINDER_COLUMN_U_DT_D_AR_A_ARCHIVED_2 =
 		"userNotificationEvent.archived = ?";
 
 	public UserNotificationEventPersistenceImpl() {
@@ -8687,6 +11256,16 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isActionRequired()
 			};
 
+			FinderCacheUtil.removeResult(_finderPathCountByU_D_AR, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_D_AR, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
 			FinderCacheUtil.removeResult(_finderPathCountByU_D_A, args);
 			FinderCacheUtil.removeResult(
 				_finderPathWithoutPaginationFindByU_D_A, args);
@@ -8697,9 +11276,9 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isArchived()
 			};
 
-			FinderCacheUtil.removeResult(_finderPathCountByU_A_A, args);
+			FinderCacheUtil.removeResult(_finderPathCountByU_AR_A, args);
 			FinderCacheUtil.removeResult(
-				_finderPathWithoutPaginationFindByU_A_A, args);
+				_finderPathWithoutPaginationFindByU_AR_A, args);
 
 			args = new Object[] {
 				userNotificationEventModelImpl.getUserId(),
@@ -8719,6 +11298,17 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isActionRequired()
 			};
 
+			FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_DT_D_AR, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.getDeliveryType(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
 			FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_A, args);
 			FinderCacheUtil.removeResult(
 				_finderPathWithoutPaginationFindByU_DT_D_A, args);
@@ -8730,9 +11320,32 @@ public class UserNotificationEventPersistenceImpl
 				userNotificationEventModelImpl.isArchived()
 			};
 
-			FinderCacheUtil.removeResult(_finderPathCountByU_DT_A_A, args);
+			FinderCacheUtil.removeResult(_finderPathCountByU_DT_AR_A, args);
 			FinderCacheUtil.removeResult(
-				_finderPathWithoutPaginationFindByU_DT_A_A, args);
+				_finderPathWithoutPaginationFindByU_DT_AR_A, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isActionRequired(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
+			FinderCacheUtil.removeResult(_finderPathCountByU_D_AR_A, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_D_AR_A, args);
+
+			args = new Object[] {
+				userNotificationEventModelImpl.getUserId(),
+				userNotificationEventModelImpl.getDeliveryType(),
+				userNotificationEventModelImpl.isDelivered(),
+				userNotificationEventModelImpl.isActionRequired(),
+				userNotificationEventModelImpl.isArchived()
+			};
+
+			FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR_A, args);
+			FinderCacheUtil.removeResult(
+				_finderPathWithoutPaginationFindByU_DT_D_AR_A, args);
 
 			FinderCacheUtil.removeResult(
 				_finderPathCountAll, FINDER_ARGS_EMPTY);
@@ -8942,13 +11555,38 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_D_A.getColumnBitmask()) !=
+				 _finderPathWithoutPaginationFindByU_D_AR.getColumnBitmask()) !=
 					 0) {
 
 				Object[] args = new Object[] {
 					userNotificationEventModelImpl.getOriginalUserId(),
 					userNotificationEventModelImpl.getOriginalDelivered(),
 					userNotificationEventModelImpl.getOriginalActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_D_A.getColumnBitmask()) !=
+					 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_D_A, args);
@@ -8958,7 +11596,7 @@ public class UserNotificationEventPersistenceImpl
 				args = new Object[] {
 					userNotificationEventModelImpl.getUserId(),
 					userNotificationEventModelImpl.isDelivered(),
-					userNotificationEventModelImpl.isActionRequired()
+					userNotificationEventModelImpl.isArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_D_A, args);
@@ -8967,7 +11605,7 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_A_A.getColumnBitmask()) !=
+				 _finderPathWithoutPaginationFindByU_AR_A.getColumnBitmask()) !=
 					 0) {
 
 				Object[] args = new Object[] {
@@ -8976,9 +11614,9 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_A_A, args);
+					_finderPathWithoutPaginationFindByU_AR_A, args);
 
 				args = new Object[] {
 					userNotificationEventModelImpl.getUserId(),
@@ -8986,9 +11624,9 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.isArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_A_A, args);
+					_finderPathWithoutPaginationFindByU_AR_A, args);
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
@@ -9019,7 +11657,7 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_DT_D_A.
+				 _finderPathWithoutPaginationFindByU_DT_D_AR.
 					 getColumnBitmask()) != 0) {
 
 				Object[] args = new Object[] {
@@ -9027,6 +11665,33 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getOriginalDeliveryType(),
 					userNotificationEventModelImpl.getOriginalDelivered(),
 					userNotificationEventModelImpl.getOriginalActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.getDeliveryType(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_AR, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_DT_D_A.
+					 getColumnBitmask()) != 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDeliveryType(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_A, args);
@@ -9037,7 +11702,7 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getUserId(),
 					userNotificationEventModelImpl.getDeliveryType(),
 					userNotificationEventModelImpl.isDelivered(),
-					userNotificationEventModelImpl.isActionRequired()
+					userNotificationEventModelImpl.isArchived()
 				};
 
 				FinderCacheUtil.removeResult(_finderPathCountByU_DT_D_A, args);
@@ -9046,7 +11711,7 @@ public class UserNotificationEventPersistenceImpl
 			}
 
 			if ((userNotificationEventModelImpl.getColumnBitmask() &
-				 _finderPathWithoutPaginationFindByU_DT_A_A.
+				 _finderPathWithoutPaginationFindByU_DT_AR_A.
 					 getColumnBitmask()) != 0) {
 
 				Object[] args = new Object[] {
@@ -9056,9 +11721,9 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.getOriginalArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_DT_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_DT_A_A, args);
+					_finderPathWithoutPaginationFindByU_DT_AR_A, args);
 
 				args = new Object[] {
 					userNotificationEventModelImpl.getUserId(),
@@ -9067,9 +11732,67 @@ public class UserNotificationEventPersistenceImpl
 					userNotificationEventModelImpl.isArchived()
 				};
 
-				FinderCacheUtil.removeResult(_finderPathCountByU_DT_A_A, args);
+				FinderCacheUtil.removeResult(_finderPathCountByU_DT_AR_A, args);
 				FinderCacheUtil.removeResult(
-					_finderPathWithoutPaginationFindByU_DT_A_A, args);
+					_finderPathWithoutPaginationFindByU_DT_AR_A, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_D_AR_A.
+					 getColumnBitmask()) != 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalActionRequired(),
+					userNotificationEventModelImpl.getOriginalArchived()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR_A, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired(),
+					userNotificationEventModelImpl.isArchived()
+				};
+
+				FinderCacheUtil.removeResult(_finderPathCountByU_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_D_AR_A, args);
+			}
+
+			if ((userNotificationEventModelImpl.getColumnBitmask() &
+				 _finderPathWithoutPaginationFindByU_DT_D_AR_A.
+					 getColumnBitmask()) != 0) {
+
+				Object[] args = new Object[] {
+					userNotificationEventModelImpl.getOriginalUserId(),
+					userNotificationEventModelImpl.getOriginalDeliveryType(),
+					userNotificationEventModelImpl.getOriginalDelivered(),
+					userNotificationEventModelImpl.getOriginalActionRequired(),
+					userNotificationEventModelImpl.getOriginalArchived()
+				};
+
+				FinderCacheUtil.removeResult(
+					_finderPathCountByU_DT_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR_A, args);
+
+				args = new Object[] {
+					userNotificationEventModelImpl.getUserId(),
+					userNotificationEventModelImpl.getDeliveryType(),
+					userNotificationEventModelImpl.isDelivered(),
+					userNotificationEventModelImpl.isActionRequired(),
+					userNotificationEventModelImpl.isArchived()
+				};
+
+				FinderCacheUtil.removeResult(
+					_finderPathCountByU_DT_D_AR_A, args);
+				FinderCacheUtil.removeResult(
+					_finderPathWithoutPaginationFindByU_DT_D_AR_A, args);
 			}
 		}
 
@@ -9632,6 +12355,40 @@ public class UserNotificationEventPersistenceImpl
 				Boolean.class.getName()
 			});
 
+		_finderPathWithPaginationFindByU_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_AR",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			});
+
 		_finderPathWithPaginationFindByU_D_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
@@ -9654,7 +12411,7 @@ public class UserNotificationEventPersistenceImpl
 			},
 			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
-			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
 		_finderPathCountByU_D_A = new FinderPath(
@@ -9666,22 +12423,22 @@ public class UserNotificationEventPersistenceImpl
 				Boolean.class.getName()
 			});
 
-		_finderPathWithPaginationFindByU_A_A = new FinderPath(
+		_finderPathWithPaginationFindByU_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_A_A",
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_AR_A",
 			new String[] {
 				Long.class.getName(), Boolean.class.getName(),
 				Boolean.class.getName(), Integer.class.getName(),
 				Integer.class.getName(), OrderByComparator.class.getName()
 			});
 
-		_finderPathWithoutPaginationFindByU_A_A = new FinderPath(
+		_finderPathWithoutPaginationFindByU_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_AR_A",
 			new String[] {
 				Long.class.getName(), Boolean.class.getName(),
 				Boolean.class.getName()
@@ -9691,10 +12448,10 @@ public class UserNotificationEventPersistenceImpl
 			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
-		_finderPathCountByU_A_A = new FinderPath(
+		_finderPathCountByU_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_AR_A",
 			new String[] {
 				Long.class.getName(), Boolean.class.getName(),
 				Boolean.class.getName()
@@ -9736,6 +12493,42 @@ public class UserNotificationEventPersistenceImpl
 				Integer.class.getName(), Boolean.class.getName()
 			});
 
+		_finderPathWithPaginationFindByU_DT_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_DT_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERYTYPE_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_DT_D_AR = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D_AR",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			});
+
 		_finderPathWithPaginationFindByU_DT_D_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
@@ -9760,7 +12553,7 @@ public class UserNotificationEventPersistenceImpl
 			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.DELIVERYTYPE_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
-			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
 		_finderPathCountByU_DT_D_A = new FinderPath(
@@ -9772,11 +12565,11 @@ public class UserNotificationEventPersistenceImpl
 				Boolean.class.getName(), Boolean.class.getName()
 			});
 
-		_finderPathWithPaginationFindByU_DT_A_A = new FinderPath(
+		_finderPathWithPaginationFindByU_DT_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_A_A",
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_AR_A",
 			new String[] {
 				Long.class.getName(), Integer.class.getName(),
 				Boolean.class.getName(), Boolean.class.getName(),
@@ -9784,11 +12577,11 @@ public class UserNotificationEventPersistenceImpl
 				OrderByComparator.class.getName()
 			});
 
-		_finderPathWithoutPaginationFindByU_DT_A_A = new FinderPath(
+		_finderPathWithoutPaginationFindByU_DT_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
 			UserNotificationEventImpl.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_AR_A",
 			new String[] {
 				Long.class.getName(), Integer.class.getName(),
 				Boolean.class.getName(), Boolean.class.getName()
@@ -9799,13 +12592,88 @@ public class UserNotificationEventPersistenceImpl
 			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
 			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
 
-		_finderPathCountByU_DT_A_A = new FinderPath(
+		_finderPathCountByU_DT_AR_A = new FinderPath(
 			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
 			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_A_A",
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_AR_A",
 			new String[] {
 				Long.class.getName(), Integer.class.getName(),
 				Boolean.class.getName(), Boolean.class.getName()
+			});
+
+		_finderPathWithPaginationFindByU_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_D_AR_A",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName()
+			});
+
+		_finderPathWithPaginationFindByU_DT_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			});
+
+		_finderPathWithoutPaginationFindByU_DT_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED,
+			UserNotificationEventImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
+			},
+			UserNotificationEventModelImpl.USERID_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERYTYPE_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.DELIVERED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ACTIONREQUIRED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.ARCHIVED_COLUMN_BITMASK |
+			UserNotificationEventModelImpl.TIMESTAMP_COLUMN_BITMASK);
+
+		_finderPathCountByU_DT_D_AR_A = new FinderPath(
+			UserNotificationEventModelImpl.ENTITY_CACHE_ENABLED,
+			UserNotificationEventModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByU_DT_D_AR_A",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Boolean.class.getName(), Boolean.class.getName(),
+				Boolean.class.getName()
 			});
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
@@ -62,12 +62,24 @@ public interface UserNotificationEventLocalService
 	 * Never modify or reference this interface directly. Always use {@link UserNotificationEventLocalServiceUtil} to access the user notification event local service. Add custom service methods to <code>com.liferay.portal.service.impl.UserNotificationEventLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
 	public UserNotificationEvent addUserNotificationEvent(
+			long userId, boolean delivered, boolean actionRequired,
+			NotificationEvent notificationEvent)
+		throws PortalException;
+
+	public UserNotificationEvent addUserNotificationEvent(
 			long userId, boolean actionRequired,
 			NotificationEvent notificationEvent)
 		throws PortalException;
 
 	public UserNotificationEvent addUserNotificationEvent(
 			long userId, NotificationEvent notificationEvent)
+		throws PortalException;
+
+	public UserNotificationEvent addUserNotificationEvent(
+			long userId, String type, long timestamp, int deliveryType,
+			long deliverBy, boolean delivered, String payload,
+			boolean actionRequired, boolean archived,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public UserNotificationEvent addUserNotificationEvent(
@@ -434,6 +446,10 @@ public interface UserNotificationEventLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getUserNotificationEventsCount(
 		long userId, String type, int deliveryType, boolean archived);
 
 	public UserNotificationEvent sendUserNotificationEvents(
@@ -444,6 +460,11 @@ public interface UserNotificationEventLocalService
 	public UserNotificationEvent sendUserNotificationEvents(
 			long userId, String portletId, int deliveryType,
 			JSONObject notificationEventJSONObject)
+		throws PortalException;
+
+	public UserNotificationEvent storeUserNotificationEvents(
+			long userId, String portletId, int deliveryType,
+			boolean actionRequired, JSONObject notificationEventJSONObject)
 		throws PortalException;
 
 	public UserNotificationEvent updateUserNotificationEvent(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
@@ -40,6 +40,17 @@ public class UserNotificationEventLocalServiceUtil {
 	 */
 	public static com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(
+				long userId, boolean delivered, boolean actionRequired,
+				com.liferay.portal.kernel.notifications.NotificationEvent
+					notificationEvent)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addUserNotificationEvent(
+			userId, delivered, actionRequired, notificationEvent);
+	}
+
+	public static com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
 				long userId, boolean actionRequired,
 				com.liferay.portal.kernel.notifications.NotificationEvent
 					notificationEvent)
@@ -57,6 +68,19 @@ public class UserNotificationEventLocalServiceUtil {
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().addUserNotificationEvent(userId, notificationEvent);
+	}
+
+	public static com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
+				long userId, String type, long timestamp, int deliveryType,
+				long deliverBy, boolean delivered, String payload,
+				boolean actionRequired, boolean archived,
+				ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addUserNotificationEvent(
+			userId, type, timestamp, deliveryType, deliverBy, delivered,
+			payload, actionRequired, archived, serviceContext);
 	}
 
 	public static com.liferay.portal.kernel.model.UserNotificationEvent
@@ -662,6 +686,13 @@ public class UserNotificationEventLocalServiceUtil {
 	}
 
 	public static int getUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return getService().getUserNotificationEventsCount(
+			userId, deliveryType, delivered, archived);
+	}
+
+	public static int getUserNotificationEventsCount(
 		long userId, String type, int deliveryType, boolean archived) {
 
 		return getService().getUserNotificationEventsCount(
@@ -690,6 +721,19 @@ public class UserNotificationEventLocalServiceUtil {
 
 		return getService().sendUserNotificationEvents(
 			userId, portletId, deliveryType, notificationEventJSONObject);
+	}
+
+	public static com.liferay.portal.kernel.model.UserNotificationEvent
+			storeUserNotificationEvents(
+				long userId, String portletId, int deliveryType,
+				boolean actionRequired,
+				com.liferay.portal.kernel.json.JSONObject
+					notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().storeUserNotificationEvents(
+			userId, portletId, deliveryType, actionRequired,
+			notificationEventJSONObject);
 	}
 
 	public static com.liferay.portal.kernel.model.UserNotificationEvent

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
@@ -37,6 +37,18 @@ public class UserNotificationEventLocalServiceWrapper
 	@Override
 	public com.liferay.portal.kernel.model.UserNotificationEvent
 			addUserNotificationEvent(
+				long userId, boolean delivered, boolean actionRequired,
+				com.liferay.portal.kernel.notifications.NotificationEvent
+					notificationEvent)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userNotificationEventLocalService.addUserNotificationEvent(
+			userId, delivered, actionRequired, notificationEvent);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
 				long userId, boolean actionRequired,
 				com.liferay.portal.kernel.notifications.NotificationEvent
 					notificationEvent)
@@ -56,6 +68,20 @@ public class UserNotificationEventLocalServiceWrapper
 
 		return _userNotificationEventLocalService.addUserNotificationEvent(
 			userId, notificationEvent);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.UserNotificationEvent
+			addUserNotificationEvent(
+				long userId, String type, long timestamp, int deliveryType,
+				long deliverBy, boolean delivered, String payload,
+				boolean actionRequired, boolean archived,
+				ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userNotificationEventLocalService.addUserNotificationEvent(
+			userId, type, timestamp, deliveryType, deliverBy, delivered,
+			payload, actionRequired, archived, serviceContext);
 	}
 
 	@Override
@@ -727,6 +753,15 @@ public class UserNotificationEventLocalServiceWrapper
 
 	@Override
 	public int getUserNotificationEventsCount(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return _userNotificationEventLocalService.
+			getUserNotificationEventsCount(
+				userId, deliveryType, delivered, archived);
+	}
+
+	@Override
+	public int getUserNotificationEventsCount(
 		long userId, String type, int deliveryType, boolean archived) {
 
 		return _userNotificationEventLocalService.
@@ -758,6 +793,20 @@ public class UserNotificationEventLocalServiceWrapper
 
 		return _userNotificationEventLocalService.sendUserNotificationEvents(
 			userId, portletId, deliveryType, notificationEventJSONObject);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.UserNotificationEvent
+			storeUserNotificationEvents(
+				long userId, String portletId, int deliveryType,
+				boolean actionRequired,
+				com.liferay.portal.kernel.json.JSONObject
+					notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _userNotificationEventLocalService.storeUserNotificationEvents(
+			userId, portletId, deliveryType, actionRequired,
+			notificationEventJSONObject);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventPersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventPersistence.java
@@ -1388,7 +1388,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired);
 
 	/**
@@ -1405,7 +1405,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end);
 
@@ -1416,7 +1416,7 @@ public interface UserNotificationEventPersistence
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_AR(long,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
@@ -1427,7 +1427,7 @@ public interface UserNotificationEventPersistence
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache);
@@ -1447,7 +1447,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_D_A(
+	public java.util.List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -1461,7 +1461,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_D_A_First(
+	public UserNotificationEvent findByU_D_AR_First(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException;
@@ -1475,7 +1475,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_D_A_First(
+	public UserNotificationEvent fetchByU_D_AR_First(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -1489,7 +1489,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_D_A_Last(
+	public UserNotificationEvent findByU_D_AR_Last(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException;
@@ -1503,7 +1503,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_D_A_Last(
+	public UserNotificationEvent fetchByU_D_AR_Last(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -1518,7 +1518,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -1531,7 +1531,7 @@ public interface UserNotificationEventPersistence
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public void removeByU_D_A(
+	public void removeByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired);
 
 	/**
@@ -1542,8 +1542,170 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_D_A(
+	public int countByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_A_First(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_A_First(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_A_Last(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_A_Last(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public void removeByU_D_A(long userId, boolean delivered, boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_D_A(long userId, boolean delivered, boolean archived);
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -1553,7 +1715,7 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived);
 
 	/**
@@ -1570,7 +1732,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end);
 
@@ -1581,7 +1743,7 @@ public interface UserNotificationEventPersistence
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_A_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_AR_A(long,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param actionRequired the action required
 	 * @param archived the archived
@@ -1592,7 +1754,7 @@ public interface UserNotificationEventPersistence
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache);
@@ -1612,7 +1774,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_A_A(
+	public java.util.List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -1626,7 +1788,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_A_A_First(
+	public UserNotificationEvent findByU_AR_A_First(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException;
@@ -1640,7 +1802,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_A_A_First(
+	public UserNotificationEvent fetchByU_AR_A_First(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -1654,7 +1816,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_A_A_Last(
+	public UserNotificationEvent findByU_AR_A_Last(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws NoSuchUserNotificationEventException;
@@ -1668,7 +1830,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_A_A_Last(
+	public UserNotificationEvent fetchByU_AR_A_Last(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -1683,7 +1845,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -1696,7 +1858,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public void removeByU_A_A(
+	public void removeByU_AR_A(
 		long userId, boolean actionRequired, boolean archived);
 
 	/**
@@ -1707,7 +1869,7 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_A_A(
+	public int countByU_AR_A(
 		long userId, boolean actionRequired, boolean archived);
 
 	/**
@@ -1897,7 +2059,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired);
 
@@ -1916,7 +2078,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end);
 
@@ -1927,7 +2089,7 @@ public interface UserNotificationEventPersistence
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_AR(long,int,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param deliveryType the delivery type
 	 * @param delivered the delivered
@@ -1939,7 +2101,7 @@ public interface UserNotificationEventPersistence
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -1961,7 +2123,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
@@ -1977,7 +2139,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_D_A_First(
+	public UserNotificationEvent findByU_DT_D_AR_First(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -1993,7 +2155,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_D_A_First(
+	public UserNotificationEvent fetchByU_DT_D_AR_First(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
@@ -2009,7 +2171,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_D_A_Last(
+	public UserNotificationEvent findByU_DT_D_AR_Last(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -2025,7 +2187,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_D_A_Last(
+	public UserNotificationEvent fetchByU_DT_D_AR_Last(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
@@ -2042,7 +2204,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -2056,7 +2218,7 @@ public interface UserNotificationEventPersistence
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public void removeByU_DT_D_A(
+	public void removeByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired);
 
@@ -2069,9 +2231,187 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_DT_D_A(
+	public int countByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_A_First(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_A_First(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_A_Last(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_A_Last(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public void removeByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived);
 
 	/**
 	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and actionRequired = &#63; and archived = &#63;.
@@ -2082,7 +2422,7 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived);
 
@@ -2101,7 +2441,7 @@ public interface UserNotificationEventPersistence
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end);
 
@@ -2112,7 +2452,7 @@ public interface UserNotificationEventPersistence
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_A_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_AR_A(long,int,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param deliveryType the delivery type
 	 * @param actionRequired the action required
@@ -2124,7 +2464,7 @@ public interface UserNotificationEventPersistence
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
@@ -2146,7 +2486,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public java.util.List<UserNotificationEvent> findByU_DT_A_A(
+	public java.util.List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
@@ -2162,7 +2502,7 @@ public interface UserNotificationEventPersistence
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_A_A_First(
+	public UserNotificationEvent findByU_DT_AR_A_First(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -2178,7 +2518,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_A_A_First(
+	public UserNotificationEvent fetchByU_DT_AR_A_First(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -2193,7 +2533,7 @@ public interface UserNotificationEventPersistence
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent findByU_DT_A_A_Last(
+	public UserNotificationEvent findByU_DT_AR_A_Last(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -2209,7 +2549,7 @@ public interface UserNotificationEventPersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public UserNotificationEvent fetchByU_DT_A_A_Last(
+	public UserNotificationEvent fetchByU_DT_AR_A_Last(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator);
 
@@ -2225,7 +2565,7 @@ public interface UserNotificationEventPersistence
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public UserNotificationEvent[] findByU_DT_A_A_PrevAndNext(
+	public UserNotificationEvent[] findByU_DT_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
@@ -2239,7 +2579,7 @@ public interface UserNotificationEventPersistence
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public void removeByU_DT_A_A(
+	public void removeByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived);
 
@@ -2252,9 +2592,390 @@ public interface UserNotificationEventPersistence
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public int countByU_DT_A_A(
+	public int countByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_AR_A(long,boolean,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_AR_A_First(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_AR_A_First(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_D_AR_A_Last(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_D_AR_A_Last(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public void removeByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived);
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived);
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_AR_A(long,int,boolean,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public java.util.List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_AR_A_First(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_AR_A_First(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent findByU_DT_D_AR_A_Last(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public UserNotificationEvent fetchByU_DT_D_AR_A_Last(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator);
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public UserNotificationEvent[] findByU_DT_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws NoSuchUserNotificationEventException;
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public void removeByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived);
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public int countByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived);
 
 	/**
 	 * Caches the user notification event in the entity cache if it is enabled.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/UserNotificationEventUtil.java
@@ -1839,10 +1839,10 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return getPersistence().findByU_D_A(userId, delivered, actionRequired);
+		return getPersistence().findByU_D_AR(userId, delivered, actionRequired);
 	}
 
 	/**
@@ -1859,11 +1859,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end) {
 
-		return getPersistence().findByU_D_A(
+		return getPersistence().findByU_D_AR(
 			userId, delivered, actionRequired, start, end);
 	}
 
@@ -1874,7 +1874,7 @@ public class UserNotificationEventUtil {
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_AR(long,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
@@ -1885,12 +1885,12 @@ public class UserNotificationEventUtil {
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_D_A(
+		return getPersistence().findByU_D_AR(
 			userId, delivered, actionRequired, start, end, orderByComparator,
 			useFinderCache);
 	}
@@ -1910,11 +1910,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_D_A(
+	public static List<UserNotificationEvent> findByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_D_A(
+		return getPersistence().findByU_D_AR(
 			userId, delivered, actionRequired, start, end, orderByComparator);
 	}
 
@@ -1928,13 +1928,13 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_D_A_First(
+	public static UserNotificationEvent findByU_D_AR_First(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_D_A_First(
+		return getPersistence().findByU_D_AR_First(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -1947,11 +1947,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_D_A_First(
+	public static UserNotificationEvent fetchByU_D_AR_First(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_D_A_First(
+		return getPersistence().fetchByU_D_AR_First(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -1965,13 +1965,13 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_D_A_Last(
+	public static UserNotificationEvent findByU_D_AR_Last(
 			long userId, boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_D_A_Last(
+		return getPersistence().findByU_D_AR_Last(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -1984,11 +1984,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_D_A_Last(
+	public static UserNotificationEvent fetchByU_D_AR_Last(
 		long userId, boolean delivered, boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_D_A_Last(
+		return getPersistence().fetchByU_D_AR_Last(
 			userId, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2003,14 +2003,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_D_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_D_A_PrevAndNext(
+		return getPersistence().findByU_D_AR_PrevAndNext(
 			userNotificationEventId, userId, delivered, actionRequired,
 			orderByComparator);
 	}
@@ -2022,10 +2022,10 @@ public class UserNotificationEventUtil {
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public static void removeByU_D_A(
+	public static void removeByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		getPersistence().removeByU_D_A(userId, delivered, actionRequired);
+		getPersistence().removeByU_D_AR(userId, delivered, actionRequired);
 	}
 
 	/**
@@ -2036,10 +2036,221 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_D_A(
+	public static int countByU_D_AR(
 		long userId, boolean delivered, boolean actionRequired) {
 
-		return getPersistence().countByU_D_A(userId, delivered, actionRequired);
+		return getPersistence().countByU_D_AR(
+			userId, delivered, actionRequired);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		return getPersistence().findByU_D_A(userId, delivered, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end) {
+
+		return getPersistence().findByU_D_A(
+			userId, delivered, archived, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_D_A(
+			userId, delivered, archived, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_A(
+		long userId, boolean delivered, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_D_A(
+			userId, delivered, archived, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_A_First(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_A_First(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_A_First(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_A_First(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_A_Last(
+			long userId, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_A_Last(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_A_Last(
+		long userId, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_A_Last(
+			userId, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_A_PrevAndNext(
+			userNotificationEventId, userId, delivered, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public static void removeByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		getPersistence().removeByU_D_A(userId, delivered, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_D_A(
+		long userId, boolean delivered, boolean archived) {
+
+		return getPersistence().countByU_D_A(userId, delivered, archived);
 	}
 
 	/**
@@ -2050,10 +2261,10 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return getPersistence().findByU_A_A(userId, actionRequired, archived);
+		return getPersistence().findByU_AR_A(userId, actionRequired, archived);
 	}
 
 	/**
@@ -2070,11 +2281,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end) {
 
-		return getPersistence().findByU_A_A(
+		return getPersistence().findByU_AR_A(
 			userId, actionRequired, archived, start, end);
 	}
 
@@ -2085,7 +2296,7 @@ public class UserNotificationEventUtil {
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_A_A(long,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_AR_A(long,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param actionRequired the action required
 	 * @param archived the archived
@@ -2096,12 +2307,12 @@ public class UserNotificationEventUtil {
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_A_A(
+		return getPersistence().findByU_AR_A(
 			userId, actionRequired, archived, start, end, orderByComparator,
 			useFinderCache);
 	}
@@ -2121,11 +2332,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_A_A(
+	public static List<UserNotificationEvent> findByU_AR_A(
 		long userId, boolean actionRequired, boolean archived, int start,
 		int end, OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_A_A(
+		return getPersistence().findByU_AR_A(
 			userId, actionRequired, archived, start, end, orderByComparator);
 	}
 
@@ -2139,13 +2350,13 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_A_A_First(
+	public static UserNotificationEvent findByU_AR_A_First(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_A_A_First(
+		return getPersistence().findByU_AR_A_First(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2158,11 +2369,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_A_A_First(
+	public static UserNotificationEvent fetchByU_AR_A_First(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_A_A_First(
+		return getPersistence().fetchByU_AR_A_First(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2176,13 +2387,13 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_A_A_Last(
+	public static UserNotificationEvent findByU_AR_A_Last(
 			long userId, boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_A_A_Last(
+		return getPersistence().findByU_AR_A_Last(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2195,11 +2406,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_A_A_Last(
+	public static UserNotificationEvent fetchByU_AR_A_Last(
 		long userId, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_A_A_Last(
+		return getPersistence().fetchByU_AR_A_Last(
 			userId, actionRequired, archived, orderByComparator);
 	}
 
@@ -2214,14 +2425,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_A_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_A_A_PrevAndNext(
+		return getPersistence().findByU_AR_A_PrevAndNext(
 			userNotificationEventId, userId, actionRequired, archived,
 			orderByComparator);
 	}
@@ -2233,10 +2444,10 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public static void removeByU_A_A(
+	public static void removeByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		getPersistence().removeByU_A_A(userId, actionRequired, archived);
+		getPersistence().removeByU_AR_A(userId, actionRequired, archived);
 	}
 
 	/**
@@ -2247,10 +2458,10 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_A_A(
+	public static int countByU_AR_A(
 		long userId, boolean actionRequired, boolean archived) {
 
-		return getPersistence().countByU_A_A(userId, actionRequired, archived);
+		return getPersistence().countByU_AR_A(userId, actionRequired, archived);
 	}
 
 	/**
@@ -2490,11 +2701,11 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 	}
 
@@ -2513,11 +2724,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end);
 	}
 
@@ -2528,7 +2739,7 @@ public class UserNotificationEventUtil {
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_AR(long,int,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param deliveryType the delivery type
 	 * @param delivered the delivered
@@ -2540,13 +2751,13 @@ public class UserNotificationEventUtil {
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end,
 			orderByComparator, useFinderCache);
 	}
@@ -2567,12 +2778,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_D_A(
+	public static List<UserNotificationEvent> findByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired, int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_DT_D_A(
+		return getPersistence().findByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired, start, end,
 			orderByComparator);
 	}
@@ -2588,14 +2799,14 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_D_A_First(
+	public static UserNotificationEvent findByU_DT_D_AR_First(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_D_A_First(
+		return getPersistence().findByU_DT_D_AR_First(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2609,12 +2820,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_D_A_First(
+	public static UserNotificationEvent fetchByU_DT_D_AR_First(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_D_A_First(
+		return getPersistence().fetchByU_DT_D_AR_First(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2629,14 +2840,14 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_D_A_Last(
+	public static UserNotificationEvent findByU_DT_D_AR_Last(
 			long userId, int deliveryType, boolean delivered,
 			boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_D_A_Last(
+		return getPersistence().findByU_DT_D_AR_Last(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2650,12 +2861,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_D_A_Last(
+	public static UserNotificationEvent fetchByU_DT_D_AR_Last(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_D_A_Last(
+		return getPersistence().fetchByU_DT_D_AR_Last(
 			userId, deliveryType, delivered, actionRequired, orderByComparator);
 	}
 
@@ -2671,14 +2882,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_DT_D_AR_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean delivered, boolean actionRequired,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_D_A_PrevAndNext(
+		return getPersistence().findByU_DT_D_AR_PrevAndNext(
 			userNotificationEventId, userId, deliveryType, delivered,
 			actionRequired, orderByComparator);
 	}
@@ -2691,11 +2902,11 @@ public class UserNotificationEventUtil {
 	 * @param delivered the delivered
 	 * @param actionRequired the action required
 	 */
-	public static void removeByU_DT_D_A(
+	public static void removeByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		getPersistence().removeByU_DT_D_A(
+		getPersistence().removeByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
 	}
 
@@ -2708,12 +2919,240 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_DT_D_A(
+	public static int countByU_DT_D_AR(
 		long userId, int deliveryType, boolean delivered,
 		boolean actionRequired) {
 
-		return getPersistence().countByU_DT_D_A(
+		return getPersistence().countByU_DT_D_AR(
 			userId, deliveryType, delivered, actionRequired);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_DT_D_A(
+			userId, deliveryType, delivered, archived, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_A_First(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_A_First(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_A_First(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_A_First(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_A_Last(
+			long userId, int deliveryType, boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_A_Last(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_A_Last(
+		long userId, int deliveryType, boolean delivered, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_A_Last(
+			userId, deliveryType, delivered, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_DT_D_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_A_PrevAndNext(
+			userNotificationEventId, userId, deliveryType, delivered, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 */
+	public static void removeByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		getPersistence().removeByU_DT_D_A(
+			userId, deliveryType, delivered, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_DT_D_A(
+		long userId, int deliveryType, boolean delivered, boolean archived) {
+
+		return getPersistence().countByU_DT_D_A(
+			userId, deliveryType, delivered, archived);
 	}
 
 	/**
@@ -2725,11 +3164,11 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 
@@ -2748,11 +3187,11 @@ public class UserNotificationEventUtil {
 	 * @param end the upper bound of the range of user notification events (not inclusive)
 	 * @return the range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end);
 	}
 
@@ -2763,7 +3202,7 @@ public class UserNotificationEventUtil {
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
 	 * </p>
 	 *
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_A_A(long,int,boolean,boolean, int, int, OrderByComparator)}
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_AR_A(long,int,boolean,boolean, int, int, OrderByComparator)}
 	 * @param userId the user ID
 	 * @param deliveryType the delivery type
 	 * @param actionRequired the action required
@@ -2775,13 +3214,13 @@ public class UserNotificationEventUtil {
 	 * @return the ordered range of matching user notification events
 	 */
 	@Deprecated
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end,
 			orderByComparator, useFinderCache);
 	}
@@ -2802,12 +3241,12 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching user notification events
 	 */
-	public static List<UserNotificationEvent> findByU_DT_A_A(
+	public static List<UserNotificationEvent> findByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		int start, int end,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().findByU_DT_A_A(
+		return getPersistence().findByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived, start, end,
 			orderByComparator);
 	}
@@ -2823,14 +3262,14 @@ public class UserNotificationEventUtil {
 	 * @return the first matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_A_A_First(
+	public static UserNotificationEvent findByU_DT_AR_A_First(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_A_A_First(
+		return getPersistence().findByU_DT_AR_A_First(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2844,11 +3283,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_A_A_First(
+	public static UserNotificationEvent fetchByU_DT_AR_A_First(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_A_A_First(
+		return getPersistence().fetchByU_DT_AR_A_First(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2863,14 +3302,14 @@ public class UserNotificationEventUtil {
 	 * @return the last matching user notification event
 	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent findByU_DT_A_A_Last(
+	public static UserNotificationEvent findByU_DT_AR_A_Last(
 			long userId, int deliveryType, boolean actionRequired,
 			boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_A_A_Last(
+		return getPersistence().findByU_DT_AR_A_Last(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2884,11 +3323,11 @@ public class UserNotificationEventUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
 	 */
-	public static UserNotificationEvent fetchByU_DT_A_A_Last(
+	public static UserNotificationEvent fetchByU_DT_AR_A_Last(
 		long userId, int deliveryType, boolean actionRequired, boolean archived,
 		OrderByComparator<UserNotificationEvent> orderByComparator) {
 
-		return getPersistence().fetchByU_DT_A_A_Last(
+		return getPersistence().fetchByU_DT_AR_A_Last(
 			userId, deliveryType, actionRequired, archived, orderByComparator);
 	}
 
@@ -2904,14 +3343,14 @@ public class UserNotificationEventUtil {
 	 * @return the previous, current, and next user notification event
 	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
 	 */
-	public static UserNotificationEvent[] findByU_DT_A_A_PrevAndNext(
+	public static UserNotificationEvent[] findByU_DT_AR_A_PrevAndNext(
 			long userNotificationEventId, long userId, int deliveryType,
 			boolean actionRequired, boolean archived,
 			OrderByComparator<UserNotificationEvent> orderByComparator)
 		throws com.liferay.portal.kernel.exception.
 			NoSuchUserNotificationEventException {
 
-		return getPersistence().findByU_DT_A_A_PrevAndNext(
+		return getPersistence().findByU_DT_AR_A_PrevAndNext(
 			userNotificationEventId, userId, deliveryType, actionRequired,
 			archived, orderByComparator);
 	}
@@ -2924,11 +3363,11 @@ public class UserNotificationEventUtil {
 	 * @param actionRequired the action required
 	 * @param archived the archived
 	 */
-	public static void removeByU_DT_A_A(
+	public static void removeByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		getPersistence().removeByU_DT_A_A(
+		getPersistence().removeByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
 	}
 
@@ -2941,12 +3380,498 @@ public class UserNotificationEventUtil {
 	 * @param archived the archived
 	 * @return the number of matching user notification events
 	 */
-	public static int countByU_DT_A_A(
+	public static int countByU_DT_AR_A(
 		long userId, int deliveryType, boolean actionRequired,
 		boolean archived) {
 
-		return getPersistence().countByU_DT_A_A(
+		return getPersistence().countByU_DT_AR_A(
 			userId, deliveryType, actionRequired, archived);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_D_AR_A(long,boolean,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_D_AR_A(
+			userId, delivered, actionRequired, archived, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_AR_A_First(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_AR_A_First(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_AR_A_First(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_AR_A_First(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_D_AR_A_Last(
+			long userId, boolean delivered, boolean actionRequired,
+			boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_AR_A_Last(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_D_AR_A_Last(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_D_AR_A_Last(
+			userId, delivered, actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_D_AR_A_PrevAndNext(
+			userNotificationEventId, userId, delivered, actionRequired,
+			archived, orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public static void removeByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		getPersistence().removeByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_D_AR_A(
+		long userId, boolean delivered, boolean actionRequired,
+		boolean archived) {
+
+		return getPersistence().countByU_D_AR_A(
+			userId, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns a range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @return the range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @deprecated As of Mueller (7.2.x), replaced by {@link #findByU_DT_D_AR_A(long,int,boolean,boolean,boolean, int, int, OrderByComparator)}
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching user notification events
+	 */
+	@Deprecated
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns an ordered range of all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not <code>QueryUtil#ALL_POS</code>), then the query will include the default ORDER BY logic from <code>UserNotificationEventModelImpl</code>. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param start the lower bound of the range of user notification events
+	 * @param end the upper bound of the range of user notification events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching user notification events
+	 */
+	public static List<UserNotificationEvent> findByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived, int start, int end,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().findByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived, start,
+			end, orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_AR_A_First(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_AR_A_First(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_AR_A_First(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_AR_A_First(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event
+	 * @throws NoSuchUserNotificationEventException if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent findByU_DT_D_AR_A_Last(
+			long userId, int deliveryType, boolean delivered,
+			boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_AR_A_Last(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the last user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching user notification event, or <code>null</code> if a matching user notification event could not be found
+	 */
+	public static UserNotificationEvent fetchByU_DT_D_AR_A_Last(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived,
+		OrderByComparator<UserNotificationEvent> orderByComparator) {
+
+		return getPersistence().fetchByU_DT_D_AR_A_Last(
+			userId, deliveryType, delivered, actionRequired, archived,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the user notification events before and after the current user notification event in the ordered set where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userNotificationEventId the primary key of the current user notification event
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next user notification event
+	 * @throws NoSuchUserNotificationEventException if a user notification event with the primary key could not be found
+	 */
+	public static UserNotificationEvent[] findByU_DT_D_AR_A_PrevAndNext(
+			long userNotificationEventId, long userId, int deliveryType,
+			boolean delivered, boolean actionRequired, boolean archived,
+			OrderByComparator<UserNotificationEvent> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchUserNotificationEventException {
+
+		return getPersistence().findByU_DT_D_AR_A_PrevAndNext(
+			userNotificationEventId, userId, deliveryType, delivered,
+			actionRequired, archived, orderByComparator);
+	}
+
+	/**
+	 * Removes all the user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63; from the database.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 */
+	public static void removeByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		getPersistence().removeByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
+	}
+
+	/**
+	 * Returns the number of user notification events where userId = &#63; and deliveryType = &#63; and delivered = &#63; and actionRequired = &#63; and archived = &#63;.
+	 *
+	 * @param userId the user ID
+	 * @param deliveryType the delivery type
+	 * @param delivered the delivered
+	 * @param actionRequired the action required
+	 * @param archived the archived
+	 * @return the number of matching user notification events
+	 */
+	public static int countByU_DT_D_AR_A(
+		long userId, int deliveryType, boolean delivered,
+		boolean actionRequired, boolean archived) {
+
+		return getPersistence().countByU_DT_D_AR_A(
+			userId, deliveryType, delivered, actionRequired, archived);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -334,6 +334,10 @@ public class SubscriptionSender implements Serializable {
 		return bulk;
 	}
 
+	public void sendEmailNotification(long userId) throws Exception {
+		sendEmailNotification(UserLocalServiceUtil.getUser(userId));
+	}
+
 	public void setBody(String body) {
 		this.body = body;
 	}
@@ -749,11 +753,23 @@ public class SubscriptionSender implements Serializable {
 		).put(
 			"classPK", _classPK
 		).put(
+			"context", _context
+		).put(
 			"entryTitle", _entryTitle
 		).put(
 			"entryURL", _entryURL
 		).put(
+			"localizedBodyMap", localizedBodyMap
+		).put(
+			"localizedContext", _localizedContext
+		).put(
+			"localizedSubjectMap", localizedSubjectMap
+		).put(
+			"mailId", mailId
+		).put(
 			"notificationType", _notificationType
+		).put(
+			"portletId", portletId
 		).put(
 			"userId", currentUserId
 		);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -102,6 +102,13 @@ public class SubscriptionSender implements Serializable {
 		hooks.add(hook);
 	}
 
+	public void addPersistedStagingSubscribers(String className, long classPK) {
+		ObjectValuePair<String, Long> ovp = new ObjectValuePair<>(
+			className, classPK);
+
+		_persistestedStagingSubscribersOVPs.add(ovp);
+	}
+
 	public void addPersistedSubscribers(String className, long classPK) {
 		ObjectValuePair<String, Long> ovp = new ObjectValuePair<>(
 			className, classPK);
@@ -153,6 +160,30 @@ public class SubscriptionSender implements Serializable {
 			}
 
 			_persistestedSubscribersOVPs.clear();
+
+			for (ObjectValuePair<String, Long> ovp :
+					_persistestedStagingSubscribersOVPs) {
+
+				String className = ovp.getKey();
+				long classPK = ovp.getValue();
+
+				List<Subscription> subscriptions =
+					SubscriptionLocalServiceUtil.getSubscriptions(
+						companyId, className, classPK);
+
+				for (Subscription subscription : subscriptions) {
+					try {
+						notifyPersistedSubscriber(subscription, false);
+					}
+					catch (Exception e) {
+						_log.error(
+							"Unable to process subscription: " + subscription,
+							e);
+					}
+				}
+			}
+
+			_persistestedStagingSubscribersOVPs.clear();
 
 			for (ObjectValuePair<String, String> ovp :
 					_runtimeSubscribersOVPs) {
@@ -575,11 +606,27 @@ public class SubscriptionSender implements Serializable {
 	protected void notifyPersistedSubscriber(Subscription subscription)
 		throws Exception {
 
-		notifyPersistedSubscriber(subscription, _className, _classPK);
+		notifyPersistedSubscriber(subscription, true);
+	}
+
+	protected void notifyPersistedSubscriber(
+			Subscription subscription, boolean notifyImmediately)
+		throws Exception {
+
+		notifyPersistedSubscriber(
+			subscription, _className, _classPK, notifyImmediately);
 	}
 
 	protected void notifyPersistedSubscriber(
 			Subscription subscription, String className, long classPK)
+		throws Exception {
+
+		notifyPersistedSubscriber(subscription, _className, _classPK, true);
+	}
+
+	protected void notifyPersistedSubscriber(
+			Subscription subscription, String className, long classPK,
+			boolean notifyImmediately)
 		throws Exception {
 
 		User user = UserLocalServiceUtil.fetchUserById(
@@ -599,21 +646,42 @@ public class SubscriptionSender implements Serializable {
 
 		String emailAddress = user.getEmailAddress();
 
-		if (_sentEmailAddresses.contains(emailAddress)) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Do not send a duplicate email to " + emailAddress);
+		if (notifyImmediately) {
+			if (_sentEmailAddresses.contains(emailAddress)) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Do not send a duplicate email to " + emailAddress);
+				}
+
+				return;
 			}
 
-			return;
-		}
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Add " + emailAddress +
+						" to the list of users who have received an email");
+			}
 
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Add " + emailAddress +
-					" to the list of users who have received an email");
+			_sentEmailAddresses.add(emailAddress);
 		}
+		else {
+			if (_stagingOutboxEmailAddresses.contains(emailAddress)) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Do not send a duplicate email to " + emailAddress);
+				}
 
-		_sentEmailAddresses.add(emailAddress);
+				return;
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Add " + emailAddress +
+						" to the list of users who will receive an email");
+			}
+
+			_stagingOutboxEmailAddresses.add(emailAddress);
+		}
 
 		if (!user.isActive()) {
 			if (_log.isDebugEnabled()) {
@@ -640,7 +708,7 @@ public class SubscriptionSender implements Serializable {
 
 		_notifyHooks(Hook.Event.PERSISTED_SUBSCRIBER_FOUND, subscription);
 
-		sendNotification(user);
+		sendNotification(user, notifyImmediately);
 	}
 
 	protected void notifyRuntimeSubscriber(InternetAddress to, Locale locale)
@@ -836,6 +904,12 @@ public class SubscriptionSender implements Serializable {
 	}
 
 	protected void sendNotification(User user) throws Exception {
+		sendNotification(user, true);
+	}
+
+	protected void sendNotification(User user, boolean notifyImmediately)
+		throws Exception {
+
 		if (currentUserId == user.getUserId()) {
 			if (_log.isDebugEnabled()) {
 				_log.debug("Skip user " + currentUserId);
@@ -844,11 +918,20 @@ public class SubscriptionSender implements Serializable {
 			return;
 		}
 
-		sendEmailNotification(user);
-		sendUserNotification(user);
+		if (notifyImmediately) {
+			sendEmailNotification(user);
+		}
+
+		sendUserNotification(user, notifyImmediately);
 	}
 
 	protected void sendUserNotification(User user) throws Exception {
+		sendNotification(user, true);
+	}
+
+	protected void sendUserNotification(User user, boolean notifyImmediately)
+		throws Exception {
+
 		JSONObject notificationEventJSONObject =
 			JSONFactoryUtil.createJSONObject();
 
@@ -859,10 +942,20 @@ public class SubscriptionSender implements Serializable {
 				_notificationType,
 				UserNotificationDeliveryConstants.TYPE_PUSH)) {
 
-			UserNotificationEventLocalServiceUtil.sendUserNotificationEvents(
-				user.getUserId(), portletId,
-				UserNotificationDeliveryConstants.TYPE_PUSH,
-				notificationEventJSONObject);
+			if (notifyImmediately) {
+				UserNotificationEventLocalServiceUtil.
+					sendUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_PUSH,
+						notificationEventJSONObject);
+			}
+			else {
+				UserNotificationEventLocalServiceUtil.
+					storeUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_PUSH, false,
+						notificationEventJSONObject);
+			}
 		}
 
 		if (UserNotificationManagerUtil.isDeliver(
@@ -870,10 +963,20 @@ public class SubscriptionSender implements Serializable {
 				_notificationType,
 				UserNotificationDeliveryConstants.TYPE_WEBSITE)) {
 
-			UserNotificationEventLocalServiceUtil.sendUserNotificationEvents(
-				user.getUserId(), portletId,
-				UserNotificationDeliveryConstants.TYPE_WEBSITE,
-				notificationEventJSONObject);
+			if (notifyImmediately) {
+				UserNotificationEventLocalServiceUtil.
+					sendUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_WEBSITE,
+						notificationEventJSONObject);
+			}
+			else {
+				UserNotificationEventLocalServiceUtil.
+					storeUserNotificationEvents(
+						user.getUserId(), portletId,
+						UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+						notificationEventJSONObject);
+			}
 		}
 	}
 
@@ -1029,9 +1132,12 @@ public class SubscriptionSender implements Serializable {
 	private long _notificationClassNameId;
 	private int _notificationType;
 	private final List<ObjectValuePair<String, Long>>
+		_persistestedStagingSubscribersOVPs = new ArrayList<>();
+	private final List<ObjectValuePair<String, Long>>
 		_persistestedSubscribersOVPs = new ArrayList<>();
 	private final List<ObjectValuePair<String, String>>
 		_runtimeSubscribersOVPs = new ArrayList<>();
 	private final Set<String> _sentEmailAddresses = new HashSet<>();
+	private final Set<String> _stagingOutboxEmailAddresses = new HashSet<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 9.10.0
+version 9.11.0

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -409,10 +409,12 @@ create unique index IX_8B6E3ACE on UserNotificationDelivery (userId, portletId[$
 create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:200$]);
 create index IX_5CE95F03 on UserNotificationEvent (userId, actionRequired, archived);
 create index IX_3DBB361A on UserNotificationEvent (userId, archived);
-create index IX_E32CC19 on UserNotificationEvent (userId, delivered, actionRequired);
+create index IX_9D34232F on UserNotificationEvent (userId, delivered, actionRequired, archived);
+create index IX_BD8BD246 on UserNotificationEvent (userId, delivered, archived);
 create index IX_C4EFBD45 on UserNotificationEvent (userId, deliveryType, actionRequired, archived);
 create index IX_A87A585C on UserNotificationEvent (userId, deliveryType, archived);
-create index IX_A6F83617 on UserNotificationEvent (userId, deliveryType, delivered, actionRequired);
+create index IX_4BF3A7AD on UserNotificationEvent (userId, deliveryType, delivered, actionRequired, archived);
+create index IX_93012C4 on UserNotificationEvent (userId, deliveryType, delivered, archived);
 create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:200$], deliveryType, delivered);
 create index IX_A6BAFDFE on UserNotificationEvent (uuid_[$COLUMN_LENGTH:75$], companyId);
 


### PR DESCRIPTION
From @ChrisKian:

> This is a pretty large issue, so I've tried to break down the commits to be as understandable as possible.  Here's the gist of the issue:
> 
> 1. With the inclusion of LPS-98473, users are now able to subscribe to Journal Articles/Folders/Portlets in a live site.
> 2. With this change came some problems when sending notifications during a publish.
> 3. Since the content update/move/add/delete/etc changes occur in the staging site, there was no way to persist that info and retrieve it when it should actually be sent - during publication.
> 4. Further, certain actions were completely missing (moving folders) and replaced with a notification for each update the article previously had instead.
> 5. My change is to store these live-site notifications, so they can be sent when the time is right
> 6. I did this by utilizing the "delivered" column in the UserNotificationEntry table, which is seemingly unused (always set to true).
> 7. During a publications, I retrieved undelivered UserNotificationEntry objects which belong to the given JournalArticle.  I then updated the delivered column to true, which then would make them appear for the users.
> 8.  For email notifications, this was trickier.  Emails need a lot of context from the SubscriptionSender class, which is populated when the article is modified in the staging site.
> 9. In order to work through this, I was able to pass more values into the UserNotificationEntry's "payload" column, and retrieve them later during publication.