### PR TITLE
LPS-100527 ddm structures are unselectable in web content More list

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_more_menu_items.jsp
@@ -103,12 +103,12 @@ JournalViewMoreMenuItemsDisplayContext journalViewMoreMenuItemsDisplayContext = 
 	dom.delegate(
 		addMenuItemFm,
 		'click',
-		'selector-button',
+		'.selector-button',
 		function(event) {
 			Util.getOpener().Liferay.fire(
 				'<%= HtmlUtil.escapeJS(journalViewMoreMenuItemsDisplayContext.getEventName()) %>',
 				{
-					ddmStructureKey: event.currentTarget.attr('data-ddmStructureKey')
+					ddmStructureKey: event.target.getAttribute('data-ddmStructureKey')
 				}
 			);
 


### PR DESCRIPTION
/cc @matthewchan1 

Notes from Matt:

> https://issues.liferay.com/browse/LPS-100527
> 
> Issue:
> In the view more menu items list of Web Content, a ddm structure currently cannot be selected.
> 
> Fix:
> This fix is pretty straightforward. With the changes in [LPS-96737](https://issues.liferay.com/browse/LPS-96737), AUI references were removed from Web Content. element.attr() is an AUI method, so it needs to be removed as well and replaced with a pure javascript method. In addition, the period needed to be added to selector-button, otherwise the function never triggers.