### PR TITLE
[TECHNICAL-SUPPORT] LPS-100131 Optimize SQL query for linked assets

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryFinderImpl.java
@@ -386,9 +386,15 @@ public class AssetEntryFinderImpl
 		}
 
 		if (entryQuery.getLinkedAssetEntryId() > 0) {
-			sb.append("INNER JOIN AssetLink ON (AssetEntry.entryId = ");
-			sb.append("AssetLink.entryId1) OR (AssetEntry.entryId = ");
-			sb.append("AssetLink.entryId2)");
+			sb.append("INNER JOIN ( ");
+			sb.append("SELECT AssetLink.entryId1 as entryId ");
+			sb.append("FROM AssetLink WHERE AssetLink.entryId2 = ? ");
+			sb.append("AND AssetLink.entryId1 != ? ");
+			sb.append("UNION ");
+			sb.append("SELECT AssetLink.entryId2 as entryId ");
+			sb.append("FROM AssetLink WHERE AssetLink.entryId1 = ? ");
+			sb.append("AND AssetLink.entryId2 != ? ) TEMP_ASSETLINK ");
+			sb.append("ON (TEMP_ASSETLINK.entryId = AssetEntry.entryId) ");
 		}
 
 		String orderByCol1 = AssetEntryQuery.ORDER_BY_COLUMNS[2];
@@ -415,8 +421,7 @@ public class AssetEntryFinderImpl
 		int whereIndex = sb.index();
 
 		if (entryQuery.getLinkedAssetEntryId() > 0) {
-			sb.append(" AND ((AssetLink.entryId1 = ?) OR (AssetLink.entryId2 ");
-			sb.append("= ?)) AND (AssetEntry.entryId != ?)");
+			sb.append(" AND (AssetEntry.entryId != ?)");
 		}
 
 		if (entryQuery.isListable() != null) {
@@ -587,6 +592,8 @@ public class AssetEntryFinderImpl
 		QueryPos qPos = QueryPos.getInstance(q);
 
 		if (entryQuery.getLinkedAssetEntryId() > 0) {
+			qPos.add(entryQuery.getLinkedAssetEntryId());
+			qPos.add(entryQuery.getLinkedAssetEntryId());
 			qPos.add(entryQuery.getLinkedAssetEntryId());
 			qPos.add(entryQuery.getLinkedAssetEntryId());
 			qPos.add(entryQuery.getLinkedAssetEntryId());


### PR DESCRIPTION
Hi @ealonso ,

I optimized the query for related assets: it basically replaces the inefficient join to `AssetLink` table and uses a sub-query called `TEMP_ASSETLINK` instead. It makes a `UNION` from both sides of the link and filters on the indexed `entryId1` and `entryId2` fields.

I tested it with both `count=true` and `count=false` and a few other test cases as well, to make sure it always generates a valid query.

Please review my changes.

Thanks,
Vendel