### PR TITLE
[TECHNICAL-SUPPORT] LPS-101840 Invert condition for RSS entry collapse

### DIFF
--- a/modules/apps/rss/rss-web/src/main/resources/META-INF/resources/feed.jspf
+++ b/modules/apps/rss/rss-web/src/main/resources/META-INF/resources/feed.jspf
@@ -67,7 +67,7 @@
 						SyndEntry syndEntry = rssFeedEntry.getSyndEntry();
 					%>
 
-						<aui:fieldset collapsed="<%= themeDisplay.isStateMaximized() || (j < rssPortletInstanceConfiguration.expandedEntriesPerFeed()) %>" collapsible="<%= true %>" cssClass="feed-entry" id='<%= renderResponse.getNamespace() + "feed_" + i + "_panelId_" + j %>' label="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
+						<aui:fieldset collapsed="<%= !themeDisplay.isStateMaximized() && (j >= rssPortletInstanceConfiguration.expandedEntriesPerFeed()) %>" collapsible="<%= true %>" cssClass="feed-entry" id='<%= renderResponse.getNamespace() + "feed_" + i + "_panelId_" + j %>' label="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
 							<div class="feed-entry-content">
 								<c:if test="<%= rssPortletInstanceConfiguration.showFeedItemAuthor() && Validator.isNotNull(syndEntry.getAuthor()) %>">
 									<strong class="feed-entry-author small">


### PR DESCRIPTION
Hi @ealonso ,

It seems like the boolean expression was coming from 6.2 originally: [feed.jspf](https://github.com/liferay/liferay-portal/blob/6.2.x/portal-web/docroot/html/portlet/rss/feed.jspf#L154-L158) . However, now we are using it for a parameter called "collapse", which is basically the opposite behavior. I've inverted the boolean expression.

Please review my changes.

Thanks,
Vendel