### PR TITLE
Lps 102240

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/edit_entry.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/edit_entry.jsp
@@ -28,13 +28,7 @@ String content = BeanParamUtil.getString(entry, request, "content");
 
 boolean alert = BeanParamUtil.getBoolean(entry, request, "alert");
 
-boolean displayImmediatelyDefaultValue = false;
-
-if (entry == null) {
-	displayImmediatelyDefaultValue = true;
-}
-
-boolean displayImmediately = ParamUtil.getBoolean(request, "displayImmediately", displayImmediatelyDefaultValue);
+boolean displayImmediately = ParamUtil.getBoolean(request, "displayImmediately", (entry == null));
 
 String headerTitle = null;
 

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/edit_entry.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/edit_entry.jsp
@@ -28,11 +28,13 @@ String content = BeanParamUtil.getString(entry, request, "content");
 
 boolean alert = BeanParamUtil.getBoolean(entry, request, "alert");
 
-boolean displayImmediately = ParamUtil.getBoolean(request, "displayImmediately");
+boolean displayImmediatelyDefaultValue = false;
 
 if (entry == null) {
-	displayImmediately = true;
+	displayImmediatelyDefaultValue = true;
 }
+
+boolean displayImmediately = ParamUtil.getBoolean(request, "displayImmediately", displayImmediatelyDefaultValue);
 
 String headerTitle = null;
 

--- a/modules/apps/app-builder/app-builder-rest-impl/src/main/java/com/liferay/app/builder/rest/internal/resource/v1_0/AppResourceImpl.java
+++ b/modules/apps/app-builder/app-builder-rest-impl/src/main/java/com/liferay/app/builder/rest/internal/resource/v1_0/AppResourceImpl.java
@@ -287,7 +287,7 @@ public class AppResourceImpl
 
 		for (AppDeployment appDeployment : app.getAppDeployments()) {
 			_appBuilderAppDeploymentLocalService.addAppBuilderAppDeployment(
-				app.getId(), _toJSONString(appDeployment.getSettings()),
+				appId, _toJSONString(appDeployment.getSettings()),
 				appDeployment.getType());
 
 			AppDeployer appDeployer = _appDeployerTracker.getAppDeployer(

--- a/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/deploy/WidgetAppDeployer.java
+++ b/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/deploy/WidgetAppDeployer.java
@@ -55,6 +55,7 @@ public class WidgetAppDeployer implements AppDeployer {
 		_serviceRegistrationsMap.computeIfAbsent(
 			appId,
 			key -> _deployAppPortlet(
+				appId,
 				appBuilderApp.getName(LocaleThreadLocal.getDefaultLocale()),
 				AppBuilderPortletKeys.WIDGET_APP + "_" + appId));
 
@@ -85,10 +86,10 @@ public class WidgetAppDeployer implements AppDeployer {
 	}
 
 	private ServiceRegistration<?> _deployAppPortlet(
-		String appName, String portletName) {
+		long appId, String appName, String portletName) {
 
 		return _bundleContext.registerService(
-			Portlet.class, new WidgetAppPortlet(),
+			Portlet.class, new WidgetAppPortlet(appId),
 			new HashMapDictionary<String, Object>() {
 				{
 					put("com.liferay.portlet.add-default-resource", true);
@@ -101,7 +102,9 @@ public class WidgetAppDeployer implements AppDeployer {
 					put(
 						"javax.portlet.init-param.template-path",
 						"/META-INF/resources/");
-					put("javax.portlet.init-param.view-template", "/view.jsp");
+					put(
+						"javax.portlet.init-param.view-template",
+						"/view_entries.jsp");
 					put(
 						"javax.portlet.security-role-ref",
 						"administrator,guest,power-user,user");

--- a/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/portlet/WidgetAppPortlet.java
+++ b/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/portlet/WidgetAppPortlet.java
@@ -14,10 +14,34 @@
 
 package com.liferay.app.builder.web.internal.portlet;
 
+import com.liferay.app.builder.web.internal.constants.AppBuilderWebKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import java.io.IOException;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 /**
  * @author Gabriel Albuquerque
  */
 public class WidgetAppPortlet extends MVCPortlet {
+
+	public WidgetAppPortlet(long appId) {
+		_appId = appId;
+	}
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		renderRequest.setAttribute(AppBuilderWebKeys.APP_ID, _appId);
+
+		super.render(renderRequest, renderResponse);
+	}
+
+	private final long _appId;
+
 }

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/list-view/ListView.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/list-view/ListView.es.js
@@ -67,15 +67,15 @@ export default ({
 	}
 
 	const refetchOnActions = actions.map(action => {
-		if (!action.callback) {
+		if (!action.action) {
 			return action;
 		}
 
 		return {
 			...action,
-			callback: item => {
-				action.callback(item).then(confirmed => {
-					if (!confirmed) {
+			action: item => {
+				action.action(item).then(isRefetch => {
+					if (!isRefetch) {
 						return;
 					}
 

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/table/DropDownAction.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/components/table/DropDownAction.es.js
@@ -17,24 +17,19 @@ import React from 'react';
 
 const {Divider, Item} = ClayDropDown;
 
-export default ({action, item, setActive}) => {
-	const {callback, link, name} = action;
-	const href = link ? link(item) : '';
-
+export default ({action: {action, name}, item, setActive}) => {
 	if (name === 'divider') {
 		return <Divider />;
 	}
 
 	return (
 		<Item
-			href={href}
 			onClick={event => {
 				event.preventDefault();
-
 				setActive(false);
 
-				if (callback) {
-					callback(item);
+				if (action) {
+					action(item);
 				}
 			}}
 		>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/ListApps.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/app/ListApps.es.js
@@ -47,13 +47,6 @@ const concatTypes = types => {
 	}, '');
 };
 
-const ACTIONS = [
-	{
-		callback: confirmDelete('/o/app-builder/v1.0/apps/'),
-		name: Liferay.Language.get('delete')
-	}
-];
-
 const COLUMNS = [
 	{
 		key: 'name',
@@ -101,7 +94,12 @@ export default ({
 
 	return (
 		<ListView
-			actions={ACTIONS}
+			actions={[
+				{
+					action: confirmDelete('/o/app-builder/v1.0/apps/'),
+					name: Liferay.Language.get('delete')
+				}
+			]}
 			addButton={() => (
 				<Button
 					className="nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ListCustomObjects.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/custom-object/ListCustomObjects.es.js
@@ -25,32 +25,9 @@ import {confirmDelete} from '../../utils/client.es';
 import isClickOutside from '../../utils/clickOutside.es';
 import {addItem} from '../../utils/client.es';
 
-const ACTIONS = [
-	{
-		link: item => `#/custom-object/${item.id}/form-views`,
-		name: Liferay.Language.get('form-views')
-	},
-	{
-		link: item => `#/custom-object/${item.id}/table-views`,
-		name: Liferay.Language.get('table-views')
-	},
-	{
-		link: item => `#/custom-object/${item.id}/apps`,
-		name: Liferay.Language.get('apps')
-	},
-	{
-		name: 'divider'
-	},
-	{
-		callback: confirmDelete('/o/data-engine/v1.0/data-definitions/'),
-		name: Liferay.Language.get('delete')
-	}
-];
-
 const COLUMNS = [
 	{
 		key: 'name',
-		link: item => `/custom-object/${item.id}/form-views`,
 		sortable: true,
 		value: Liferay.Language.get('name')
 	},
@@ -148,7 +125,42 @@ export default ({history}) => {
 			/>
 
 			<ListView
-				actions={ACTIONS}
+				actions={[
+					{
+						action: item =>
+							Promise.resolve(
+								history.push(
+									`/custom-object/${item.id}/form-views`
+								)
+							),
+						name: Liferay.Language.get('form-views')
+					},
+					{
+						action: item =>
+							Promise.resolve(
+								history.push(
+									`/custom-object/${item.id}/table-views`
+								)
+							),
+						name: Liferay.Language.get('table-views')
+					},
+					{
+						action: item =>
+							Promise.resolve(
+								history.push(`/custom-object/${item.id}/apps`)
+							),
+						name: Liferay.Language.get('apps')
+					},
+					{
+						name: 'divider'
+					},
+					{
+						callback: confirmDelete(
+							'/o/data-engine/v1.0/data-definitions/'
+						),
+						name: Liferay.Language.get('delete')
+					}
+				]}
 				addButton={() => (
 					<div ref={addButtonRef}>
 						<Button

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/ListEntries.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/entry/ListEntries.es.js
@@ -20,13 +20,6 @@ import ListView from '../../components/list-view/ListView.es';
 import {Loading} from '../../components/loading/Loading.es';
 import {confirmDelete, getItem} from '../../utils/client.es';
 
-const ACTIONS = [
-	{
-		callback: confirmDelete('/o/data-engine/v1.0/data-records/'),
-		name: Liferay.Language.get('delete')
-	}
-];
-
 const ListEntries = () => {
 	const [state, setState] = useState({
 		dataDefinitionId: null,
@@ -76,7 +69,14 @@ const ListEntries = () => {
 	return (
 		<Loading isLoading={isLoading}>
 			<ListView
-				actions={ACTIONS}
+				actions={[
+					{
+						action: confirmDelete(
+							'/o/data-engine/v1.0/data-records/'
+						),
+						name: Liferay.Language.get('delete')
+					}
+				]}
 				addButton={() => (
 					<Button
 						className="nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/ListFormViews.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/ListFormViews.es.js
@@ -39,17 +39,6 @@ export default ({
 		Liferay.Util.navigate(itemURL);
 	};
 
-	const ACTIONS = [
-		{
-			callback: item => Promise.resolve(handleEditItem(item)),
-			name: Liferay.Language.get('edit')
-		},
-		{
-			callback: confirmDelete('/o/data-engine/v1.0/data-layouts/'),
-			name: Liferay.Language.get('delete')
-		}
-	];
-
 	const COLUMNS = [
 		{
 			key: 'name',
@@ -76,7 +65,16 @@ export default ({
 
 	return (
 		<ListView
-			actions={ACTIONS}
+			actions={[
+				{
+					action: item => Promise.resolve(handleEditItem(item)),
+					name: Liferay.Language.get('edit')
+				},
+				{
+					action: confirmDelete('/o/data-engine/v1.0/data-layouts/'),
+					name: Liferay.Language.get('delete')
+				}
+			]}
 			addButton={() => (
 				<Button
 					className="nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/renderSettingsForm.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/renderSettingsForm.es.js
@@ -17,7 +17,7 @@ import {PagesVisitor} from 'dynamic-data-mapping-form-renderer/js/util/visitors.
 
 const spritemap = `${Liferay.ThemeDisplay.getPathThemeImages()}/lexicon/icons.svg`;
 
-const UNIMPLIMENTED_PROPERTIES = ['indexType', 'required', 'validation'];
+const UNIMPLIMENTED_PROPERTIES = ['indexType', 'validation'];
 
 export const getFilteredSettingsContext = settingsContext => {
 	const visitor = new PagesVisitor(settingsContext.pages);

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ListTableViews.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/ListTableViews.es.js
@@ -19,18 +19,6 @@ import Button from '../../components/button/Button.es';
 import ListView from '../../components/list-view/ListView.es';
 import {confirmDelete} from '../../utils/client.es';
 
-const ACTIONS = [
-	{
-		link: item =>
-			`#/custom-object/${item.dataDefinitionId}/table-views/${item.id}`,
-		name: Liferay.Language.get('edit')
-	},
-	{
-		callback: confirmDelete('/o/data-engine/v1.0/data-list-views/'),
-		name: Liferay.Language.get('delete')
-	}
-];
-
 const COLUMNS = [
 	{
 		key: 'name',
@@ -51,6 +39,7 @@ const COLUMNS = [
 ];
 
 export default ({
+	history,
 	match: {
 		params: {dataDefinitionId},
 		url
@@ -58,7 +47,19 @@ export default ({
 }) => {
 	return (
 		<ListView
-			actions={ACTIONS}
+			actions={[
+				{
+					action: item =>
+						Promise.resolve(history.push(`${url}/${item.id}`)),
+					name: Liferay.Language.get('edit')
+				},
+				{
+					action: confirmDelete(
+						'/o/data-engine/v1.0/data-list-views/'
+					),
+					name: Liferay.Language.get('delete')
+				}
+			]}
 			addButton={() => (
 				<Button
 					className="nav-btn nav-btn-monospaced navbar-breakpoint-down-d-none"

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -1030,10 +1030,9 @@ public class AssetPublisherDisplayContext {
 		}
 
 		SearchContainer searchContainer = new SearchContainer(
-			_portletRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM,
-			getDelta(), getPortletURL(), null, null);
+			_portletRequest, getPortletURL(), null, null);
 
-		if (!isPaginationTypeNone()) {
+		if (isPaginationTypeNone()) {
 			searchContainer.setDelta(getDelta());
 			searchContainer.setDeltaConfigurable(false);
 		}

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -1032,7 +1032,7 @@ public class AssetPublisherDisplayContext {
 		SearchContainer searchContainer = new SearchContainer(
 			_portletRequest, getPortletURL(), null, null);
 
-		if (isPaginationTypeNone()) {
+		if (isPaginationTypeNone() || isPaginationTypeSimple()) {
 			searchContainer.setDelta(getDelta());
 			searchContainer.setDeltaConfigurable(false);
 		}
@@ -1353,6 +1353,14 @@ public class AssetPublisherDisplayContext {
 		String curPaginationType = getPaginationType();
 
 		return curPaginationType.equals(paginationType);
+	}
+
+	public boolean isPaginationTypeSimple() {
+		if (Objects.equals(getPaginationType(), PAGINATION_TYPE_SIMPLE)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	public boolean isSearchWithIndex() {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/servlet/taglib/util/AssetEntryActionDropdownItemsProvider.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/servlet/taglib/util/AssetEntryActionDropdownItemsProvider.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -135,9 +136,16 @@ public class AssetEntryActionDropdownItemsProvider {
 				redirect = _fullContentRedirect;
 			}
 
-			return _assetRenderer.getURLEdit(
+			PortletURL portletURL = _assetRenderer.getURLEdit(
 				_liferayPortletRequest, _liferayPortletResponse,
 				LiferayWindowState.NORMAL, redirect);
+
+			PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
+			portletURL.setParameter(
+				"portletResource", portletDisplay.getPortletName());
+
+			return portletURL;
 		}
 		catch (Exception e) {
 		}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets
 manual-export-enabled=Enable Manual Export
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple.
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported.
 ordering=Ordering
 other-site=Other Site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ar.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=أصول ذات صلة
 manual-export-enabled=التصدير اليدوي ممكّن
 manual-export-enabled-key-description=حدد هذه الخانة لتمكين المستخدمين من تحديد الأصول ذات الصلة يدويًا لتصديرها.
-number-of-items-to-display-help=الحد الأقصى لعدد العناصر المراد عرضها في حالة تعطيل تقسيم الصفحات، وإلا عرض عدد العناصر لكل صفحة.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=لا يتم دعم إلا قاعدة واحدة بالمجموعة {0}.
 ordering=إرسال طلب
 other-site=ولاية أخرى

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_bg.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Съответните активи (Automatic Translation)
 manual-export-enabled=Разреши ръчно износ (Automatic Translation)
 manual-export-enabled-key-description=Отметнете това квадратче, за да разрешите на потребителите да изберете ръчно съответните активи за експортиране. (Automatic Translation)
-number-of-items-to-display-help=Максимален брой елементи за показване ако пагинация е изключена, в противен случай брой елементи за показване на страница. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Поръчване (Automatic Translation)
 other-site=Друго състояние

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ca.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Continguts relacionats
 manual-export-enabled=Exportació manual habilitada
 manual-export-enabled-key-description=Activeu aquesta casella per permetre que els usuaris seleccionin manualment els continguts relacionats per exportar.
-number-of-items-to-display-help=El màxim nombre d'elements a visualitzar si la paginació està desactivada, en qualsevol altre cas, nombre d'elements a visualitzar per pàgina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Només es suporta una regla amb la combinació {0}.
 ordering=Ordenació
 other-site=Un altre lloc

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_cs.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Související položky
 manual-export-enabled=Povolit ruční Export (Automatic Translation)
 manual-export-enabled-key-description=Zaškrtněte toto políčko, chcete-li umožnit uživatelům ručně vybrat související aktiva pro export. (Automatic Translation)
-number-of-items-to-display-help=Maximální počet zobrazených položek, pokud je stránkování vypnuto. Pokud je zapnuto, jedná se o počet zobrazených položek na stránku.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Je podporováno pouze jedno pravidlo s kombinací {0}.
 ordering=Řazení (Automatic Translation)
 other-site=Jiný stav

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_da.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterede assets
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Other Site (Automatic Copy)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_de.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Verknüpfte Assets
 manual-export-enabled=Manueller Export aktiviert
 manual-export-enabled-key-description=Aktivieren Sie diese Option, damit Benutzer verbundene Assets zum Exportieren manuell auswählen können.
-number-of-items-to-display-help=Die Anzahl der anzuzeigenden Elemente wenn kein Seitenumbruch verwendet wird, ansonsten die maximale Anzahl von Elementen pro Seite.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Es wird nur eine Richtlinie mit der Kombination {0} unterstützt.
 ordering=Sortierung
 other-site=Andere Site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_el.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Σχετικά αντικείμενα
 manual-export-enabled=Ενεργοποίηση μη αυτόματης εξαγωγής (Automatic Translation)
 manual-export-enabled-key-description=Τσεκάρετε το κουτί αυτό για να επιτρέψετε στους χρήστες να επιλέξετε χειροκίνητα σχετικών περιουσιακών στοιχείων για την εξαγωγή. (Automatic Translation)
-number-of-items-to-display-help=Ο μέγιστος αριθμός αντικειμένων που θα εμφανίζονται αν η σελιδοποίηση είναι απενεργοποιημένη, ειδάλλως ο αριθμός των αντικειμένων ανά σελίδα.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Παραγγελία (Automatic Translation)
 other-site=Άλλη κατάσταση

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_en.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets
 manual-export-enabled=Enable Manual Export
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export.
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple.
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported.
 ordering=Ordering
 other-site=Other Site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_es.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Contenidos web relacionados
 manual-export-enabled=Exportación manual habilitada
 manual-export-enabled-key-description=Active esta casilla para permitir que los usuarios puedan seleccionar de forma manual los activos relacionados que se exportarán.
-number-of-items-to-display-help=Numero máximo de elementos a mostrar cuando la paginación está deshabilitada. En otro caso, número de elementos por página.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Sólo una regla con la combinación {0} es soportada
 ordering=Orden
 other-site=Otro Sitio

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_et.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Seotud varad (Automatic Translation)
 manual-export-enabled=Lubade kasutada käsitsi ekspordi programmi (Automatic Translation)
 manual-export-enabled-key-description=Märkige see ruut, et kasutajad valida käsitsi varade eksportida. (Automatic Translation)
-number-of-items-to-display-help=Palju üksusi kuvada kui lehekülgjaotuse on keelatud, muidu ühel lehel kuvatavate üksuste arv. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Tellimine (Automatic Translation)
 other-site=Muu riik

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_eu.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Erlazionatutako Edukiak
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Beste egoera

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fa.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=داده‌های مرتبط
 manual-export-enabled=صادر کردن کتابچه راهنمای کاربر را قادر می سازد (Automatic Translation)
 manual-export-enabled-key-description=این جعبه برای فعال کردن کاربران به دستی دارایی های مرتبط برای صادرات را انتخاب کنید. (Automatic Translation)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy) تعداد بخش‌های نمایشح
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=فقط یک قانون با ترکیب {0} پشتیبانی می‌شود.
 ordering=مرتب سازی
 other-site=سایر سایت‌ها

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fi.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Liittyvät sisällöt
 manual-export-enabled=Manuaalinen Vienti Käytössä
 manual-export-enabled-key-description=Valitse tämä ruutu salliaksesi käyttäjien manuaalisesti valita liittyviä sisältöjä vietäväksi.
-number-of-items-to-display-help=Suurin määrä kohteita näytettäväks ilman sivujakoa, muuten näytetään sivujaon mukainen määrä.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Vain yksi sääntö per yhdistelmä {0} on tuettu.
 ordering=Järjestäminen
 other-site=Toinen sivusto

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_fr.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Actifs associés
 manual-export-enabled=Exportation manuelle activée
 manual-export-enabled-key-description=Cochez cette option pour permettre aux utilisateurs de sélectionner manuellement les actifs liés à exporter.
-number-of-items-to-display-help=Nombre maximum d'éléments à afficher si la pagination est désactivée, sinon nombre d'items à afficher par page.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Une seule règle avec la combinaison {0} est supportée.
 ordering=Ordre
 other-site=Autre site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_gl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Elementos relacionados
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Outro estado

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hi_IN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=संबंधित संपत्ति (Automatic Translation)
 manual-export-enabled=मैंयुअल निर्यात सक्षम करें (Automatic Translation)
 manual-export-enabled-key-description=उपयोगकर्ताओं को निर्यात करने के लिए संबंधित परिसंपत्तियों को मैंयुअली चुनने में सक्षम करने के लिए इस बॉक्स को चेक (Automatic Translation)
-number-of-items-to-display-help=यदि पृष्ठ पर अंक लगाना अक्षम की गई है, प्रदर्शित करने के लिए आइटम्स की अधिकतम संख्या नहीं तो प्रति पृष्ठ प्रदर्शित करने के लिए आइटम्स की संख्या। (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=आदेश (Automatic Translation)
 other-site=अन्य साइट (Automatic Translation)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hr.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Srodna imovina
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Druga država

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_hu.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Kapcsolódó tartalmak
 manual-export-enabled=Manuális exportálás engedélyezve
 manual-export-enabled-key-description=Jelölje be ezt a mezőt, ha engedélyezni kívánja, hogy a felhasználók manuálisan válasszák ki exportálásra a kapcsolódó tartalmakat.
-number-of-items-to-display-help=Maximum tételek száma jelenjen meg, ha a lapozás ki van kapcsolva, egyébként az oldalankénti tételek száma jelenjen meg.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Csak egy szabály támogatott a {0}-val kombinálva.
 ordering=Sorrend
 other-site=Egyéb webhely

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_in.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Terkait Aset
 manual-export-enabled=Mengaktifkan ekspor Manual (Automatic Translation)
 manual-export-enabled-key-description=Centang kotak ini untuk memungkinkan pengguna untuk secara manual memilih aset terkait untuk ekspor. (Automatic Translation)
-number-of-items-to-display-help=Maksimum jumlah item untuk menampilkan jika pagination dinonaktifkan, jika jumlah item untuk ditampilkan per halaman. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Memesan (Automatic Translation)
 other-site=Negara Lain

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_it.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Risorse correlate
 manual-export-enabled=Abilitare l'esportazione manuale (Automatic Translation)
 manual-export-enabled-key-description=Selezionare questa casella per consentire agli utenti di selezionare manualmente i relativi beni da esportare. (Automatic Translation)
-number-of-items-to-display-help=Massimo numero di elementi da visualizzare se la paginazione é disabilitata, altrimenti, numero di elementi da visualizzare per pagina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=E' consentita solo una regola con la combinazione {0}.
 ordering=L'ordinazione (Automatic Translation)
 other-site=Altro Sito

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_iw.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=נכסים קשורים
 manual-export-enabled=ייצוא ידני מופעל
 manual-export-enabled-key-description=סמן תיבה זו כדי לאפשר למשתמשים לבחור באופן ידני נכסים הקשורים לייצוא.
-number-of-items-to-display-help=מספר מרבי של פריטים להצגה במקרה שהחלוקה לדפים אינה פעילה, אחרת, מספר הפריטים להצגה בכל דף.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=רק כלל אחד עם הצירוף {0} נתמך.
 ordering=סידור
 other-site=אתר אחר

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ja.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=関連するアセット
 manual-export-enabled=手動エクスポートを有効にする
 manual-export-enabled-key-description=ここにチェックすると、エクスポートする関連するアセットを手動で選択できる機能が有効になります。
-number-of-items-to-display-help=ページネーションが無効の場合は、表示できるだけのデータを表示します。もしくはページ毎に表示できるアイテム数を表示します。
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported={0}のコンビネーションにはひとつのルールしかサポートされていません。
 ordering=順序付け
 other-site=他のサイト

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_kk.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets (Automatic Copy)
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Other Site (Automatic Copy)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ko.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=관련된 자산 (Automatic Translation)
 manual-export-enabled=수동 내보내기 사용 (Automatic Translation)
 manual-export-enabled-key-description=사용자가 수동으로 내보낼 관련된 자산을 선택 하도록 설정 하려면이 확인란을 확인 하십시오. (Automatic Translation)
-number-of-items-to-display-help=페이지 매김을 사용 하는 경우 표시할 항목의 최대 수 그렇지 않으면 페이지 당 표시할 항목의 번호. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=주문 (Automatic Translation)
 other-site=그밖 국가

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lo.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=ຊັບພະຍາກອນທີ່ກ່ຽວຂ້ອງ
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=ລັດອື່ນໆ

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_lt.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Susijusio turto (Automatic Translation)
 manual-export-enabled=Įgalinti rankiniu būdu eksporto (Automatic Translation)
 manual-export-enabled-key-description=Pažymėkite šį laukelį, kad vartotojai galėtų pasirinkti neautomatiniu būdu eksportuoti susijusio turto. (Automatic Translation)
-number-of-items-to-display-help=Maksimalus naikintinų elementų Rodyti Jei numeracija yra išjungta, kitaip skaičius viename puslapyje rodomų elementų. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Užsisakyti (Automatic Translation)
 other-site=Kitos svetainės (Automatic Translation)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nb.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterte ressurser
 manual-export-enabled=Aktivere manuell eksport (Automatic Translation)
 manual-export-enabled-key-description=Merk av i denne boksen for å la brukerne velge manuelt relaterte eiendeler for å eksportere. (Automatic Translation)
-number-of-items-to-display-help=Maksimalt antall innlegg som skal vises dersom paginering er påslått, ellers antall innlegg som skal vises på hver side.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Bare en regel med kombinasjonen {0} støttes.
 ordering=Bestilling (Automatic Translation)
 other-site=Annet nettsted

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Gerelateerde content
 manual-export-enabled=Handmatige export ingeschakeld
 manual-export-enabled-key-description=Vink dit vakje aan om gebruikers toe te staan handmatige verwante assets te selecteren voor export.
-number-of-items-to-display-help=Maximaal aantal weer te geven items bij uitgeschakelde paginering. Anders het aantal items per pagina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Er wordt slechts één regel met de combinatie {0} ondersteund.
 ordering=Ordenen
 other-site=Andere site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_nl_BE.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Gerelateerde content
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximaal aantal weer te geven items als paginering is uitgeschakeld. Anders het het aantal items per pagina.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Andere provincie/staat

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Powiązane treści
 manual-export-enabled=Po ręcznym eksportu (Automatic Translation)
 manual-export-enabled-key-description=Zaznacz to pole, aby umożliwić użytkownikom ręcznie wybierz powiązane zasoby do eksportu. (Automatic Translation)
-number-of-items-to-display-help=Maksymalna liczba wyświetlanych elementów, o ile stronicowanie jest wyłączone, lub ilość elementów wyświetlanych na każdej stronie.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=W połączeniu z {0} tylko jedna reguła jest dozwolona.
 ordering=Zamawianie (Automatic Translation)
 other-site=Inne województwo

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_BR.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Conteúdo Relacionado
 manual-export-enabled=Exportação Manual Habilitada
 manual-export-enabled-key-description=Marcar esta caixa para permitir que os usuários selecionem manualmente os conteúdos relacionados a serem exportados.
-number-of-items-to-display-help=O número máximo de itens a serem exibidos se a paginação estiver desabilitada ou, caso contrário, o número de itens a serem exibidos por página.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Apenas uma regra é suportada com a combinação {0}.
 ordering=Ordem
 other-site=Outro site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_pt_PT.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Conteúdo Relacionado
 manual-export-enabled=Ativar exportação Manual (Automatic Translation)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Número máximo de itens apresentados caso a paginação esteja desabilitada, caso contrário, o número de itens apresentados por página.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Apenas uma regra com a combinação {0} é suportada.
 ordering=Ordering (Automatic Copy)
 other-site=Outro site

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ro.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Resurse conectate
 manual-export-enabled=Permite exportul manuală (Automatic Translation)
 manual-export-enabled-key-description=Bifați această casetă pentru a permite utilizatorilor să selecteze manual activelor legate de export. (Automatic Translation)
-number-of-items-to-display-help=Numărul maxim de elemente pentru a afişa dacă paginare este dezactivat, altfel numărul de elemente pentru a afişa pe pagină. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Comanda (Automatic Translation)
 other-site=Alt Judet

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ru.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Связанные ресурсы
 manual-export-enabled=Включить руководство экспорт (Automatic Translation)
 manual-export-enabled-key-description=Установите этот флажок, чтобы пользователи могли вручную выбрать связанные ресурсы для экспорта. (Automatic Translation)
-number-of-items-to-display-help=Максимально количестов элементов для показа, если постраничный просмотр отключен, иначе это будет количество элементов для показа на одной странице.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=С комбинацией {0} может быть только одно правило.
 ordering=Заказ (Automatic Translation)
 other-site=Другое состояние

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sk.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Súvisiace príspevky
 manual-export-enabled=Povolenie ručné vývozných (Automatic Translation)
 manual-export-enabled-key-description=Toto políčko umožňuje používateľom manuálne vybrať súvisiaceho majetku na export. (Automatic Translation)
-number-of-items-to-display-help=Maximálny počet zobrazovaných položiek ak je zakázané stránkovanie, inak počet položiek na stránku.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Podporované je len jedno pravidlo s kombináciou {0}.
 ordering=Objednávanie (Automatic Translation)
 other-site=Iné sídlo

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sl.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Povezanih sredstev (Automatic Translation)
 manual-export-enabled=Omogoči izvoz ročno (Automatic Translation)
 manual-export-enabled-key-description=Potrdite to polje, če želite omogočiti uporabnikom, da ročno izberete povezanih sredstev za izvoz. (Automatic Translation)
-number-of-items-to-display-help=Največje število elementov za prikaz označeno je onemogočena, sicer število elementov za prikaz na strani. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Naročanje (Automatic Translation)
 other-site=Drugo stanje

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Повезане Имовине
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Друга Стања

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Povezane Imovine
 manual-export-enabled=Enable Manual Export (Automatic Copy)
 manual-export-enabled-key-description=Check this box to enable users to manually select related assets to export. (Automatic Copy)
-number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page. (Automatic Copy)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Ordering (Automatic Copy)
 other-site=Other Site (Automatic Copy)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_sv.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Relaterat innehåll
 manual-export-enabled=Manuell export aktiverad
 manual-export-enabled-key-description=Markera den här rutan för att aktivera att användare manuellt kan välja relaterade tillgångar att exportera.
-number-of-items-to-display-help=Maximalt antal objekt att visa om sidnumrering är inaktiverat. Annars antalet objekt att visa per sida.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Endast en regel med kombinationen {0} stöds.
 ordering=Sortering
 other-site=Annat tillstånd

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_ta_IN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Related Assets
 manual-export-enabled=தானாக எக்ஸ்போர்ட் செய்வதை செயல்படுத்து
 manual-export-enabled-key-description=எக்ஸ்போர்ட் செய்ய தொடர்புடைய Assets-களை Manual-ஆக தேர்ந்தெடுப்பதற்கு பயனர்களை இயக்குவதற்கு இந்த பாக்ஸை டிக் செய்யவும்.
-number-of-items-to-display-help=Pagination முடக்கப்பட்டால் காட்டப்படும் அயிட்டம்களின் அதிகபட்ச எண்ணிக்கை, இல்லையெனில் ஒரு பக்கத்தில் காட்டப்படும் அயிட்டம்களின் எண்ணிக்கை.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=இதனுடன் {0} ஒரே ஒரு விதி மட்டும் ஆதரிக்கப்படுகிறது.
 ordering=வரிசைப்படுத்துதல்
 other-site=மற்ற தளங்கள்

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_th.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=สินทรัพย์ที่เกี่ยวข้อง (Automatic Translation)
 manual-export-enabled=เปิดใช้งานการส่งออกด้วยตนเอง (Automatic Translation)
 manual-export-enabled-key-description=เลือกช่องนี้เพื่อให้ผู้ใช้สามารถเลือกสินทรัพย์ที่เกี่ยวข้องกับการส่งออกด้วยตนเอง (Automatic Translation)
-number-of-items-to-display-help=จำนวนสูงสุดของรายการที่จะแสดงการแบ่งงาน หรือหมายเลขของสินค้าที่จะแสดงต่อหน้า (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=การสั่งซื้อ (Automatic Translation)
 other-site=เว็บไซต์อื่น ๆ (Automatic Translation)

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_tr.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=İlgili varlık (Automatic Translation)
 manual-export-enabled=El ile ihracat etkinleştirmek (Automatic Translation)
 manual-export-enabled-key-description=Kullanıcıların el ile vermek için ilgili kıymetleri seçmek bu onay kutusunu işaretleyin. (Automatic Translation)
-number-of-items-to-display-help=En fazla sayfalama devre dışıysa, görüntülenecek öğe sayısını aksi takdirde sayfa başına görüntülenecek öğe sayısı. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Sipariş (Automatic Translation)
 other-site=Diğer Şehir

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_uk.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Відповідних активів (Automatic Translation)
 manual-export-enabled=Увімкнути ручний експорту (Automatic Translation)
 manual-export-enabled-key-description=Позначте цей пункт, щоб надати користувачам можливість вибрати вручну відповідних активів для експорту. (Automatic Translation)
-number-of-items-to-display-help=Максимальна кількість елементів для відображення, якщо вимкнуто нумерацію сторінок, в іншому випадку кількість пунктів для відображення на сторінці. (Automatic Translation)
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Only one rule with the combination {0} is supported. (Automatic Copy)
 ordering=Замовлення (Automatic Translation)
 other-site=Інший стан

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_vi.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=Tài sản liên quan
 manual-export-enabled=Sử xuất khẩu hướng dẫn sử dụng (Automatic Translation)
 manual-export-enabled-key-description=Kiểm tra hộp này để cho phép người dùng tự lựa chọn các tài sản có liên quan để xuất khẩu. (Automatic Translation)
-number-of-items-to-display-help=Tham số quy định tổng số Nội dung được hiển thị nếu bỏ qua hiển thị dạng phân trang, trường hợp cho phép phân trang sẽ quy định số Nội dung được hiển thị trên từng trang.
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=Chỉ duy nhất luật với kết hợp {0} được hỗ trợ.
 ordering=Đặt hàng (Automatic Translation)
 other-site=Trạng thái khác

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_CN.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=相关资产
 manual-export-enabled=启用手动导出
 manual-export-enabled-key-description=选中此框可以让用户手动选择要导出的相关资产。
-number-of-items-to-display-help=页码禁用时，此值为展示条目的最大值，其他情况下，此值为每页展示条目数。
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=对于组合{0}只有一个规则是被支持的。
 ordering=排序
 other-site=其他站点

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/content/Language_zh_TW.properties
@@ -47,7 +47,7 @@ javax.portlet.title.com_liferay_asset_publisher_web_portlet_RecentContentPortlet
 javax.portlet.title.com_liferay_asset_publisher_web_portlet_RelatedAssetsPortlet=相關資產
 manual-export-enabled=啟用手動匯出 (Automatic Translation)
 manual-export-enabled-key-description=選中此框可使使用者手動選擇要匯出的相關資產。 (Automatic Translation)
-number-of-items-to-display-help=當分頁被停用時顯示最大項目數，否則顯示每頁項目數。
+number-of-items-to-display-help=Maximum number of items to display if pagination is disabled, otherwise number of items to display per page if pagination is simple. (Automatic Copy)
 only-one-rule-with-the-combination-x-is-supported=只有組合 {0} 的一個規則被支援。
 ordering=訂購 (Automatic Translation)
 other-site=其它站台

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataDefinitionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataDefinitionResourceTest.java
@@ -81,8 +81,6 @@ public class DataDefinitionResourceTest
 			"description", "definition name", "definition name");
 		_testGetSiteDataDefinitionsPage(
 			"description", "nam", "definition name");
-		_testGetSiteDataDefinitionsPage("description", "π€†", "π€† name");
-		_testGetSiteDataDefinitionsPage("π€† description", "π€†", "name");
 	}
 
 	@Ignore

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataLayoutResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataLayoutResourceTest.java
@@ -65,7 +65,6 @@ public class DataLayoutResourceTest extends BaseDataLayoutResourceTestCase {
 			"abcdefghijklmnopqrstuvwxyz0123456789");
 		_testGetDataDefinitionDataLayoutsPage("form layout", "form layout");
 		_testGetDataDefinitionDataLayoutsPage("layo", "form layout");
-		_testGetDataDefinitionDataLayoutsPage("π€† layout", "π€† layout");
 	}
 
 	@Ignore
@@ -86,7 +85,6 @@ public class DataLayoutResourceTest extends BaseDataLayoutResourceTestCase {
 			"abcdefghijklmnopqrstuvwxyz0123456789");
 		_testGetSiteDataLayoutPage("form layout", "form layout");
 		_testGetSiteDataLayoutPage("layo", "form layout");
-		_testGetSiteDataLayoutPage("π€†", "π€† layout");
 	}
 
 	@Ignore

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataRecordCollectionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v1_0/test/DataRecordCollectionResourceTest.java
@@ -60,8 +60,6 @@ public class DataRecordCollectionResourceTest
 		_testGetDataDefinitionDataRecordCollectionsPage(
 			"definition", "abcdefghijklmnopqrstuvwxyz0123456789",
 			"abcdefghijklmnopqrstuvwxyz0123456789");
-		_testGetDataDefinitionDataRecordCollectionsPage(
-			"description", "π€†", "π€† name");
 	}
 
 	@Override
@@ -74,7 +72,6 @@ public class DataRecordCollectionResourceTest
 		_testGetSiteDataRecordCollectionsPage(
 			"definition", "abcdefghijklmnopqrstuvwxyz0123456789",
 			"abcdefghijklmnopqrstuvwxyz0123456789");
-		_testGetSiteDataRecordCollectionsPage("description", "π€†", "π€† name");
 	}
 
 	@Ignore

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/DataLayoutBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/DataLayoutBuilder.es.js
@@ -147,14 +147,22 @@ class DataLayoutBuilder extends Component {
 		return {
 			...settingsContext,
 			pages: visitor.mapFields(field => {
-				const {fieldName} = field;
+				const {fieldName, localizable} = field;
 				const propertyName = this._getDataDefinitionFieldPropertyName(
 					fieldName
 				);
-				const propertyValue = this._getDataDefinitionFieldPropertyValue(
+				let propertyValue = this._getDataDefinitionFieldPropertyValue(
 					dataDefinitionField,
 					propertyName
 				);
+
+				if (
+					localizable &&
+					propertyValue &&
+					propertyValue[themeDisplay.getLanguageId()]
+				) {
+					propertyValue = propertyValue[themeDisplay.getLanguageId()];
+				}
 
 				return {
 					...field,
@@ -271,6 +279,7 @@ class DataLayoutBuilder extends Component {
 			'localizable',
 			'name',
 			'repeatable',
+			'required',
 			'tip'
 		];
 
@@ -288,8 +297,10 @@ class DataLayoutBuilder extends Component {
 	}
 
 	_getDataDefinitionFieldPropertyValue(dataDefinitionField, propertyName) {
-		if (this._isCustomProperty(propertyName)) {
-			return dataDefinitionField.customProperties[propertyName];
+		const {customProperties} = dataDefinitionField;
+
+		if (customProperties && this._isCustomProperty(propertyName)) {
+			return customProperties[propertyName];
 		}
 
 		return dataDefinitionField[propertyName];

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -213,7 +213,7 @@ public class DDMFormAdminDisplayContext {
 			return availableLocales;
 		}
 
-		return new Locale[] {getSiteDefaultLocale()};
+		return new Locale[] {getDefaultLocale()};
 	}
 
 	public String getClearResultsURL() throws PortletException {
@@ -417,7 +417,7 @@ public class DDMFormAdminDisplayContext {
 			return defaultLanguageId;
 		}
 
-		return LocaleUtil.toLanguageId(getSiteDefaultLocale());
+		return LocaleUtil.toLanguageId(getDefaultLocale());
 	}
 
 	public String getDisplayStyle() {
@@ -1109,6 +1109,16 @@ public class DDMFormAdminDisplayContext {
 			DDMFormWebKeys.DYNAMIC_DATA_MAPPING_FORM_INSTANCE_RECORD);
 	}
 
+	protected Locale getDefaultLocale() {
+		ThemeDisplay themeDisplay = formAdminRequestHelper.getThemeDisplay();
+
+		return Optional.ofNullable(
+			themeDisplay.getLocale()
+		).orElse(
+			themeDisplay.getSiteDefaultLocale()
+		);
+	}
+
 	protected String getDisplayStyle(
 		PortletRequest portletRequest,
 		DDMFormWebConfiguration formWebConfiguration, String[] displayViews) {
@@ -1302,12 +1312,6 @@ public class DDMFormAdminDisplayContext {
 				add(getOrderByDropdownItem("name"));
 			}
 		};
-	}
-
-	protected Locale getSiteDefaultLocale() {
-		ThemeDisplay themeDisplay = formAdminRequestHelper.getThemeDisplay();
-
-		return themeDisplay.getSiteDefaultLocale();
 	}
 
 	protected boolean hasResults() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -135,7 +135,11 @@
 
 			var ddmFormDefinition = <%= DDMUtil.getDDMFormJSONString(ddmForm) %>;
 
-			ddmFormDefinition.defaultLanguageId = '<%= LocaleUtil.toLanguageId(defaultLocale) %>';
+			var availableLanguageIds = ddmFormDefinition.availableLanguageIds;
+
+			if (availableLanguageIds.includes('<%= LocaleUtil.toLanguageId(defaultLocale) %>')) {
+				ddmFormDefinition.defaultLanguageId = '<%= LocaleUtil.toLanguageId(defaultLocale) %>';
+			}
 
 			var liferayDDMForm = Liferay.component(
 				'<portlet:namespace /><%= HtmlUtil.escapeJS(fieldsNamespace) %>ddmForm',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3603,7 +3603,17 @@ AUI.add(
 
 					var fieldOptions = fieldDefinition.options;
 
-					fieldOptions.unshift(instance._getPlaceholderOption());
+					if (fieldOptions && fieldOptions[0]) {
+						if (fieldOptions[0].value === '') {
+							var displayLocale = instance.get('displayLocale');
+
+							fieldOptions[0].label[displayLocale] = '';
+						} else {
+							fieldOptions.unshift(
+								instance._getPlaceholderOption()
+							);
+						}
+					}
 
 					return fieldOptions;
 				},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -875,6 +875,14 @@ AUI.add(
 				repeat() {
 					var instance = this;
 
+					var formDefinition = instance.get('definition');
+
+					formDefinition.fields.forEach(function(field) {
+						if (field.type === 'select') {
+							field.options.shift();
+						}
+					});
+
 					instance._getTemplate(function(fieldTemplate) {
 						var field = instance.createField(fieldTemplate);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -875,9 +875,9 @@ AUI.add(
 				repeat() {
 					var instance = this;
 
-					var formDefinition = instance.get('definition');
+					var definition = instance.get('definition');
 
-					formDefinition.fields.forEach(function(field) {
+					definition.fields.forEach(function(field) {
 						if (field.type === 'select') {
 							field.options.shift();
 						}

--- a/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/WEB-INF/liferay-look-and-feel.xml
+++ b/modules/apps/frontend-theme-fjord/frontend-theme-fjord/src/WEB-INF/liferay-look-and-feel.xml
@@ -7,6 +7,9 @@
 	</compatibility>
 	<theme id="fjord" name="Fjord">
 		<template-extension>ftl</template-extension>
+		<settings>
+			<setting configurable="false" key="color-palette" value="primary,success,danger,warning,info,dark,secondary,light,white" />
+		</settings>
 		<portlet-decorator id="barebone" name="Barebone">
 			<portlet-decorator-css-class>portlet-barebone</portlet-decorator-css-class>
 		</portlet-decorator>

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/src/WEB-INF/liferay-look-and-feel.xml
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/src/WEB-INF/liferay-look-and-feel.xml
@@ -8,7 +8,7 @@
 	<theme id="porygon" name="Porygon">
 		<template-extension>ftl</template-extension>
 		<settings>
-			<setting configurable="false" key="color-palette" value="primary,success,danger,warning,info,dark,gray-dark,secondary,light,lighter,white" />
+			<setting configurable="false" key="color-palette" value="primary,success,danger,warning,info,dark,secondary,light,white" />
 			<setting configurable="true" key="show-footer" type="checkbox" value="true" />
 			<setting configurable="true" key="show-header" type="checkbox" value="true" />
 			<setting configurable="true" key="show-header-main-search" type="checkbox" value="true" />

--- a/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/src/WEB-INF/liferay-look-and-feel.xml
+++ b/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/src/WEB-INF/liferay-look-and-feel.xml
@@ -8,7 +8,7 @@
 	<theme id="westeros-bank" name="Westeros Bank">
 		<template-extension>ftl</template-extension>
 		<settings>
-			<setting configurable="false" key="color-palette" value="primary,success,danger,warning,info,dark,gray-dark,secondary,light,lighter,white" />
+			<setting configurable="false" key="color-palette" value="primary,success,danger,warning,info,dark,secondary,light,white" />
 			<setting configurable="true" key="show-footer" type="checkbox" value="true" />
 			<setting configurable="true" key="show-global-menu-on" options="all-screens,big-screens,small-screen,no-screen" type="select" value="big-screens" />
 			<setting configurable="true" key="show-header" type="checkbox" value="true" />

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -652,6 +652,11 @@ public class JournalContentDisplayContext {
 				PortalUtil.getLiferayPortletRequest(_portletRequest), null,
 				LiferayWindowState.NORMAL, _themeDisplay.getURLCurrent());
 
+			PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
+			portletURL.setParameter(
+				"portletResource", portletDisplay.getPortletName());
+
 			return portletURL.toString();
 		}
 		catch (Exception e) {

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -20,7 +20,8 @@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.journal.content.web.internal.constants.JournalContentWebKeys" %><%@
+<%@ page import="com.liferay.journal.constants.JournalContentPortletKeys" %><%@
+page import="com.liferay.journal.content.web.internal.constants.JournalContentWebKeys" %><%@
 page import="com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext" %><%@
 page import="com.liferay.journal.content.web.internal.security.permission.resource.JournalArticlePermission" %><%@
 page import="com.liferay.journal.model.JournalArticle" %><%@

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -20,6 +20,8 @@
 JournalArticle article = journalContentDisplayContext.getArticle();
 %>
 
+<liferay-ui:success key='<%= JournalContentPortletKeys.JOURNAL_CONTENT + "requestProcessed" %>' message="your-request-completed-successfully" />
+
 <div class="visible-interaction">
 	<liferay-ui:icon-menu
 		cssClass="btn btn-monospaced btn-sm"

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -88,6 +88,7 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -1215,6 +1216,13 @@ public class ContentPageEditorDisplayContext {
 					return false;
 				}
 
+				if (ArrayUtil.contains(
+						_UNSUPPORTED_PORTLETS_NAMES,
+						portlet.getPortletName())) {
+
+					return false;
+				}
+
 				try {
 					return PortletPermissionUtil.contains(
 						themeDisplay.getPermissionChecker(),
@@ -1378,6 +1386,10 @@ public class ContentPageEditorDisplayContext {
 
 		return false;
 	}
+
+	private static final String[] _UNSUPPORTED_PORTLETS_NAMES = {
+		"com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet"
+	};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ContentPageEditorDisplayContext.class);

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_content.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_content.js
@@ -50,7 +50,7 @@ AUI.add(
 							instance._refreshContentList,
 							instance
 						),
-						Liferay.on('AddContent:addPortlet', function(event) {
+						Liferay.once('AddContent:addPortlet', function(event) {
 							instance.addPortlet(event.node, event.options);
 						})
 					);

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/constants/SegmentsExperimentConstants.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/constants/SegmentsExperimentConstants.java
@@ -145,7 +145,7 @@ public class SegmentsExperimentConstants {
 		},
 		TERMINATED(
 			STATUS_TERMINATED, "TERMINATED", "terminated", true, false, false,
-			true);
+			false);
 
 		public static int[] getExclusiveStatusValues() {
 			Stream<Status> stream = Arrays.stream(Status.values());

--- a/modules/apps/segments/segments-experiment-web/jest-setup.config.js
+++ b/modules/apps/segments/segments-experiment-web/jest-setup.config.js
@@ -25,3 +25,5 @@ window.Liferay.Util.sub = function(string, data) {
 		return data[key] === undefined ? match : data[key];
 	});
 };
+
+window.Liferay.Util.openToast = () => true;

--- a/modules/apps/segments/segments-experiment-web/jest-setup.config.js
+++ b/modules/apps/segments/segments-experiment-web/jest-setup.config.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const REGEX_SUB = /(?<=-|^)x(?=-|\s)/g;
+
+window.Liferay.Util.sub = function(string, data) {
+	if (
+		arguments.length > 2 ||
+		(typeof data !== 'object' && typeof data !== 'function')
+	) {
+		data = Array.prototype.slice.call(arguments, 1);
+	}
+	return string.replace(REGEX_SUB, function(match, key) {
+		return data[key] === undefined ? match : data[key];
+	});
+};

--- a/modules/apps/segments/segments-experiment-web/package.json
+++ b/modules/apps/segments/segments-experiment-web/package.json
@@ -15,6 +15,9 @@
 		"react": "16.9.0"
 	},
 	"jest": {
+		"setupFiles": [
+			"<rootDir>/jest-setup.config.js"
+		],
 		"testPathIgnorePatterns": [
 			"<rootDir>/test/js/[^/]+\\.js"
 		]

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ReviewExperimentModal.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ReviewExperimentModal.es.js
@@ -233,7 +233,7 @@ function ReviewExperimentModal({onRun, variants, visible, setVisible}) {
 									displayType="secondary"
 									onClick={onClose}
 								>
-									{Liferay.Language.get('Cancel')}
+									{Liferay.Language.get('cancel')}
 								</ClayButton>
 
 								<BusyButton
@@ -241,7 +241,7 @@ function ReviewExperimentModal({onRun, variants, visible, setVisible}) {
 									disabled={busy}
 									onClick={_handleRun}
 								>
-									{Liferay.Language.get('Run')}
+									{Liferay.Language.get('run')}
 								</BusyButton>
 							</ClayButton.Group>
 						)

--- a/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
@@ -237,6 +237,7 @@ function SegmentsExperimentsSidebar({
 		APIService.editExperimentStatus(body)
 			.then(function _successCallback(objectResponse) {
 				const {editable, status} = objectResponse.segmentsExperiment;
+
 				if (
 					status.value === STATUS_TERMINATED ||
 					status.value === STATUS_COMPLETED

--- a/modules/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
@@ -298,6 +298,8 @@ describe('Variants', () => {
 });
 
 describe('Run and review test', () => {
+	afterEach(cleanup);
+
 	it('can view review Experiment Modal', async () => {
 		const {
 			getByText,
@@ -327,6 +329,27 @@ describe('Run and review test', () => {
 
 		expect(confidenceSlider.length).toBe(1);
 		expect(splitSliders.length).toBe(2);
+	});
+
+	it('can view estimation time', async () => {
+		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+			APIService: {
+				getEstimatedTime: jest.fn(() =>
+					Promise.resolve({
+						segmentsExperimentEstimatedDaysDuration: 14
+					})
+				)
+			},
+			initialSegmentsExperiences: segmentsExperiences,
+			initialSegmentsExperiment: segmentsExperiment,
+			initialSegmentsVariants: segmentsVariants
+		});
+
+		const runTestButton = getByText('review-and-run-test');
+		userEvent.click(runTestButton);
+
+		await waitForElement(() => getByText('traffic-split'));
+		await waitForElement(() => getByText('14-days'));
 	});
 
 	test.todo('Running test cannot be edited');

--- a/modules/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/apps/segments/segments-experiment-web/test/js/components/SegmentsExperimentsSidebar.es.js
@@ -16,19 +16,15 @@ import '@testing-library/jest-dom/extend-expect';
 import {
 	cleanup,
 	fireEvent,
-	render,
 	waitForElement,
 	wait,
 	waitForElementToBeRemoved
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import SegmentsExperimentsSidebar from '../../../src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es';
-import SegmentsExperimentsContext from '../../../src/main/resources/META-INF/resources/js/context.es';
-import React from 'react';
+import renderApp from '../renderApp.es';
 import {
 	segmentsExperiment,
 	segmentsExperiences,
-	segmentsGoals,
 	segmentsVariants
 } from '../fixtures.es';
 import {INITIAL_CONFIDENCE_LEVEL} from '../../../src/main/resources/META-INF/resources/js/util/percentages.es';
@@ -47,69 +43,11 @@ jest.mock(
 	}
 );
 
-function _renderSegmentsExperimentsSidebarComponent({
-	classNameId = '',
-	classPK = '',
-	initialGoals = segmentsGoals,
-	initialSegmentsExperiences = [],
-	initialSegmentsExperiment,
-	initialSegmentsVariants = [],
-	APIService = {},
-	selectedSegmentsExperienceId,
-	type = 'content',
-	winnerSegmentsVariantId = null
-} = {}) {
-	const {
-		createExperiment = () => {},
-		createVariant = () => {},
-		deleteVariant = () => {},
-		editExperiment = () => {},
-		editVariant = () => {},
-		getEstimatedTime = () => Promise.resolve(),
-		publishExperience = () => {}
-	} = APIService;
-
-	return render(
-		<SegmentsExperimentsContext.Provider
-			value={{
-				APIService: {
-					createExperiment,
-					createVariant,
-					deleteVariant,
-					editExperiment,
-					editVariant,
-					getEstimatedTime,
-					publishExperience
-				},
-				assetsPath: '',
-				page: {
-					classNameId,
-					classPK,
-					type
-				}
-			}}
-		>
-			<SegmentsExperimentsSidebar
-				initialExperimentHistory={[]}
-				initialGoals={initialGoals}
-				initialSegmentsExperiences={initialSegmentsExperiences}
-				initialSegmentsExperiment={initialSegmentsExperiment}
-				initialSegmentsVariants={initialSegmentsVariants}
-				selectedSegmentsExperienceId={selectedSegmentsExperienceId}
-				winnerSegmentsVariantId={winnerSegmentsVariantId}
-			/>
-		</SegmentsExperimentsContext.Provider>,
-		{
-			baseElement: document.body
-		}
-	);
-}
-
 describe('SegmentsExperimentsSidebar', () => {
 	afterEach(cleanup);
 
 	it('renders info message ab testing panel only available for content pages', () => {
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			type: 'widget'
 		});
 
@@ -121,10 +59,7 @@ describe('SegmentsExperimentsSidebar', () => {
 	});
 
 	it('renders ab testing panel with experience selected and zero experiments', () => {
-		const {
-			getByText,
-			getByDisplayValue
-		} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText, getByDisplayValue} = renderApp({
 			initialSegmentsExperiences: segmentsExperiences
 		});
 
@@ -135,10 +70,7 @@ describe('SegmentsExperimentsSidebar', () => {
 	});
 
 	it('renders ab testing panel with experience selected and an experiment', () => {
-		const {
-			getByText,
-			getByDisplayValue
-		} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText, getByDisplayValue} = renderApp({
 			initialSegmentsExperiences: segmentsExperiences,
 			initialSegmentsExperiment: segmentsExperiment
 		});
@@ -157,7 +89,7 @@ describe('SegmentsExperimentsSidebar', () => {
 	});
 
 	it('renders modal to create experiment when the user clicks on create test button', async () => {
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			initialSegmentsExperiences: segmentsExperiences
 		});
 
@@ -174,7 +106,7 @@ describe('SegmentsExperimentsSidebar', () => {
 	});
 
 	it('renders experiment status label', () => {
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			initialSegmentsExperiment: segmentsExperiment
 		});
 
@@ -185,7 +117,7 @@ describe('SegmentsExperimentsSidebar', () => {
 	it("renders experiment without actions when it's not editable", () => {
 		segmentsExperiment.editable = false;
 
-		const {queryByTestId} = _renderSegmentsExperimentsSidebarComponent({
+		const {queryByTestId} = renderApp({
 			initialSegmentsExperiment: segmentsExperiment
 		});
 
@@ -199,7 +131,7 @@ describe('Variants', () => {
 	afterEach(cleanup);
 
 	it('renders no variants message', () => {
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			initialSegmentsExperiences: segmentsExperiences,
 			initialSegmentsExperiment: segmentsExperiment,
 			initialSegmentsVariants: [segmentsVariants[0]],
@@ -217,7 +149,7 @@ describe('Variants', () => {
 	});
 
 	it('renders variant list', () => {
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			initialSegmentsExperiences: segmentsExperiences,
 			initialSegmentsExperiment: segmentsExperiment,
 			initialSegmentsVariants: segmentsVariants,
@@ -244,10 +176,7 @@ describe('Variants', () => {
 				}
 			})
 		);
-		const {
-			getByText,
-			getByLabelText
-		} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText, getByLabelText} = renderApp({
 			APIService: {
 				createVariant: createVariantMock
 			},
@@ -287,7 +216,7 @@ describe('Variants', () => {
 	it("renders variants without create variant button when it's not editable", () => {
 		segmentsExperiment.editable = false;
 
-		const {queryByTestId} = _renderSegmentsExperimentsSidebarComponent({
+		const {queryByTestId} = renderApp({
 			initialSegmentsExperiment: segmentsExperiment
 		});
 
@@ -301,11 +230,7 @@ describe('Run and review test', () => {
 	afterEach(cleanup);
 
 	it('can view review Experiment Modal', async () => {
-		const {
-			getByText,
-			getByDisplayValue,
-			getAllByDisplayValue
-		} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText, getByDisplayValue, getAllByDisplayValue} = renderApp({
 			initialSegmentsExperiences: segmentsExperiences,
 			initialSegmentsExperiment: segmentsExperiment,
 			initialSegmentsVariants: segmentsVariants
@@ -332,7 +257,7 @@ describe('Run and review test', () => {
 	});
 
 	it('can view estimation time', async () => {
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			APIService: {
 				getEstimatedTime: jest.fn(() =>
 					Promise.resolve({
@@ -413,10 +338,7 @@ describe('Winner declared', () => {
 	afterEach(cleanup);
 
 	it('experiment has basic Winner Declared basic elements', () => {
-		const {
-			getByText,
-			getAllByText
-		} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText, getAllByText} = renderApp({
 			initialSegmentsExperiences: segmentsExperiences,
 			initialSegmentsExperiment: {
 				...segmentsExperiment,
@@ -449,7 +371,7 @@ describe('Winner declared', () => {
 				}
 			});
 		});
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			APIService: {
 				publishExperience: mockPublish
 			},
@@ -491,7 +413,7 @@ describe('Winner declared', () => {
 			});
 		});
 
-		const {getByText} = _renderSegmentsExperimentsSidebarComponent({
+		const {getByText} = renderApp({
 			APIService: {
 				publishExperience: mockDiscard
 			},

--- a/modules/apps/segments/segments-experiment-web/test/js/fixtures.es.js
+++ b/modules/apps/segments/segments-experiment-web/test/js/fixtures.es.js
@@ -83,3 +83,11 @@ export const segmentsVariants = [
 		split: 0.0
 	}
 ];
+
+/*
+ * Default values used by the tests in assertions and mocked responses
+ */
+export const DEFAULT_ESTIMATED_DAYS = {
+	message: '14-days',
+	value: 14
+};

--- a/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
+++ b/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+import {render} from '@testing-library/react';
+import {segmentsGoals} from './fixtures.es';
+import SegmentsExperimentsSidebar from '../../src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es';
+import SegmentsExperimentsContext from '../../src/main/resources/META-INF/resources/js/context.es';
+
+export default function renderApp({
+	classNameId = '',
+	classPK = '',
+	initialGoals = segmentsGoals,
+	initialSegmentsExperiences = [],
+	initialSegmentsExperiment,
+	initialSegmentsVariants = [],
+	APIService = {},
+	selectedSegmentsExperienceId,
+	type = 'content',
+	winnerSegmentsVariantId = null
+} = {}) {
+	const {
+		createExperiment = () => {},
+		createVariant = () => {},
+		deleteVariant = () => {},
+		editExperiment = () => {},
+		editVariant = () => {},
+		getEstimatedTime = () => Promise.resolve(),
+		publishExperience = () => {}
+	} = APIService;
+
+	return render(
+		<SegmentsExperimentsContext.Provider
+			value={{
+				APIService: {
+					createExperiment,
+					createVariant,
+					deleteVariant,
+					editExperiment,
+					editVariant,
+					getEstimatedTime,
+					publishExperience
+				},
+				assetsPath: '',
+				page: {
+					classNameId,
+					classPK,
+					type
+				}
+			}}
+		>
+			<SegmentsExperimentsSidebar
+				initialExperimentHistory={[]}
+				initialGoals={initialGoals}
+				initialSegmentsExperiences={initialSegmentsExperiences}
+				initialSegmentsExperiment={initialSegmentsExperiment}
+				initialSegmentsVariants={initialSegmentsVariants}
+				selectedSegmentsExperienceId={selectedSegmentsExperienceId}
+				winnerSegmentsVariantId={winnerSegmentsVariantId}
+			/>
+		</SegmentsExperimentsContext.Provider>,
+		{
+			baseElement: document.body
+		}
+	);
+}

--- a/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
+++ b/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
@@ -14,7 +14,11 @@
 
 import React from 'react';
 import {render} from '@testing-library/react';
-import {segmentsGoals, DEFAULT_ESTIMATED_DAYS} from './fixtures.es';
+import {
+	segmentsGoals,
+	DEFAULT_ESTIMATED_DAYS,
+	segmentsExperiment
+} from './fixtures.es';
 import SegmentsExperimentsSidebar from '../../src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es';
 import SegmentsExperimentsContext from '../../src/main/resources/META-INF/resources/js/context.es';
 
@@ -39,6 +43,9 @@ export default function renderApp({
 		getEstimatedTime = jest.fn(_getEstimatedTimeMock),
 		publishExperience = jest.fn(
 			_publishExperienceMockGenerator(initialSegmentsExperiment)
+		),
+		runExperiment = jest.fn(
+			_runExperimentMockGenerator(initialSegmentsExperiment)
 		)
 	} = APIService;
 
@@ -52,7 +59,8 @@ export default function renderApp({
 					editExperiment,
 					editVariant,
 					getEstimatedTime,
-					publishExperience
+					publishExperience,
+					runExperiment
 				},
 				assetsPath: '',
 				page: {
@@ -82,7 +90,8 @@ export default function renderApp({
 		APIServiceMocks: {
 			createVariant,
 			getEstimatedTime,
-			publishExperience
+			publishExperience,
+			runExperiment
 		}
 	};
 }
@@ -114,5 +123,19 @@ const _publishExperienceMockGenerator = experiment => ({status}) =>
 				label: 'completed',
 				value: status
 			}
+		}
+	});
+
+const _runExperimentMockGenerator = segmentsExperiment => ({
+	confidenceLevel,
+	segmentsExperimentId,
+	segmentsExperimentRels,
+	status
+}) =>
+	Promise.resolve({
+		segmentsExperiment: {
+			...segmentsExperiment,
+			editable: false,
+			status: {label: 'running', value: status}
 		}
 	});

--- a/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
+++ b/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
@@ -22,6 +22,7 @@ export default function renderApp({
 	classNameId = '',
 	classPK = '',
 	initialGoals = segmentsGoals,
+	initialExperimentHistory = [],
 	initialSegmentsExperiences = [],
 	initialSegmentsExperiment,
 	initialSegmentsVariants = [],
@@ -71,7 +72,7 @@ export default function renderApp({
 			}}
 		>
 			<SegmentsExperimentsSidebar
-				initialExperimentHistory={[]}
+				initialExperimentHistory={initialExperimentHistory}
 				initialGoals={initialGoals}
 				initialSegmentsExperiences={initialSegmentsExperiences}
 				initialSegmentsExperiment={initialSegmentsExperiment}
@@ -116,7 +117,10 @@ const _getEstimatedTimeMock = () =>
 		segmentsExperimentEstimatedDaysDuration: DEFAULT_ESTIMATED_DAYS.value
 	});
 
-const _publishExperienceMockGenerator = experiment => ({status}) =>
+const _publishExperienceMockGenerator = experiment => ({
+	status,
+	winnerSegmentsExperienceId
+}) =>
 	Promise.resolve({
 		segmentsExperiment: {
 			...experiment,
@@ -124,7 +128,8 @@ const _publishExperienceMockGenerator = experiment => ({status}) =>
 				label: 'completed',
 				value: status
 			}
-		}
+		},
+		winnerSegmentsExperienceId
 	});
 
 const _runExperimentMockGenerator = segmentsExperiment => ({status}) =>

--- a/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
+++ b/modules/apps/segments/segments-experiment-web/test/js/renderApp.es.js
@@ -14,11 +14,7 @@
 
 import React from 'react';
 import {render} from '@testing-library/react';
-import {
-	segmentsGoals,
-	DEFAULT_ESTIMATED_DAYS,
-	segmentsExperiment
-} from './fixtures.es';
+import {segmentsGoals, DEFAULT_ESTIMATED_DAYS} from './fixtures.es';
 import SegmentsExperimentsSidebar from '../../src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es';
 import SegmentsExperimentsContext from '../../src/main/resources/META-INF/resources/js/context.es';
 
@@ -39,6 +35,9 @@ export default function renderApp({
 		createVariant = jest.fn(_createVariantMock),
 		deleteVariant = () => {},
 		editExperiment = () => {},
+		editExperimentStatus = jest.fn(
+			_editExperimentStatusMockGenerator(initialSegmentsExperiment)
+		),
 		editVariant = () => {},
 		getEstimatedTime = jest.fn(_getEstimatedTimeMock),
 		publishExperience = jest.fn(
@@ -57,6 +56,7 @@ export default function renderApp({
 					createVariant,
 					deleteVariant,
 					editExperiment,
+					editExperimentStatus,
 					editVariant,
 					getEstimatedTime,
 					publishExperience,
@@ -89,6 +89,7 @@ export default function renderApp({
 		...renderMethods,
 		APIServiceMocks: {
 			createVariant,
+			editExperimentStatus,
 			getEstimatedTime,
 			publishExperience,
 			runExperiment
@@ -126,12 +127,7 @@ const _publishExperienceMockGenerator = experiment => ({status}) =>
 		}
 	});
 
-const _runExperimentMockGenerator = segmentsExperiment => ({
-	confidenceLevel,
-	segmentsExperimentId,
-	segmentsExperimentRels,
-	status
-}) =>
+const _runExperimentMockGenerator = segmentsExperiment => ({status}) =>
 	Promise.resolve({
 		segmentsExperiment: {
 			...segmentsExperiment,
@@ -139,3 +135,14 @@ const _runExperimentMockGenerator = segmentsExperiment => ({
 			status: {label: 'running', value: status}
 		}
 	});
+
+const _editExperimentStatusMockGenerator = experiment => ({status}) => {
+	return Promise.resolve({
+		segmentsExperiment: {
+			...experiment,
+			status: {
+				value: status
+			}
+		}
+	});
+};

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/js/main.js
@@ -79,16 +79,9 @@ AUI.add(
 							body: new FormData(form),
 							method: 'POST'
 						}
-					)
-						.then(response => {
-							return response.text();
-						})
-						.then(() => {
-							A.all('#' + form.id + ' input').set(
-								'checked',
-								false
-							);
-						});
+					).then(() => {
+						A.all('#' + form.id + ' input').set('checked', false);
+					});
 				},
 
 				_simulateSegmentsEntries() {
@@ -100,23 +93,19 @@ AUI.add(
 							body: new FormData(instance.get('form')),
 							method: 'POST'
 						}
-					)
-						.then(response => {
-							return response.text();
-						})
-						.then(() => {
-							const iframe = A.one('#simulationDeviceIframe');
+					).then(() => {
+						const iframe = A.one('#simulationDeviceIframe');
 
-							if (iframe) {
-								const iframeWindow = A.Node.getDOMNode(
-									iframe.get('contentWindow')
-								);
+						if (iframe) {
+							const iframeWindow = A.Node.getDOMNode(
+								iframe.get('contentWindow')
+							);
 
-								if (iframeWindow) {
-									iframeWindow.location.reload();
-								}
+							if (iframeWindow) {
+								iframeWindow.location.reload();
 							}
-						});
+						}
+					});
 				},
 
 				destructor() {

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/js/main.js
@@ -73,12 +73,10 @@ AUI.add(
 
 					var form = instance.get('form');
 
-					const body = new URLSearchParams(new FormData(form));
-
 					Liferay.Util.fetch(
 						instance.get('deactivateSimulationUrl'),
 						{
-							body,
+							body: new FormData(form),
 							method: 'POST'
 						}
 					)
@@ -96,14 +94,10 @@ AUI.add(
 				_simulateSegmentsEntries() {
 					var instance = this;
 
-					const body = new URLSearchParams(
-						new FormData(instance.get('form'))
-					);
-
 					Liferay.Util.fetch(
 						instance.get('simulateSegmentsEntriesUrl'),
 						{
-							body,
+							body: new FormData(instance.get('form')),
 							method: 'POST'
 						}
 					)

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java
@@ -27,7 +27,9 @@ import com.liferay.portal.kernel.model.LayoutStagingHandler;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalServiceUtil;
@@ -90,7 +92,10 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 		aopInvocationHandler.setTarget(
 			ProxyUtil.newProxyInstance(
 				LayoutLocalServiceStagingAdvice.class.getClassLoader(),
-				new Class<?>[] {LayoutLocalService.class},
+				new Class<?>[] {
+					IdentifiableOSGiService.class, LayoutLocalService.class,
+					BaseLocalService.class
+				},
 				new LayoutLocalServiceStagingInvocationHandler(
 					this, aopInvocationHandler.getTarget())));
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceStagingAdvice.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetStagingHandler;
 import com.liferay.portal.kernel.model.ModelWrapper;
+import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
+import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -54,7 +56,10 @@ public class LayoutSetLocalServiceStagingAdvice implements BeanFactoryAware {
 		aopInvocationHandler.setTarget(
 			ProxyUtil.newProxyInstance(
 				LayoutSetLocalServiceStagingAdvice.class.getClassLoader(),
-				new Class<?>[] {LayoutSetLocalService.class},
+				new Class<?>[] {
+					IdentifiableOSGiService.class, LayoutSetLocalService.class,
+					BaseLocalService.class
+				},
 				new LayoutSetLocalServiceStagingInvocationHandler(
 					aopInvocationHandler.getTarget())));
 	}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7490,7 +7490,8 @@
     #
     # Env: LIFERAY_JSONWS_PERIOD_WEB_PERIOD_SERVICE_PERIOD_PATHS_PERIOD_EXCLUDES
     #
-    jsonws.web.service.paths.excludes=
+    jsonws.web.service.paths.excludes=\
+        /user/update-password
 
     #
     # The property "jsonws.web.service.paths.includes" denotes patterns for JSON

--- a/portal-web/test/functional/com/liferay/portalweb/macros/CalendarEvent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CalendarEvent.macro
@@ -685,7 +685,7 @@ definition {
 			Refresh();
 		}
 
-		CalendarScheduler.viewSpecificEventNotVisible(eventTitle = "${eventTitle}");
+		CalendarScheduler.viewSpecificEventNotPresent(eventTitle = "${eventTitle}");
 	}
 
 	macro edit {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLNavigator.macro
@@ -22,10 +22,6 @@ definition {
 	macro gotoDDLRecordEditViaWorkflow {
 		Click(locator1 = "WorkflowSubmissionsTask#PREVIEW_EDIT");
 
-		SelectFrame(value1 = "relative=top");
-
-		SelectFrame(locator1 = "IFrame#DIALOG");
-
 		WorkflowAsset.viewDetails(
 			userName = "${userName}",
 			workflowStatus = "${workflowStatus}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/NavItem.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/NavItem.macro
@@ -24,6 +24,10 @@ definition {
 		NavItem.click(navItem = "Display Page Templates");
 	}
 
+	macro gotoFeeds {
+		NavItem.click(navItem = "Feeds");
+	}
+
 	macro gotoOrganizations {
 		NavItem.click(navItem = "Organizations");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContentNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContentNavigator.macro
@@ -56,6 +56,15 @@ definition {
 		AssertElementPresent(locator1 = "Icon#BACK");
 	}
 
+	macro gotoEditFeed {
+		AssertClick(
+			key_feedName = "${feedName}",
+			locator1 = "DDMSelectFeed#FEED_TABLE_NAME_LINK",
+			value1 = "${feedName}");
+
+		SelectFrame(value1 = "relative=top");
+	}
+
 	macro gotoEditStructure {
 		AssertClick(
 			key_ddlDataDefinitionName = "${structureName}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/template/WebContentFeeds.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/template/WebContentFeeds.macro
@@ -1,0 +1,47 @@
+definition {
+
+	macro addCP {
+		LexiconEntry.gotoAdd();
+
+		Type(
+			locator1 = "TextInput#NAME",
+			value1 = "${feedTitle}");
+
+		Type(
+			locator1 = "TextInput#TARGET_PAGE_FRIENDLY_URL",
+			value1 = "${pageFriendlyUrl}");
+
+		Panel.expandPanel(panel = "Web Content Constraints");
+
+		WebContentFeeds.selectStructure(structureName = "${structureName}");
+
+		SelectFrame(value1 = "relative=top");
+
+		PortletEntry.save();
+	}
+
+	macro selectStructure {
+		var key_ddlDataDefinitionName = "${structureName}";
+
+		AssertClick(
+			locator1 = "DDMEditTemplate#DETAILS_SELECT_STRUCTURE",
+			value1 = "Select");
+
+		SelectFrame(locator1 = "IFrame#DIALOG");
+
+		ClickNoError(
+			locator1 = "DDMSelectStructure#DDM_STRUCTURE_TABLE_NAME_LINK",
+			value1 = "${structureName}");
+
+		AssertConfirm(value1 = "Selecting a new structure changes the available templates and available feed item content. Do you want to proceed?");
+	}
+
+	macro viewTableEntryCP {
+		var key_feedName = "${feedName}";
+
+		AssertTextEquals(
+			locator1 = "DDMSelectFeed#FEED_TABLE_NAME",
+			value1 = "${feedName}");
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/EditableFloatingToolbar/PageEditorEditableLink.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/EditableFloatingToolbar/PageEditorEditableLink.macro
@@ -1,11 +1,50 @@
 definition {
 
+	@summary = "gotoEditableFieldLink must be called first"
+	macro _gotoFromContentField {
+		Select(
+			locator1 = "PageEditorEditableLink#LINK_TYPE",
+			value1 = "From Content Field");
+	}
+
+	macro _selectContent {
+		Click(locator1 = "PageEditorEditableLink#ASSET_SELECT_BUTTON");
+
+		Click(
+			assetType = "${assetType}",
+			locator1 = "PageEditorEditableLink#ASSET_SELECTION");
+
+		SelectFrame(locator1 = "IFrame#DIALOG");
+
+		LexiconEntry.gotoEntry(rowEntry = "${assetName}");
+
+		SelectFrameTop();
+	}
+
+	macro _selectField {
+		Select(
+			locator1 = "PageEditorEditableLink#FIELD",
+			value1 = "${field}");
+	}
+
 	macro gotoEditableFieldLink {
 		PageEditor.clickEditableField(
 			fragmentName = "${fragmentName}",
 			id = "${id}");
 
 		Click(locator1 = "PageEditor#EDITABLE_FIELD_TOOLBAR_LINK_BUTTON");
+	}
+
+	macro mapURLToAsset {
+		Variables.assertDefined(parameterList = "${assetName},${assetType},${field}");
+
+		PageEditorEditableLink._gotoFromContentField();
+
+		PageEditorEditableLink._selectContent(
+			assetName = "${assetName}",
+			assetType = "${assetType}");
+
+		PageEditorEditableLink._selectField(field = "${field}");
 	}
 
 	macro updateURL {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/sitepage/Page.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/sitepage/Page.macro
@@ -82,16 +82,34 @@ definition {
 		if ("${locale}" == "zh") {
 			var zhAlternate = '''" hreflang="zh-CN" rel="alternate" />''';
 
+			var hrefURL = selenium.getAttribute("//link[contains(@rel,'alternate')][contains(@hreflang,'zh-CN')]@href");
+
+			var hrefURLNoPortalURL = StringUtil.replace("${hrefURL}", "${portalURL}/zh", "");
+
 			var pageSource = StringUtil.add("${HTML}", "${portalURL}/zh${zhAlternate}","");
+
+			var pageSourceAlternate = StringUtil.add("${HTML}", "${portalURL}/zh/web/guest${zhAlternate}","");
 		}
 
 		else if ("${locale}" == "es") {
 			var esAlternate = '''" hreflang="es-ES" rel="alternate" />''';
 
-			var pageSource = StringUtil.add("${HTML}", "${portalURL}/es${esAlternate}","");
-		}
+			var hrefURL = selenium.getAttribute("//link[contains(@rel,'alternate')][contains(@hreflang,'es-ES')]@href");
 
-		AssertHTMLSourceTextPresent(value1 = "${pageSource}");
+			var hrefURLNoPortalURL = StringUtil.replace("${hrefURL}", "${portalURL}/es", "");
+
+			var pageSource = StringUtil.add("${HTML}", "${portalURL}/es${esAlternate}","");
+
+			var pageSourceAlternate = StringUtil.add("${HTML}", "${portalURL}/es/web/guest${esAlternate}","");
+		}
+		echo("${hrefURL}");
+
+		if ("${hrefURLNoPortalURL}" == "/web/guest") {
+			AssertHTMLSourceTextPresent(value1 = "${pageSourceAlternate}");
+		}
+		else {
+			AssertHTMLSourceTextPresent(value1 = "${pageSource}");
+		}
 	}
 
 	macro assertCannotDeleteOnlyPage {
@@ -107,18 +125,47 @@ definition {
 		var HTML2 = '''" rel="canonical" />''';
 
 		if (isSet(pageName)) {
-			var portalURL = StringUtil.add("${portalURL}", "/${pageName}","");
+			var pageNameURL = StringUtil.lowerCase("${pageName}");
 
-			var portalURL = StringUtil.lowerCase("${portalURL}");
-			var portalURL = StringUtil.replace("${portalURL}", " ", "-");
+			var pageNameURL = StringUtil.replace("${pageNameURL}", " ", "-");
+
+			var hrefURL = selenium.getAttribute("//link[contains(@rel,'canonical')]@href");
+
+			var hrefURLNoPageName = StringUtil.replace("${hrefURL}", "/${pageNameURL}", "");
+
+			var hrefURLNoPortalURL = StringUtil.replace("${hrefURLNoPageName}", "${portalURL}", "");
+
+			var pageSource = StringUtil.add("${HTML}", "${portalURL}/${pageNameURL}${HTML2}","");
+
+			var pageSourceAlternate = StringUtil.add("${HTML}", "${portalURL}/web/guest/${pageNameURL}${HTML2}","");
 		}
 
-		if (isSet(locale)) {
+		else if (isSet(locale)) {
+			var hrefURL = selenium.getAttribute("//link[contains(@rel,'canonical')]@href");
+
+			var hrefURLNoPortalURL = StringUtil.replace("${hrefURL}", "${portalURL}/${locale}", "");
+
 			var pageSource = StringUtil.add("${HTML}", "${portalURL}/${locale}${HTML2}","");
+
+			var pageSourceAlternate = StringUtil.add("${HTML}", "${portalURL}/${locale}/web/guest${HTML2}","");
 		}
 
 		else {
+			var hrefURL = selenium.getAttribute("//link[contains(@rel,'canonical')]@href");
+
+			var hrefURLNoPortalURL = StringUtil.replace("${hrefURL}", "${portalURL}", "");
+
 			var pageSource = StringUtil.add("${HTML}", "${portalURL}${HTML2}","");
+
+			var pageSourceAlternate = StringUtil.add("${HTML}", "${portalURL}/web/guest${HTML2}","");
+		}
+		echo("${hrefURL}");
+
+		if ("${hrefURLNoPortalURL}" == "/web/guest") {
+			AssertHTMLSourceTextPresent(value1 = "${pageSourceAlternate}");
+		}
+		else {
+			AssertHTMLSourceTextPresent(value1 = "${pageSource}");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TextInput.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TextInput.path
@@ -419,6 +419,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>TARGET_PAGE_FRIENDLY_URL</td>
+	<td>//input[contains(@id,'targetLayoutFriendlyUrl')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TEXT</td>
 	<td>//input[@type='text']</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectFeed.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectFeed.path
@@ -1,0 +1,25 @@
+<html>
+<head>
+<title>DDMSelectFeed</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">DDMSelectFeed</td></tr>
+</thead>
+<tbody>
+<!--FEED_TABLE-->
+<tr>
+	<td>FEED_TABLE_NAME</td>
+	<td>//div[contains(@id,'feedsSearchContainer')]//tr[contains(.,'${key_feedName}')]/td[count(//th[contains(.,'Name')]//preceding-sibling::th) + 1][1]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FEED_TABLE_NAME_LINK</td>
+	<td>//div[contains(@id,'feedsSearchContainer')]//tr[contains(.,'${key_feedName}')]/td[count(//th[contains(.,'Name')]//preceding-sibling::th) + 1]//a[1]</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditorEditableLink.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditorEditableLink.path
@@ -9,13 +9,28 @@
 </thead>
 <tbody>
 <tr>
+	<td>ASSET_SELECT_BUTTON</td>
+	<td>//button[contains(@id,'asset-select-button')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ASSET_SELECTION</td>
+	<td>//div[contains(@id,'asset-select-dropdown')]//button[contains(@data-asset-browser-window-title,'${assetType}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FIELD</td>
+	<td>//select[contains(@id,'floatingToolbarMappingPanelFieldSelect')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>URL</td>
 	<td>//div[contains(@class,'floating-toolbar-link-panel')]//input[contains(@id,'floatingToolbarLinkHrefPanelOption')]</td>
 	<td></td>
 </tr>
 <tr>
-	<td></td>
-	<td></td>
+	<td>LINK_TYPE</td>
+	<td>//select[contains(@id,'floatingToolbarLinkTypePanelOption')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/DMSharing.testcase
@@ -546,7 +546,7 @@ definition {
 		AssertElementNotPresent(locator1 = "Sharing#MODAL_INVITE_TO_COLLABORATE_TAG");
 	}
 
-	@description = "This test asserts that users can share via Shared Content app."
+	@description = "This test covers LPS-94585. It ensures that users can share via Shared Content app."
 	@priority = "5"
 	test ShareViaSharedContent {
 		JSONUser.addUser(
@@ -591,6 +591,8 @@ definition {
 		DMNavigator.gotoShareViaSharedContent(dmDocumentTitle = "DM Document Title");
 
 		DMDocument.shareWithNoSharingPermissionsUser(userEmailAddress = "userea2@liferay.com");
+
+		AssertConsoleTextNotPresent(value1 = "ArrayIndexOutOfBoundsException");
 
 		User.logoutPG();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/experiencemanagement/ContentPageReview.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/experiencemanagement/ContentPageReview.testcase
@@ -596,6 +596,8 @@ definition {
 			fragmentName = "Title",
 			openComment = "true");
 
+		Pause(locator1 = "5000");
+
 		var fragmentComment = "Title fragment comment";
 
 		if (!(IsElementPresent(locator1 = "PageEditor#FRAGMENT_SIDEBAR_COMMENT_ENTRY"))) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
@@ -726,6 +726,115 @@ definition {
 			webContentTitle = "Web Content Title2");
 	}
 
+	@description = "This is a use case for LPS-82757."
+	@priority = "3"
+	test PublishWebContentWithFeeds {
+		ProductMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "System Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Web Content",
+			configurationName = "Administration",
+			configurationScope = "System Scope");
+
+		FormFields.enableCheckbox(fieldName = "Show Feeds");
+
+		SystemSettings.saveConfiguration();
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Staging Test Page",
+			siteName = "Site Name");
+
+		Portlet.addPG(portletName = "Asset Publisher");
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name-staging");
+
+		NavItem.gotoFeeds();
+
+		WebContentFeeds.addCP(
+			feedTitle = "Web Content Feed",
+			pageFriendlyUrl = "/web/site-name-staging/staging-test-page",
+			structureName = "Basic Web Content");
+
+		WebContentFeeds.viewTableEntryCP(feedName = "Web Content Feed");
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Staging Test Page",
+			siteName = "Site Name");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive();
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
+
+		NavItem.gotoFeeds();
+
+		WebContentFeeds.viewTableEntryCP(feedName = "Web Content Feed");
+
+		SitePages.openPagesAdmin(siteURLKey = "site-name-staging");
+
+		SitePages.addPublicPage(pageName = "Second Page");
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Second Page",
+			siteName = "Site Name");
+
+		Portlet.addPG(portletName = "Web Content Display");
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name-staging");
+
+		NavItem.gotoFeeds();
+
+		WebContentNavigator.gotoEditFeed(feedName = "Web Content Feed");
+
+		var webContentFeedUrl = selenium.getAttribute("//a[contains(@href,'rss') and contains(.,'Preview')]@href");
+		var stagingFeedId = StringUtil.extractLast("${webContentFeedUrl}", "/");
+
+		echo("## * Staging FeedId: ${stagingFeedId}");
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name-staging");
+
+		WebContentNavigator.gotoAddCP();
+
+		WebContent.addCP(
+			webContentContent = "${webContentFeedUrl}",
+			webContentTitle = "Web Content Title");
+
+		AlloyEditor.addEntryExternalURL(entryExternalURL = "${webContentFeedUrl}");
+
+		Button.clickPublish();
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Second Page",
+			siteName = "Site Name");
+
+		WebContentDisplayPortlet.selectWebContent(webContentTitle = "Web Content Title");
+
+		Navigator.gotoStagedSitePage(
+			pageName = "Staging Test Page",
+			siteName = "Site Name");
+
+		Staging.gotoPublishToLive();
+
+		Staging.publishToLive();
+
+		Navigator.gotoSitePage(
+			pageName = "Second Page",
+			siteName = "Site Name");
+
+		var webContentFeedUrl = selenium.getAttribute("//div[contains(@class,'journal-content-article')]//a[contains(@href,'rss')]@href");
+		var liveFeedId = StringUtil.extractLast("${webContentFeedUrl}", "/");
+
+		echo("## * Live FeedId: ${liveFeedId}");
+
+		if ("${liveFeedId}" == "${stagingFeedId}") {
+			fail("The feedID should be different in live site.");
+		}
+	}
+
 	@priority = "4"
 	test SearchPublishTemplate {
 		ProductMenu.gotoPortlet(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsDataProvider.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsDataProvider.testcase
@@ -233,8 +233,6 @@ definition {
 
 		Form.editFieldLabelMetal(fieldValue = "Data Provider Select Field");
 
-		Form.gotoAutocompleteTab();
-
 		Form.editFieldDataProvider(
 			dataProvider = "Liferay Countries",
 			dataProviderOutput = "Country Names");
@@ -335,8 +333,6 @@ definition {
 		Form.gotoAddField(fieldType = "Select from List");
 
 		Form.editFieldLabelMetal(fieldValue = "Countries");
-
-		Form.gotoAutocompleteTab();
 
 		Form.editFieldDataProvider(
 			dataProvider = "Liferay Countries",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/contentpage/ContentPagesWithMapping.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/contentpage/ContentPagesWithMapping.testcase
@@ -59,4 +59,42 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-96794. Mapped Web Content will appear in the sidebar in a Page Editor's edit mode."
+	@priority = "5"
+	test MapWebContentURLToLinkFragment {
+		property portal.acceptance = "true";
+
+		JSONWebcontent.addWebContent(
+			content = "Test Content",
+			groupName = "Test Site Name",
+			title = "liferay.com");
+
+		ContentPagesNavigator.openEditContentPage(
+			pageName = "Content Page Name",
+			siteName = "Test Site Name");
+
+		PageEditor.addFragment(
+			collectionName = "Basic Sections",
+			fragmentName = "Banner Center");
+
+		PageEditorEditableLink.gotoEditableFieldLink(
+			fragmentName = "Banner Center",
+			id = "link");
+
+		PageEditorEditableLink.mapURLToAsset(
+			assetName = "liferay.com",
+			assetType = "Web Content Article",
+			field = "Title");
+
+		PageEditor.clickPublish();
+
+		ContentPagesNavigator.openViewContentPage(
+			pageName = "Content Page Name",
+			siteName = "Test Site Name");
+
+		task ("Assert editable has the specified URL mapped correctly") {
+			AssertElementPresent(locator1 = "//a[contains(@class,'btn')][contains(@href,'liferay.com')]");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/seo/CanonicalURL.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/seo/CanonicalURL.testcase
@@ -141,9 +141,7 @@ definition {
 
 		User.logoutPG();
 
-		Page.assertCanonicalURL(
-			locale = "en",
-			portalURL = "${portalURL}");
+		Page.assertCanonicalURL(portalURL = "${portalURL}");
 
 		Navigator.openSpecificURL(url = "${portalURL}/zh/");
 


### PR DESCRIPTION
/cc @brianikim

Notes from Brian:

> https://issues.liferay.com/browse/LPS-102240
> 
> Issue is that:
> 
> You cannot specify items per page using the pagination bar for asset publisher portlets. Page navigation behavior is similar as in other Control Panel menus, like in Web Content. The difference is that it's possible to specify the items per page, thus displaying the navigation if items are 6+ makes sense. In AP, it is not possible to specify items per page, rendering the pagination useless.
> 
> The reason for the issue is that our current searchContainer implementation logic for AssetPublisherDisplayContext is not in line with our other existing implementations.
> 
> For AssetPublisher, we allow paginationType "None","Regular", and "Simple".
> 
> The expected behaviors of the three are: (from https://portal.liferay.dev/docs/7-1/user/-/knowledge_base/u/configuring-display-settings)
> 
> > Pagination Type: This can be set to None, Simple, or Regular. None displays at most the number of assets specified in the Number of Items to Display property. Simple adds Previous and Next buttons for browsing through pages of assets in the Asset Publisher. Regular adds more options and information including First and Last buttons, a dropdown selector for pages, the number of items per page, and the total number of results (assets being displayed).
> 
> For our AP use-case, paginationType "Regular" needs to use the default searchContainer propKeys and propValues in determining its pagination while "None" and "Simple" should use the Number of Items to Display property set in the configuration setting for AP portlet.
> 
> Please let me know if you have any questions. Thanks.
> 
> Sincerely,
> Brian Kim