### PR TITLE
LPS-102749 When subscribing to a Live Site, use the defaultArticleURL…

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8125,19 +8125,26 @@ public class JournalArticleLocalServiceImpl
 		JournalArticle article, String portletId,
 		ServiceContext serviceContext) {
 
+		String defaultArticleURL = StringPool.BLANK;
+
+		try {
+			defaultArticleURL = _portal.getControlPanelFullURL(
+				article.getGroupId(), portletId, null);
+		}
+		catch (PortalException pe) {
+			_log.error(pe, pe);
+		}
+
 		LiferayPortletRequest liferayPortletRequest =
 			serviceContext.getLiferayPortletRequest();
 
 		if (liferayPortletRequest == null) {
-			return StringPool.BLANK;
+			return defaultArticleURL;
 		}
 
 		String urlViewInContext = StringPool.BLANK;
 
 		try {
-			String defaultArticleURL = _portal.getControlPanelFullURL(
-				article.getGroupId(), portletId, null);
-
 			AssetRendererFactory<JournalArticle> assetRendererFactory =
 				AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
 					JournalArticle.class);


### PR DESCRIPTION
/cc @joshuacords

Notes from Josh:
> https://issues.liferay.com/browse/LPS-102749
> https://issues.liferay.com/browse/LPP-35235
> 
> **Problem:** When notifications are sent out to live site subscribers in a staging environment, the liferayPortletRequest is null, this causes getURLViewInContext() to return "" which is later replaced with the notification portlet url instead of the appropriate Journal Article URL.
> 
> **Solution:** Use the defaultArticleURL which points to the correct portlet, if one can be created, in the above situation. 