### PR TITLE
[TECHNICAL-SUPPORT] LPS-102480 "layoutUpdateable" property for prototype layouts

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutServiceTest.java
@@ -19,6 +19,7 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -27,11 +28,14 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.sites.kernel.util.Sites;
 
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -99,6 +103,41 @@ public class LayoutServiceTest {
 		layoutTypePortlet.setLayoutTemplateId(userId, "1_column", false);
 
 		layout = LayoutLocalServiceUtil.updateLayout(layout);
+	}
+
+	@Test
+	public void testUpdateLayoutPrototypeVerifyTypeSettings() throws Exception {
+		LayoutPrototype layoutPrototype = LayoutTestUtil.addLayoutPrototype(
+			RandomTestUtil.randomString());
+
+		Layout layout = layoutPrototype.getLayout();
+
+		LayoutLocalServiceUtil.updateLayout(layout);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		long userId = layout.getUserId();
+
+		serviceContext.setUserId(userId);
+
+		LayoutLocalServiceUtil.updateLayout(
+			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
+			layout.getParentLayoutId(), layout.getNameMap(),
+			layout.getTitleMap(), layout.getDescriptionMap(),
+			layout.getKeywordsMap(), layout.getRobotsMap(), layout.getType(),
+			layout.isHidden(), layout.getFriendlyURLMap(),
+			layout.getIconImage(), null, serviceContext);
+
+		Layout updatedLayout = LayoutLocalServiceUtil.getLayout(
+			layout.getPlid());
+
+		UnicodeProperties typeSettingsProperties =
+			updatedLayout.getTypeSettingsProperties();
+
+		Assert.assertFalse(
+			"Updating layout prototype should not add " +
+				Sites.LAYOUT_UPDATEABLE + " property",
+			typeSettingsProperties.containsKey(Sites.LAYOUT_UPDATEABLE));
 	}
 
 	@DeleteAfterTestRun

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -2459,8 +2459,12 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 		UnicodeProperties typeSettingsProperties =
 			layout.getTypeSettingsProperties();
 
-		typeSettingsProperties.put(
-			Sites.LAYOUT_UPDATEABLE, String.valueOf(layoutUpdateable));
+		Group group = layout.getGroup();
+
+		if (!group.isLayoutPrototype()) {
+			typeSettingsProperties.put(
+				Sites.LAYOUT_UPDATEABLE, String.valueOf(layoutUpdateable));
+		}
 
 		if (privateLayout) {
 			typeSettingsProperties.put(


### PR DESCRIPTION
Hi @ealonso ,

The original issue (creating pages from templates in sites when the site has mandatory categories) is fixed in master recently by [LPS-101409](https://issues.liferay.com/browse/LPS-101409), which introduced selection of categories in the page creation form.
However, in all previous versions (7.2.x, 7.1.x, 7.0.x), it is permitted to create a page without enforcing the constraints. They can only be updated later, if these mandatory categories are selected. [LayoutAssetEntryValidatorExclusionRule](https://github.com/liferay/liferay-portal-ee/blob/b228b7a5b53f26ee0ea3c1d3c4301495e112d11d/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/asset/validator/LayoutAssetEntryValidatorExclusionRule.java#L65) was used to skip the validation at page creation. For this exclusion rule to work properly, it's required that the page created does not inherit the `layoutUpdateable` property from the template.

I made this change to avoid adding `layoutUpdateable`, which is not required for page templates.

Please review my changes.

Thanks,
Vendel
