### PR TITLE
[TECHNICAL-SUPPORT] LPS-103229 FTL embedded repeatable fields

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/image.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/image.ftl
@@ -5,13 +5,6 @@
 	variableFieldEntryId = name + ".getAttribute(\"fileEntryId\")"
 />
 
-<#if repeatable>
-	<#assign
-		variableAltName = "cur_" + variableAltName
-		variableFieldEntryId = "cur_" + variableFieldEntryId
-	/>
-</#if>
-
 <#if stringUtil.equals(language, "ftl")>
 ${r"<#if"} ${variableName}?? && ${variableName} != "">
 	<img alt="${getVariableReferenceCode(variableAltName)}" data-fileentryid="${getVariableReferenceCode(variableFieldEntryId)}" src="${getVariableReferenceCode(variableName)}" />

--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/init.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/init.ftl
@@ -1,10 +1,10 @@
 <#-- Common -->
 
-<#assign variableName = name + ".getData()" />
-
 <#if repeatable>
-	<#assign variableName = "cur_" + variableName />
+	<#assign name = "cur_" + stringUtil.replace(name, ".", "_") />
 </#if>
+
+<#assign variableName = name + ".getData()" />
 
 <#-- Util -->
 

--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/journal-article.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/journal-article.ftl
@@ -5,13 +5,6 @@
 	variableFriendlyUrl = name + ".getFriendlyUrl()"
 />
 
-<#if repeatable>
-	<#assign
-		variableData = "cur_" + variableData
-		variableFriendlyUrl = "cur_" + variableFriendlyUrl
-	/>
-</#if>
-
 <#if stringUtil.equals(language, "ftl")>
 ${r"<#assign"}
 	webContentData = jsonFactoryUtil.createJSONObject(${variableData})

--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/link-to-page.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/link-to-page.ftl
@@ -2,10 +2,6 @@
 
 <#assign variableName = name + ".getFriendlyUrl()" />
 
-<#if repeatable>
-	<#assign variableName = "cur_" + variableName />
-</#if>
-
 <a href="${getVariableReferenceCode(variableName)}">
 	${label}
 </a>

--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/repeatable.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/repeatable.ftl
@@ -1,5 +1,5 @@
 <#assign
-	itemName = "cur_" + name
+	itemName = "cur_" + stringUtil.replace(name, ".", "_")
 
 	variableName = name + ".getSiblings()"
 />


### PR DESCRIPTION
Hi @ealonso ,

I restructured the variable name generation a bit: when it's a repeatable field, we should use the "encoded" variable name, e.g.: "cur_Abc_Def" instead of "cur_Abc.Def". This worked for all the test cases I could think of. However, overwriting the "name" field in init.ftl seems a bit of a risky change.

Please review my changes.

Thanks,
Vendel