### PR TITLE
[TECHNICAL-SUPPORT] LPS-103273 Generated FTL for embedded geolocation fields

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/geolocation.ftl
+++ b/modules/apps/journal/journal-web/src/main/resources/com/liferay/journal/web/portlet/template/dependencies/geolocation.ftl
@@ -1,5 +1,7 @@
 <#include "init.ftl">
 
+<#assign encodedName = stringUtil.replace(name, ".", "_")  />
+
 <#if stringUtil.equals(language, "ftl")>
 	${r"<#assign"} latitude = 0>
 	${r"<#assign"} longitude = 0>
@@ -14,7 +16,7 @@
 			geolocation=true
 			latitude=latitude
 			longitude=longitude
-			name="${name}${r"${randomizer.nextInt()}"}"
+			name="${encodedName}${r"${randomizer.nextInt()}"}"
 		/>
 	${r"</#if>"}
 <#else>


### PR DESCRIPTION
Hi @ealonso ,

I discovered this issue while testing [LPS-103229](https://issues.liferay.com/browse/LPS-103229). It seems like `<@liferay_map>` does not work correctly when it has a "." in its `name` attribute.

Please review my changes.

Thanks,
Vendel