### PR TITLE
LPS-103719 Set node path to be shown by the view

### DIFF
--- a/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
@@ -209,6 +209,8 @@ public class AssetCategoriesSelectorDisplayContext {
 				"id", category.getCategoryId()
 			).put(
 				"name", category.getTitle(themeDisplay.getLocale())
+			).put(
+				"nodePath", category.getPath(themeDisplay.getLocale(), true)
 			);
 
 			if (getSelectedCategories().contains(

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -125,6 +125,7 @@ class SelectCategory extends PortletBase {
 			newVal.forEach(node => {
 				data[node.id] = {
 					categoryId: node.vocabulary ? 0 : node.id,
+					nodePath: node.nodePath,
 					value: node.name,
 					vocabularyId: node.vocabulary ? node.id : 0
 				};
@@ -134,6 +135,7 @@ class SelectCategory extends PortletBase {
 				if (newVal.indexOf(node) === -1) {
 					data[node.id] = {
 						categoryId: node.vocabulary ? 0 : node.id,
+						nodePath: node.nodePath,
 						unchecked: true,
 						value: node.name,
 						vocabularyId: node.vocabulary ? node.id : 0

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/cards_treeview/CardsTreeview.soy
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/cards_treeview/CardsTreeview.soy
@@ -52,6 +52,7 @@
 		icon: string,
 		id: string,
 		name: string,
+		nodePath: string,
 		selected: bool,
 		value: string
 	]}
@@ -89,9 +90,11 @@
 
 					{call .card}
 						{param icon: $node.icon /}
+						{param nodePath: $node.nodePath /}
 						{param path: $path /}
 						{param pathThemeImages: $pathThemeImages /}
 						{param title: $node.name /}
+						{param viewType: $viewType /}
 					{/call}
 				</div>
 
@@ -113,9 +116,11 @@
  */
 {template .card}
 	{@param icon: string}
+	{@param? nodePath: string}
 	{@param path: string}
 	{@param pathThemeImages: string}
 	{@param title: string}
+	{@param? viewType: string}
 
 	{let $nodeAttributes kind="attributes"}
 		class="card card-horizontal"
@@ -141,6 +146,11 @@
 				<span class="lfr-card-title-text text-default text-truncate treeview-node-name">
 					{$title}
 				</span>
+				{if $viewType == 'flat' and isNonnull($nodePath)}
+					<span class="lfr-card-subtitle-text text-default text-truncate treeview-node-name">
+						{$nodePath}
+					</span>
+				{/if}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Hi,
This pull fixes https://issues.liferay.com/browse/LPS-103719.

Part of it changes the taglib CardsTreeView to show the path in each card when the nodes are being filtered with a search.

I could see that this CardsTreeView is being used in several other areas such as:
- When creating a new SiteNavigationMenuItem of type layout.
- When moving a journal article to another folder
- When selecting a display page for a journal article
Because of this, I tested these other areas and I made my changes optional so this path should only be shown if the node contains a path.

Could you please take a look a it?
Thanks!