### PR TITLE
LPS-103343 Using Display Page Templates with articles that have friendly URL with special characters gives 404 error

### DIFF
--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -152,9 +151,6 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 
 	@Reference
 	protected AssetHelper assetHelper;
-
-	@Reference
-	protected Http http;
 
 	@Reference
 	protected InfoDisplayContributorTracker infoDisplayContributorTracker;
@@ -282,7 +278,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 				friendlyURL.length() - versionClassPKValue.length() - 1);
 		}
 
-		return http.encodePath(urlTitle);
+		return urlTitle;
 	}
 
 	private long _getVersionClassPK(String friendlyURL) {


### PR DESCRIPTION
Hi Eudaldo,
Could you please review this pull request?
This issue probably caused by [LPS-100542](https://issues.liferay.com/browse/LPS-100542)
The problem is we encode twice at return.
I tested my solution with the following cases:

Original version:
1. /  char in the URL, OK
2. common chars, OK
3. “ char looks like - in the URL, but the content is showing
4. 败敗 chars, ERROR
5. special chars (for example: á,é,ű,ú), ERROR

New version with one encode:
1. /  char in the URL, OK
2. common chars, OK
3. “ char looks like - in the URL, but the content is showing
4. 败敗, OK
5. special chars (for example: á,é,ű,ú), OK

Thank you and best regards,
Marci