### PR TITLE
[TECHNICAL-SUPPORT] LPS-102838 Display absolute path of Layouts and JournalArticles in staging messages

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -96,6 +96,7 @@ import java.io.File;
 import java.io.InputStream;
 
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -184,6 +185,41 @@ public class JournalArticleStagedModelDataHandler
 
 	@Override
 	public String getDisplayName(JournalArticle article) {
+		try {
+			StringBundler sb = new StringBundler();
+
+			if (article.getFolderId() !=
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+
+				JournalFolder folder = article.getFolder();
+
+				List<JournalFolder> ancestors = folder.getAncestors();
+
+				Collections.reverse(ancestors);
+
+				for (JournalFolder ancestor : ancestors) {
+					sb.append(ancestor.getName());
+					sb.append(StringPool.SPACE);
+					sb.append(StringPool.GREATER_THAN);
+					sb.append(StringPool.SPACE);
+				}
+
+				sb.append(folder.getName());
+				sb.append(StringPool.SPACE);
+				sb.append(StringPool.GREATER_THAN);
+				sb.append(StringPool.SPACE);
+			}
+
+			sb.append(article.getTitleCurrentValue());
+
+			return sb.toString();
+		}
+		catch (PortalException pe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(pe, pe);
+			}
+		}
+
 		return article.getTitleCurrentValue();
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalFolderStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalFolderStagedModelDataHandler.java
@@ -25,8 +25,12 @@ import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.model.JournalFolderConstants;
 import com.liferay.journal.service.JournalFolderLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -35,6 +39,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -91,6 +96,30 @@ public class JournalFolderStagedModelDataHandler
 
 	@Override
 	public String getDisplayName(JournalFolder folder) {
+		try {
+			List<JournalFolder> ancestors = folder.getAncestors();
+
+			StringBundler sb = new StringBundler(4 * ancestors.size() + 1);
+
+			Collections.reverse(ancestors);
+
+			for (JournalFolder ancestor : ancestors) {
+				sb.append(ancestor.getName());
+				sb.append(StringPool.SPACE);
+				sb.append(StringPool.GREATER_THAN);
+				sb.append(StringPool.SPACE);
+			}
+
+			sb.append(folder.getName());
+
+			return sb.toString();
+		}
+		catch (PortalException pe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(pe, pe);
+			}
+		}
+
 		return folder.getName();
 	}
 
@@ -282,6 +311,9 @@ public class JournalFolderStagedModelDataHandler
 
 		_journalFolderLocalService = journalFolderLocalService;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalFolderStagedModelDataHandler.class);
 
 	private DDMStructureLocalService _ddmStructureLocalService;
 	private JournalFolderLocalService _journalFolderLocalService;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -181,6 +181,30 @@ public class LayoutStagedModelDataHandler
 
 	@Override
 	public String getDisplayName(Layout layout) {
+		try {
+			List<Layout> ancestors = layout.getAncestors();
+
+			Collections.reverse(ancestors);
+
+			StringBundler sb = new StringBundler(4 * ancestors.size() + 1);
+
+			for (Layout ancestor : ancestors) {
+				sb.append(ancestor.getNameCurrentValue());
+				sb.append(StringPool.SPACE);
+				sb.append(StringPool.GREATER_THAN);
+				sb.append(StringPool.SPACE);
+			}
+
+			sb.append(layout.getNameCurrentValue());
+
+			return sb.toString();
+		}
+		catch (PortalException pe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(pe, pe);
+			}
+		}
+
 		return layout.getNameCurrentValue();
 	}
 


### PR DESCRIPTION
Hi @ealonso ,

cc: @moltam89

I implemented this staging-related fix by adding the absolute path generation to each `StagedModelDataHandler`'s `getDisplayName()` method. This method is used when displaying staging progress or error messages.

I also considered using [JournalHelperImpl.getAbsolutePath(..)](https://github.com/liferay/liferay-portal/blob/2d571f94caed70f2a32dc5a014d405cb8e53842a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalHelperImpl.java#L110), however, that requires a PortletRequest, which we don't have at this point. Although, it might be cleaner to implement new methods here.

Please review my changes.

Thanks,
Vendel