### PR TITLE
[TS] LPS-104398

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -1613,6 +1613,12 @@ public interface JournalArticleLocalService
 		PortletDataContext portletDataContext);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public String getFolderURLViewInContext(
+			JournalArticle article, String portletId,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -1947,6 +1947,15 @@ public class JournalArticleLocalServiceUtil {
 		return getService().getExportActionableDynamicQuery(portletDataContext);
 	}
 
+	public static String getFolderURLViewInContext(
+			com.liferay.journal.model.JournalArticle article, String portletId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().getFolderURLViewInContext(
+			article, portletId, serviceContext);
+	}
+
 	public static
 		com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery
 			getIndexableActionableDynamicQuery() {

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -2008,6 +2008,16 @@ public class JournalArticleLocalServiceWrapper
 	}
 
 	@Override
+	public String getFolderURLViewInContext(
+			JournalArticle article, String portletId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.getFolderURLViewInContext(
+			article, portletId, serviceContext);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery
 		getIndexableActionableDynamicQuery() {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -67,6 +67,8 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.portlet.PortletProvider;
+import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -81,6 +83,7 @@ import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlEscapableObject;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -1043,7 +1046,8 @@ public class JournalArticleStagedModelDataHandler
 				_importFriendlyURLEntries(
 					portletDataContext, article, importedArticle);
 
-				_sendUndeliveredUserNotificationEvents(article);
+				_sendUndeliveredUserNotificationEvents(
+					article, importedArticle, serviceContext);
 			}
 			finally {
 				ServiceContextThreadLocal.popServiceContext();
@@ -1465,7 +1469,8 @@ public class JournalArticleStagedModelDataHandler
 	}
 
 	private void _sendUndeliveredUserNotificationEvents(
-		JournalArticle article) {
+		JournalArticle article, JournalArticle importedArticle,
+		ServiceContext serviceContext) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_userNotificationEventLocalService.getActionableDynamicQuery();
@@ -1489,9 +1494,6 @@ public class JournalArticleStagedModelDataHandler
 				userNotificationEvent -> {
 					userNotificationEvent.setDelivered(true);
 
-					_userNotificationEventLocalService.
-						updateUserNotificationEvent(userNotificationEvent);
-
 					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 						userNotificationEvent.getPayload());
 
@@ -1509,9 +1511,48 @@ public class JournalArticleStagedModelDataHandler
 						(Map)JSONFactoryUtil.looseDeserialize(
 							String.valueOf(jsonObject.get("context")));
 
+					String portletId = PortletProviderUtil.getPortletId(
+						JournalArticle.class.getName(),
+						PortletProvider.Action.EDIT);
+
+					String articleURL =
+						_journalArticleLocalService.getFolderURLViewInContext(
+							importedArticle, portletId, serviceContext);
+
+					HashMap<String, Object> articleURLMap =
+						HashMapBuilder.<String, Object>put(
+							"escape", true
+						).put(
+							"escapedValue",
+							() -> {
+								HtmlEscapableObject escapedObject =
+									new HtmlEscapableObject<>(articleURL, true);
+
+								return escapedObject.getEscapedValue();
+							}
+						).put(
+							"originalValue", articleURL
+						).build();
+
+					contextMap.put("[$ARTICLE_URL$]", articleURLMap);
+
 					contextMap.forEach(
 						(key, value) -> subscriptionSender.setContextAttribute(
 							key, value.get("originalValue")));
+
+					jsonObject.put(
+						"context", contextMap
+					).put(
+						"entryURL", articleURL
+					);
+
+					userNotificationEvent.setPayload(jsonObject.toString());
+
+					userNotificationEvent.setTimestamp(
+						System.currentTimeMillis());
+
+					_userNotificationEventLocalService.
+						updateUserNotificationEvent(userNotificationEvent);
 
 					JournalGroupServiceConfiguration
 						journalGroupServiceConfiguration =

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -45,6 +45,7 @@ import com.liferay.journal.configuration.JournalGroupServiceConfiguration;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.constants.JournalActivityKeys;
 import com.liferay.journal.constants.JournalConstants;
+import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.exception.ArticleExpirationDateException;
 import com.liferay.journal.exception.ArticleFriendlyURLException;
 import com.liferay.journal.exception.ArticleReviewDateException;
@@ -3166,6 +3167,31 @@ public class JournalArticleLocalServiceImpl
 					"folderId", String.valueOf(folder.getFolderId()));
 
 				articleURL = portletURL.toString();
+			}
+		}
+
+		if (Validator.isNull(articleURL)) {
+			try {
+				articleURL = _portal.getControlPanelFullURL(
+					article.getGroupId(), portletId, null);
+
+				StringBundler sb = new StringBundler(9);
+				JournalFolder folder = article.getFolder();
+
+				sb.append(articleURL);
+				sb.append("&_");
+				sb.append(JournalPortletKeys.JOURNAL);
+				sb.append("_group=");
+				sb.append(folder.getGroupId());
+				sb.append("&_");
+				sb.append(JournalPortletKeys.JOURNAL);
+				sb.append("_folderId=");
+				sb.append(folder.getFolderId());
+
+				articleURL = sb.toString();
+			}
+			catch (PortalException pe) {
+				_log.error(pe, pe);
 			}
 		}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8142,7 +8142,7 @@ public class JournalArticleLocalServiceImpl
 		String portletId = PortletProviderUtil.getPortletId(
 			JournalArticle.class.getName(), PortletProvider.Action.EDIT);
 
-		String articleURL = getURLViewInContext(
+		String articleURL = getFolderURLViewInContext(
 			article, portletId, serviceContext);
 
 		String articleStatus = LanguageUtil.get(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -103,6 +103,7 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletProvider;
 import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.portlet.PortletRequestModel;
@@ -191,6 +192,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -3139,6 +3142,34 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		return articles.get(0);
+	}
+
+	public String getFolderURLViewInContext(
+			JournalArticle article, String portletId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		String articleURL = StringPool.BLANK;
+
+		LiferayPortletResponse liferayPortletResponse =
+			serviceContext.getLiferayPortletResponse();
+
+		if (liferayPortletResponse != null) {
+			PortletURL portletURL = liferayPortletResponse.createRenderURL();
+
+			if (portletURL != null) {
+				JournalFolder folder = article.getFolder();
+
+				portletURL.setParameter(
+					"groupId", String.valueOf(folder.getGroupId()));
+				portletURL.setParameter(
+					"folderId", String.valueOf(folder.getFolderId()));
+
+				articleURL = portletURL.toString();
+			}
+		}
+
+		return articleURL;
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-104398

From @joshuacords:

> Problem: Notifications for Web Content always directed users to the root folder (of the staging site if local staging).
> 
> Solution: Proposed here https://liferay.slack.com/archives/CMFC54M1N/p1573508487009900 have the Notification redirect to the article's direct folder (and to the article's site if staging).
> 
> Most of the complication was in the JournalArticleStagedModelDataHandler where we need to update the notification to contain the proper URLs in the case of having a subscriber on a Live site in Local Staging. There's no Liferay utilities to help us, so it is almost completely manual manipulation. Similarly, in the getFolderURLViewInContext(), manipulating the URL in the case of staging is manual. I kept the liferayPortletResponse as the primary way to generate the URL. It's preferred because that URL will contain the p_p_auth token id which we have no access to without the Response.