### PR TITLE
J cords lps 104398 rebased 2

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalUtil.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalUtil.java
@@ -22,6 +22,7 @@ import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.internal.transformer.JournalTransformer;
 import com.liferay.journal.internal.transformer.JournalTransformerListenerRegistryUtil;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.model.JournalStructureConstants;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.petra.string.CharPool;
@@ -37,6 +38,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletProvider;
 import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.portlet.PortletRequestModel;
@@ -44,6 +46,7 @@ import com.liferay.portal.kernel.portlet.ThemeDisplayModel;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateHandlerRegistryUtil;
@@ -204,6 +207,39 @@ public class JournalUtil {
 			rootElement, tokens,
 			JournalStructureConstants.RESERVED_ARTICLE_AUTHOR_JOB_TITLE,
 			userJobTitle);
+	}
+
+	public static String getFolderURLViewInContext(
+			JournalArticle article, String portletId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		String articleURL = StringPool.BLANK;
+
+		LiferayPortletResponse liferayPortletResponse =
+			serviceContext.getLiferayPortletResponse();
+
+		if (liferayPortletResponse != null) {
+			PortletURL portletURL = liferayPortletResponse.createRenderURL();
+
+			try {
+				JournalFolder folder = article.getFolder();
+
+				if (portletURL != null) {
+					portletURL.setParameter(
+						"groupId", String.valueOf(folder.getGroupId()));
+					portletURL.setParameter(
+						"folderId", String.valueOf(folder.getFolderId()));
+
+					articleURL = portletURL.toString();
+				}
+			}
+			catch (PortalException pe) {
+				_log.error(pe, pe);
+			}
+		}
+
+		return articleURL;
 	}
 
 	public static String getJournalControlPanelLink(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalUtil.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalUtil.java
@@ -19,6 +19,7 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalServiceUtil;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.internal.transformer.JournalTransformer;
 import com.liferay.journal.internal.transformer.JournalTransformerListenerRegistryUtil;
 import com.liferay.journal.model.JournalArticle;
@@ -233,6 +234,31 @@ public class JournalUtil {
 
 					articleURL = portletURL.toString();
 				}
+			}
+			catch (PortalException pe) {
+				_log.error(pe, pe);
+			}
+		}
+
+		if (Validator.isNull(articleURL)) {
+			try {
+				articleURL = PortalUtil.getControlPanelFullURL(
+					article.getGroupId(), portletId, null);
+
+				StringBundler sb = new StringBundler(9);
+				JournalFolder folder = article.getFolder();
+
+				sb.append(articleURL);
+				sb.append("&_");
+				sb.append(JournalPortletKeys.JOURNAL);
+				sb.append("_group=");
+				sb.append(folder.getGroupId());
+				sb.append("&_");
+				sb.append(JournalPortletKeys.JOURNAL);
+				sb.append("_folderId=");
+				sb.append(folder.getFolderId());
+
+				articleURL = sb.toString();
 			}
 			catch (PortalException pe) {
 				_log.error(pe, pe);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8111,7 +8111,7 @@ public class JournalArticleLocalServiceImpl
 		String portletId = PortletProviderUtil.getPortletId(
 			JournalArticle.class.getName(), PortletProvider.Action.EDIT);
 
-		String articleURL = getURLViewInContext(
+		String articleURL = JournalUtil.getFolderURLViewInContext(
 			article, portletId, serviceContext);
 
 		String articleStatus = LanguageUtil.get(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-104398

cc @chriskian

Resent from: https://github.com/ealonso/liferay-portal/pull/2630

I put the method into the JournalUtil. I also made sure article.getFolder() was inside trys. getFolder() should either throw an exception or [return a folder](https://github.com/liferay/liferay-portal/blob/ffbfff2673f2ada7c16f021ede1caa0562de7280/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java#L345-L347).

Let me know any specific changes still needed.

> Problem: Notifications for Web Content always directed users to the root folder (of the staging site if local staging).
> 
> Solution: Proposed here https://liferay.slack.com/archives/CMFC54M1N/p1573508487009900 have the Notification redirect to the article's direct folder (and to the article's site if staging).
> 
> Most of the complication was in the JournalArticleStagedModelDataHandler where we need to update the notification to contain the proper URLs in the case of having a subscriber on a Live site in Local Staging. There's no Liferay utilities to help us, so it is almost completely manual manipulation. Similarly, in the getFolderURLViewInContext(), manipulating the URL in the case of staging is manual. I kept the liferayPortletResponse as the primary way to generate the URL. It's preferred because that URL will contain the p_p_auth token id which we have no access to without the Response.