### PR TITLE
[TS] LPS-105099 Same logic as in view.jsp

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -903,7 +903,7 @@ public class JournalDisplayContext {
 			return _searchContainer;
 		}
 
-		if (!isSearch()) {
+		if (!isSearch() || isWebContentTabSelected()) {
 			_searchContainer = _getArticlesSearchContainer();
 
 			return _searchContainer;


### PR DESCRIPTION
Hi @ealonso ,

If we are initiating a search on the Journal Portlet JournalDisplayContext#getTabs1() will return empty string. This results in JournalDisplayContext#_getVersionsSearchContainer() being used for displaying the search results of a keyword search.

I think we should mimic the view.jsp's [logic](https://github.com/brianchandotcom/liferay-portal/pull/78848/files#diff-c0c7f26dff3a740a35a466efd572fa6eR129) to determine the correct Search Container.

Can you please review?
https://issues.liferay.com/browse/LPS-105099

Thanks,
Balázs