### PR TITLE
[TECHNICAL SUPPORT] LPS-105801

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
@@ -469,7 +469,7 @@ public class DDMTemplateStagedModelDataHandler
 
 			try {
 				portletDataContext.importPermissions(
-					getResourceName(template), template.getPrimaryKey(),
+					getResourceName(importedTemplate), template.getPrimaryKey(),
 					importedTemplate.getPrimaryKey());
 			}
 			catch (Exception e) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-105801

Use importedTemplate instead of template because it has the correct resourceClassNameId value populated from target environment