### PR TITLE
[TECHNICAL-SUPPORT] LPS-105858 Asset Publisher configuration removes tags from filter values after validation error

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -550,15 +550,17 @@ public class AssetPublisherDisplayContext {
 				"queryName" + queryLogicIndex, "assetTags");
 
 			if (Objects.equals(queryName, "assetTags")) {
-				queryValues = ParamUtil.getString(
-					_httpServletRequest, "queryTagNames" + queryLogicIndex,
-					queryValues);
-
-				queryValues = _assetPublisherWebUtil.filterAssetTagNames(
-					_themeDisplay.getScopeGroupId(), queryValues);
-
 				String[] tagNames = StringUtil.split(
-					queryValues, StringPool.COMMA);
+						queryValues, StringPool.COMMA);
+				
+				tagNames = ParamUtil.getStringValues(
+					_httpServletRequest, "queryTagNames" + queryLogicIndex,
+					tagNames);
+
+				tagNames = _assetPublisherWebUtil.filterAssetTagNames(
+					_themeDisplay.getScopeGroupId(), tagNames);
+
+				queryValues = StringUtil.merge(tagNames);
 
 				if (ArrayUtil.isEmpty(tagNames)) {
 					continue;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherWebUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherWebUtil.java
@@ -198,13 +198,11 @@ public class AssetPublisherWebUtil {
 		return _ddmIndexer.encodeName(ddmStructureId, fieldName, locale);
 	}
 
-	public String filterAssetTagNames(long groupId, String assetTagNames) {
+	public String[] filterAssetTagNames(long groupId, String[] assetTagNames) {
 		List<String> filteredAssetTagNames = new ArrayList<>();
 
-		String[] assetTagNamesArray = StringUtil.split(assetTagNames);
-
 		long[] assetTagIds = _assetTagLocalService.getTagIds(
-			groupId, assetTagNamesArray);
+			groupId, assetTagNames);
 
 		for (long assetTagId : assetTagIds) {
 			AssetTag assetTag = _assetTagLocalService.fetchAssetTag(assetTagId);
@@ -214,7 +212,7 @@ public class AssetPublisherWebUtil {
 			}
 		}
 
-		return StringUtil.merge(filteredAssetTagNames);
+		return ArrayUtil.toStringArray(filteredAssetTagNames);
 	}
 
 	public String getClassName(AssetRendererFactory<?> assetRendererFactory) {


### PR DESCRIPTION
Hi @ealonso ,

In [AssetPublisherConfigurationAction.getQueryRule(..)](https://github.com/liferay/liferay-portal/blob/22934b9e8a4d33478335582031ac42bed2a1d5a6/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/action/AssetPublisherConfigurationAction.java#L466-L467), tag names are already read from ActionRequest as string arrays. I applied a similar method for AssetPublisherDisplayContext.getAutoFieldRulesJSONArray(..).

Please review my changes.

Thanks,
Vendel