### PR TITLE
[TECHNICAL-SUPPORT] LPS-106615 Don't localize text in Language Selector Portlet

### DIFF
--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/template/dependencies/portlet_display_template_long_text.ftl
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/template/dependencies/portlet_display_template_long_text.ftl
@@ -13,6 +13,7 @@
 				href=entry.getURL()
 				label=entry.getLongDisplayName()
 				lang=entry.getW3cLanguageId()
+				localizeLabel=false
 			/>
 		</#if>
 	</#list>

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/template/dependencies/portlet_display_template_select_box.ftl
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/template/dependencies/portlet_display_template_select_box.ftl
@@ -34,6 +34,7 @@
 					disabled=entry.isDisabled()
 					label=entry.getLongDisplayName()
 					lang=entry.getW3cLanguageId()
+					localizeLabel=false
 					selected=entry.isSelected()
 					value=entry.getLanguageId()
 				/>


### PR DESCRIPTION
Hi @ealonso ,

I added `localizeLabel=false` to the FTL templates of the Language Selector portlet. This way it won't translate the word "English" to the current language.

Please review my changes.

Thanks,
Vendel