### PR TITLE
[TECHNICAL-SUPPORT] LPS-107050 Fix the order of query parameters

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
@@ -1105,16 +1105,16 @@ public class JournalArticleFinderImpl
 			qPos.add(groupId);
 			qPos.add(classNameId);
 
+			for (long folderId : folderIds) {
+				qPos.add(folderId);
+			}
+
 			if (queryDefinition.getOwnerUserId() > 0) {
 				qPos.add(queryDefinition.getOwnerUserId());
 
 				if (queryDefinition.isIncludeOwner()) {
 					qPos.add(WorkflowConstants.STATUS_IN_TRASH);
 				}
-			}
-
-			for (long folderId : folderIds) {
-				qPos.add(folderId);
 			}
 
 			qPos.add(queryDefinition.getStatus());


### PR DESCRIPTION
Hi @ealonso ,

It seems like the query parameter were added in the wrong order. The `folderId` and `userId` values were mixed up, resulting always in a 0 count.

Please review my changes.

Thanks,
Vendel