### PR TITLE
[TECHNICAL-SUPPORT] LPS-108003 Check before removing language prefix from the URL

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -118,7 +118,9 @@ public class UpdateLanguageAction implements Action {
 		if (themeDisplay.isI18n()) {
 			String i18nPath = themeDisplay.getI18nPath();
 
-			layoutURL = layoutURL.substring(i18nPath.length());
+			if (layoutURL.startsWith(i18nPath)) {
+				layoutURL = layoutURL.substring(i18nPath.length());
+			}
 		}
 
 		Layout layout = themeDisplay.getLayout();


### PR DESCRIPTION
Hi @ealonso ,

This code change will handle the case when a language-specific Home URL is set for the instance. The actual `layoutURL` does not contain the language part, while `themeDisplay` will still show it does.

Please review my change.

Thanks,
Vendel