### PR TITLE
LPS-110199 | Parent folder cannot be restricted to different structure than child folder's if latter has contents

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalFolderModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalFolderModelValidator.java
@@ -107,8 +107,13 @@ public class JournalFolderModelValidator
 		}
 
 		for (JournalFolder curFolder : folders) {
-			validateArticleDDMStructures(
-				curFolder.getFolderId(), ddmStructureIds);
+			if (curFolder.getRestrictionType() !=
+					JournalFolderConstants.
+						RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW) {
+
+				validateArticleDDMStructures(
+					curFolder.getFolderId(), ddmStructureIds);
+			}
 		}
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
@@ -162,6 +162,64 @@ public class JournalFolderServiceTest {
 	}
 
 	@Test
+	public void testAddRestrictionToParentWithRestrictedChildFolder()
+		throws Exception {
+
+		JournalFolder parentFolder = JournalTestUtil.addFolder(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test 1");
+
+		JournalFolder childFolder = JournalTestUtil.addFolder(
+			_group.getGroupId(), parentFolder.getFolderId(), "Test 2");
+
+		String xml = DDMStructureTestUtil.getSampleStructuredContent(
+			"Test Article");
+
+		DDMStructure childDDMStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), childDDMStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class),
+			LocaleUtil.getDefault());
+
+		JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(), childFolder.getFolderId(),
+			JournalArticleConstants.CLASSNAME_ID_DEFAULT, xml,
+			childDDMStructure.getStructureKey(), ddmTemplate.getTemplateKey());
+
+		long[] childDDMStructureIds = {childDDMStructure.getStructureId()};
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			childFolder.getFolderId(), childFolder.getParentFolderId(),
+			childFolder.getName(), childFolder.getDescription(),
+			childDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		DDMStructure parentDDMStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		long[] parentDDMStructureIds = {parentDDMStructure.getStructureId()};
+
+		parentFolder = JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			parentFolder.getFolderId(), parentFolder.getParentFolderId(),
+			parentFolder.getName(), parentFolder.getDescription(),
+			parentDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		Assert.assertEquals(
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			parentFolder.getRestrictionType());
+	}
+
+	@Test
 	public void testGetInheritedWorkflowFolderId() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
@@ -544,6 +544,91 @@ public class JournalFolderServiceTest {
 	}
 
 	@Test
+	public void testRemoveChildRestriction() throws Exception {
+		JournalFolder parentFolder = JournalTestUtil.addFolder(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test 1");
+
+		DDMStructure parentDDMStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		long[] parentDDMStructureIds = {parentDDMStructure.getStructureId()};
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		parentFolder = JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			parentFolder.getFolderId(), parentFolder.getParentFolderId(),
+			parentFolder.getName(), parentFolder.getDescription(),
+			parentDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		JournalFolder childFolder = JournalTestUtil.addFolder(
+			_group.getGroupId(), parentFolder.getFolderId(), "Test 2");
+
+		String xml = DDMStructureTestUtil.getSampleStructuredContent(
+			"Test Article");
+
+		DDMStructure childDDMStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		long[] childDDMStructureIds = {childDDMStructure.getStructureId()};
+
+		JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			childFolder.getFolderId(), childFolder.getParentFolderId(),
+			childFolder.getName(), childFolder.getDescription(),
+			childDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		DDMTemplate childDDMTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), childDDMStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class),
+			LocaleUtil.getDefault());
+
+		JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(), childFolder.getFolderId(),
+			JournalArticleConstants.CLASSNAME_ID_DEFAULT, xml,
+			childDDMStructure.getStructureKey(),
+			childDDMTemplate.getTemplateKey());
+
+		try {
+			JournalFolderLocalServiceUtil.updateFolder(
+				TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+				childFolder.getFolderId(), childFolder.getParentFolderId(),
+				childFolder.getName(), childFolder.getDescription(),
+				new long[0], JournalFolderConstants.RESTRICTION_TYPE_INHERIT,
+				false, serviceContext);
+
+			Assert.fail();
+		}
+		catch (InvalidDDMStructureException invalidDDMStructureException) {
+		}
+
+		JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			parentFolder.getFolderId(), parentFolder.getParentFolderId(),
+			parentFolder.getName(), parentFolder.getDescription(),
+			childDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		childFolder = JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			childFolder.getFolderId(), childFolder.getParentFolderId(),
+			childFolder.getName(), childFolder.getDescription(),
+			new long[0], JournalFolderConstants.RESTRICTION_TYPE_INHERIT,
+			false, serviceContext);
+
+		Assert.assertEquals(
+			JournalFolderConstants.RESTRICTION_TYPE_INHERIT,
+			childFolder.getRestrictionType());
+	}
+
+	@Test
 	public void testSubfolders() throws Exception {
 		JournalFolder folder1 = JournalTestUtil.addFolder(
 			_group.getGroupId(),

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderServiceTest.java
@@ -631,6 +631,68 @@ public class JournalFolderServiceTest {
 		}
 	}
 
+	@Test
+	public void testUpdateParentWithRestriction() throws Exception {
+		JournalFolder parentFolder = JournalTestUtil.addFolder(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test 1");
+
+		DDMStructure parentDDMStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		long[] parentDDMStructureIds = {parentDDMStructure.getStructureId()};
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		parentFolder = JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			parentFolder.getFolderId(), parentFolder.getParentFolderId(),
+			parentFolder.getName(), parentFolder.getDescription(),
+			parentDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		JournalFolder childFolder = JournalTestUtil.addFolder(
+			_group.getGroupId(), parentFolder.getFolderId(), "Test 2");
+
+		String xml = DDMStructureTestUtil.getSampleStructuredContent(
+			"Test Article");
+
+		DDMStructure childDDMStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		long[] childDDMStructureIds = {childDDMStructure.getStructureId()};
+
+		JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			childFolder.getFolderId(), childFolder.getParentFolderId(),
+			childFolder.getName(), childFolder.getDescription(),
+			childDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		DDMTemplate childDDMTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), childDDMStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class),
+			LocaleUtil.getDefault());
+
+		JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(), childFolder.getFolderId(),
+			JournalArticleConstants.CLASSNAME_ID_DEFAULT, xml,
+			childDDMStructure.getStructureKey(),
+			childDDMTemplate.getTemplateKey());
+
+		parentFolder = JournalFolderLocalServiceUtil.updateFolder(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			parentFolder.getFolderId(), parentFolder.getParentFolderId(),
+			parentFolder.getName(), "Description 1", parentDDMStructureIds,
+			JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW,
+			false, serviceContext);
+
+		Assert.assertEquals("Description 1", parentFolder.getDescription());
+	}
+
 	@DeleteAfterTestRun
 	private Group _group;
 


### PR DESCRIPTION
Hi @ealonso, 

This issue reported by a customer using 7.2. 

Before creating [LPS-110199](https://issues.liferay.com/browse/LPS-110199) there was a discussion in [PTR-1569](https://issues.liferay.com/browse/PTR-1569) about expected behavior. 

The solution has two parts:
- The first focuses on allowing subfolders to define their own restrictions, irrespective of restrictions on folders above it.
- The second makes sure that whenever a restriction is removed on a folder, we check that the new situation is compatible with the restrictions of the closest ancestor folder with restrictions. 

Three tests have been added to ensure this behavior. Notice that these rules resemble those for workflows on folders. 

Please let me know if you have any questions. Thanks! 

/cc @dacousalr