### PR TITLE
[TS] LPS-111194

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7122,47 +7122,38 @@ public class JournalArticleLocalServiceImpl
 					"between ", _previousCheckDate, " and ", reviewDate));
 		}
 
-		Set<Long> latestArticleIds = new HashSet<>();
-
 		List<JournalArticle> articles = journalArticleFinder.findByReviewDate(
 			JournalArticleConstants.CLASSNAME_ID_DEFAULT, reviewDate,
 			_previousCheckDate);
 
 		for (JournalArticle article : articles) {
-			if (article.isInTrash()) {
-				continue;
-			}
-
 			long groupId = article.getGroupId();
 			String articleId = article.getArticleId();
 
-			if (!journalArticleLocalService.isLatestVersion(
+			if (article.isInTrash() ||
+				!journalArticleLocalService.isLatestVersion(
 					groupId, articleId, article.getVersion())) {
 
-				article = journalArticleLocalService.getLatestArticle(
-					groupId, articleId);
+				continue;
 			}
 
-			if (latestArticleIds.add(article.getPrimaryKey())) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"Sending review notification for article " +
-							article.getId());
-				}
-
-				String portletId = PortletProviderUtil.getPortletId(
-					JournalArticle.class.getName(),
-					PortletProvider.Action.EDIT);
-
-				String articleURL = _portal.getControlPanelFullURL(
-					article.getGroupId(), portletId, null);
-
-				articleURL = buildArticleURL(
-					articleURL, article.getGroupId(), article.getFolderId(),
-					article.getArticleId());
-
-				sendEmail(article, articleURL, "review", new ServiceContext());
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Sending review notification for article " +
+						article.getId());
 			}
+
+			String portletId = PortletProviderUtil.getPortletId(
+				JournalArticle.class.getName(), PortletProvider.Action.EDIT);
+
+			String articleURL = _portal.getControlPanelFullURL(
+				article.getGroupId(), portletId, null);
+
+			articleURL = buildArticleURL(
+				articleURL, article.getGroupId(), article.getFolderId(),
+				article.getArticleId());
+
+			sendEmail(article, articleURL, "review", new ServiceContext());
 		}
 	}
 


### PR DESCRIPTION
From @kevhlee:

> <https://issues.liferay.com/browse/LPS-111194>
> 
> The issue was that a notification email to review the latest version of a journal article would be sent for each version. For example, if a previous version had a review date of 03/20/20 and the latest version had a review date of 03/22/20, the portal would send review notification emails for both dates. A review notification email should only be sent for the latest version of a journal article. To fix this issue, I modified and corrected `checkArticlesByReviewDate()` to only check and email the latest versions of journal articles. My solution makes the assumption that each journal article can only have one latest version.
> 
> With regards,
> Kevin

CC @wanderlast