### PR TITLE
[TS] LPS-111550 Update assetEntry expirationDate on journalArticle expiration

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleIndexer.java
@@ -458,6 +458,8 @@ public class JournalArticleIndexer extends BaseIndexer<JournalArticle> {
 		document.addKeywordSortable(Field.ARTICLE_ID, articleId);
 
 		document.addDate(Field.DISPLAY_DATE, journalArticle.getDisplayDate());
+		document.addDate(
+			Field.EXPIRATION_DATE, journalArticle.getExpirationDate());
 		document.addKeyword(Field.LAYOUT_UUID, journalArticle.getLayoutUuid());
 		document.addKeyword(
 			Field.TREE_PATH,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8565,9 +8565,15 @@ public class JournalArticleLocalServiceImpl
 			article);
 
 		if (previousApprovedArticle.getVersion() == article.getVersion()) {
-			assetEntryLocalService.updateVisible(
+			AssetEntry assetEntry = assetEntryLocalService.updateVisible(
 				JournalArticle.class.getName(), article.getResourcePrimKey(),
 				false);
+
+			if (article.getStatus() == WorkflowConstants.STATUS_EXPIRED) {
+				assetEntry.setExpirationDate(article.getExpirationDate());
+
+				assetEntryLocalService.updateAssetEntry(assetEntry);
+			}
 		}
 		else {
 			AssetEntry assetEntry = assetEntryLocalService.updateEntry(


### PR DESCRIPTION
Hi @ealonso ,

The JournalArticle's base search documents are partially created by AssetEntryDocumentContributor. This contributor sets the base document's expiration date as well.
Due to the n-to-1 relation between JournalArticle-s and AssetEntry-s, I'd like to suggest that JournalArticles override the expiration date coming from the AssetEntry. 

Can you please review?
https://issues.liferay.com/browse/LPS-111550

Thanks,
Balázs