### PR TITLE
LPS-112114 Publish schema version as OSGI property for JournalPortlet…

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -111,7 +111,10 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	configurationPid = "com.liferay.journal.configuration.JournalServiceConfiguration",
-	property = "javax.portlet.name=" + JournalPortletKeys.JOURNAL,
+	property = {
+		"javax.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"schema.version=" + JournalPortletDataHandler.SCHEMA_VERSION
+	},
 	service = PortletDataHandler.class
 )
 public class JournalPortletDataHandler extends BasePortletDataHandler {


### PR DESCRIPTION
/cc @brianikim

Notes from Brian:
> Solution for this particular case is to publish schema version as an OSGI property for JournalPortletDataHandler so that the JournalPortletDataHandler is loaded with the correct schema. The ticket itself was created in that particular style as recommended by MCD so that other cases can be fixed through it.