### PR TITLE
LPS 194345 Subfoldering

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageDisplayContext.java
@@ -144,6 +144,9 @@ public class DisplayPageDisplayContext {
 					LayoutPageTemplateEntryServiceUtil.
 						getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 							_themeDisplay.getScopeGroupId(),
+							ParamUtil.getLong(
+								_httpServletRequest,
+								"layoutPageTemplateCollectionId", -1),
 							LayoutPageTemplateEntryTypeConstants.
 								TYPE_DISPLAY_PAGE,
 							displayPagesSearchContainer.getStart(),
@@ -152,6 +155,9 @@ public class DisplayPageDisplayContext {
 				LayoutPageTemplateEntryServiceUtil.
 					getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 						_themeDisplay.getScopeGroupId(),
+						ParamUtil.getLong(
+							_httpServletRequest,
+							"layoutPageTemplateCollectionId", -1),
 						LayoutPageTemplateEntryTypeConstants.
 							TYPE_DISPLAY_PAGE));
 		}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageDisplayContext.java
@@ -126,7 +126,7 @@ public class DisplayPageDisplayContext {
 				() ->
 					LayoutPageTemplateEntryServiceUtil.
 						getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-							_themeDisplay.getScopeGroupId(), getKeywords(),
+							_themeDisplay.getScopeGroupId(), getKeywords(), -1,
 							LayoutPageTemplateEntryTypeConstants.
 								TYPE_DISPLAY_PAGE,
 							displayPagesSearchContainer.getStart(),
@@ -144,13 +144,13 @@ public class DisplayPageDisplayContext {
 					LayoutPageTemplateEntryServiceUtil.
 						getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 							_themeDisplay.getScopeGroupId(),
-							ParamUtil.getLong(
-								_httpServletRequest,
-								"layoutPageTemplateCollectionId", -1),
 							LayoutPageTemplateEntryTypeConstants.
 								TYPE_DISPLAY_PAGE,
 							displayPagesSearchContainer.getStart(),
 							displayPagesSearchContainer.getEnd(),
+							ParamUtil.getLong(
+								_httpServletRequest,
+								"layoutPageTemplateCollectionId", -1),
 							displayPagesSearchContainer.getOrderByComparator()),
 				LayoutPageTemplateEntryServiceUtil.
 					getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
@@ -161,6 +161,11 @@ public class DisplayPageManagementToolbarDisplayContext
 						"/select_display_page_master_layout.jsp"
 					).setRedirect(
 						_themeDisplay.getURLCurrent()
+					).setParameter(
+						"parentLayoutPageTemplateCollectionId",
+						ParamUtil.getLong(
+							httpServletRequest,
+							"layoutPageTemplateCollectionId")
 					).buildString());
 				dropdownItem.setLabel(
 					LanguageUtil.get(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -141,6 +142,11 @@ public class DisplayPageManagementToolbarDisplayContext
 							"/add_display_page_collection"
 					).setRedirect(
 						_themeDisplay.getURLCurrent()
+					).setParameter(
+						"parentLayoutPageTemplateCollectionId",
+						ParamUtil.getLong(
+							httpServletRequest,
+							"layoutPageTemplateCollectionId")
 					).buildString());
 				dropdownItem.setIcon("folder");
 				dropdownItem.setLabel(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
@@ -84,7 +84,8 @@ public class LayoutPageTemplatesAdminDisplayContext {
 				navigationItem.setActive(
 					Objects.equals(getTabs1(), "display-page-templates"));
 				navigationItem.setHref(
-					getPortletURL(), "tabs1", "display-page-templates");
+					getPortletURL(), "tabs1", "display-page-templates",
+					"layoutPageTemplateCollectionId", 0);
 				navigationItem.setLabel(
 					LanguageUtil.get(
 						_httpServletRequest, "display-page-templates"));

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/DisplayPageTemplateCollectionHorizontalCard.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/DisplayPageTemplateCollectionHorizontalCard.java
@@ -7,12 +7,16 @@ package com.liferay.layout.page.template.admin.web.internal.frontend.taglib.clay
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.BaseHorizontalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.layout.page.template.admin.web.internal.security.permission.resource.LayoutPageTemplateCollectionPermission;
 import com.liferay.layout.page.template.admin.web.internal.servlet.taglib.util.LayoutPageTemplateCollectionActionDropdownItem;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.RowChecker;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.List;
@@ -53,6 +57,37 @@ public class DisplayPageTemplateCollectionHorizontalCard
 			return layoutPageTemplateCollectionActionDropdownItem.
 				getActionDropdownItems(
 					_layoutPageTemplateCollection, "display-page-templates");
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getHref() {
+		try {
+			if (!LayoutPageTemplateCollectionPermission.contains(
+					themeDisplay.getPermissionChecker(),
+					_layoutPageTemplateCollection, ActionKeys.UPDATE)) {
+
+				return StringPool.BLANK;
+			}
+
+			return PortletURLBuilder.createRenderURL(
+				_renderResponse
+			).setTabs1(
+				"display-page-templates"
+			).setParameter(
+				"groupId", _layoutPageTemplateCollection.getGroupId()
+			).setParameter(
+				"layoutPageTemplateCollectionId",
+				_layoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId()
+			).buildString();
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/SelectDisplayPageMasterLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/SelectDisplayPageMasterLayoutVerticalCard.java
@@ -10,6 +10,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -44,6 +45,10 @@ public class SelectDisplayPageMasterLayoutVerticalCard implements VerticalCard {
 			_themeDisplay.getURLCurrent()
 		).setParameter(
 			"masterLayoutPlid", _layoutPageTemplateEntry.getPlid()
+		).setParameter(
+			"parentLayoutPageTemplateCollectionId",
+			ParamUtil.getLong(
+				_httpServletRequest, "parentLayoutPageTemplateCollectionId", -1)
 		).setParameter(
 			"type", LayoutPageTemplateEntryTypeConstants.TYPE_DISPLAY_PAGE
 		).buildString();

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageCollectionMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageCollectionMVCActionCommand.java
@@ -58,6 +58,8 @@ public class AddDisplayPageCollectionMVCActionCommand
 					themeDisplay.getScopeGroupId(),
 					ParamUtil.getString(actionRequest, "name"),
 					ParamUtil.getString(actionRequest, "description"),
+					ParamUtil.getLong(
+						actionRequest, "parentLayoutPageTemplateCollectionId"),
 					ServiceContextFactory.getInstance(actionRequest));
 
 			jsonObject.put(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageMVCActionCommand.java
@@ -118,13 +118,16 @@ public class AddDisplayPageMVCActionCommand extends BaseMVCActionCommand {
 		long classTypeId = ParamUtil.getLong(actionRequest, "classTypeId");
 		long masterLayoutPlid = ParamUtil.getLong(
 			actionRequest, "masterLayoutPlid");
+		long parentLayoutPageTemplateCollectionId = ParamUtil.getLong(
+			actionRequest, "layoutPageTemplateCollectionId", -1);
 
 		try {
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				_layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
 					serviceContext.getScopeGroupId(),
 					layoutPageTemplateCollectionId, classNameId, classTypeId,
-					name, masterLayoutPlid, WorkflowConstants.STATUS_DRAFT,
+					name, parentLayoutPageTemplateCollectionId,
+					masterLayoutPlid, WorkflowConstants.STATUS_DRAFT,
 					serviceContext);
 
 			return JSONUtil.put(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddDisplayPageMVCActionCommand.java
@@ -99,6 +99,10 @@ public class AddDisplayPageMVCActionCommand extends BaseMVCActionCommand {
 					PortletRequest.RENDER_PHASE)
 			).setTabs1(
 				"display-page-templates"
+			).setParameter(
+				"parentLayoutPageTemplateCollectionId",
+				ParamUtil.getLong(
+					actionRequest, "layoutPageTemplateCollectionId", -1)
 			).buildString());
 
 		return HttpComponentsUtil.setParameter(
@@ -112,22 +116,22 @@ public class AddDisplayPageMVCActionCommand extends BaseMVCActionCommand {
 
 		long layoutPageTemplateCollectionId = ParamUtil.getLong(
 			actionRequest, "layoutPageTemplateCollectionId");
+		long parentLayoutPageTemplateCollectionId = ParamUtil.getLong(
+			actionRequest, "parentLayoutPageTemplateCollectionId");
 
 		String name = ParamUtil.getString(actionRequest, "name");
 		long classNameId = ParamUtil.getLong(actionRequest, "classNameId");
 		long classTypeId = ParamUtil.getLong(actionRequest, "classTypeId");
 		long masterLayoutPlid = ParamUtil.getLong(
 			actionRequest, "masterLayoutPlid");
-		long parentLayoutPageTemplateCollectionId = ParamUtil.getLong(
-			actionRequest, "layoutPageTemplateCollectionId", -1);
 
 		try {
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				_layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
 					serviceContext.getScopeGroupId(),
 					layoutPageTemplateCollectionId, classNameId, classTypeId,
-					name, parentLayoutPageTemplateCollectionId,
-					masterLayoutPlid, WorkflowConstants.STATUS_DRAFT,
+					name,
+					masterLayoutPlid, parentLayoutPageTemplateCollectionId, WorkflowConstants.STATUS_DRAFT,
 					serviceContext);
 
 			return JSONUtil.put(

--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 18.2.0
+Bundle-Version: 19.0.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 18.1.1
+Bundle-Version: 18.2.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionModel.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionModel.java
@@ -279,6 +279,35 @@ public interface LayoutPageTemplateCollectionModel
 	public void setDescription(String description);
 
 	/**
+	 * Returns the parent layout page template collection ID of this layout page template collection.
+	 *
+	 * @return the parent layout page template collection ID of this layout page template collection
+	 */
+	public long getParentLayoutPageTemplateCollectionId();
+
+	/**
+	 * Sets the parent layout page template collection ID of this layout page template collection.
+	 *
+	 * @param parentLayoutPageTemplateCollectionId the parent layout page template collection ID of this layout page template collection
+	 */
+	public void setParentLayoutPageTemplateCollectionId(
+		long parentLayoutPageTemplateCollectionId);
+
+	/**
+	 * Returns the type of this layout page template collection.
+	 *
+	 * @return the type of this layout page template collection
+	 */
+	public int getType();
+
+	/**
+	 * Sets the type of this layout page template collection.
+	 *
+	 * @param type the type of this layout page template collection
+	 */
+	public void setType(int type);
+
+	/**
 	 * Returns the last publish date of this layout page template collection.
 	 *
 	 * @return the last publish date of this layout page template collection

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionTable.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionTable.java
@@ -62,6 +62,13 @@ public class LayoutPageTemplateCollectionTable
 	public final Column<LayoutPageTemplateCollectionTable, String> description =
 		createColumn(
 			"description", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<LayoutPageTemplateCollectionTable, Long>
+		parentLayoutPageTemplateCollectionId = createColumn(
+			"parentLPTCollectionId", Long.class, Types.BIGINT,
+			Column.FLAG_DEFAULT);
+	public final Column<LayoutPageTemplateCollectionTable, Integer> type =
+		createColumn(
+			"type_", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
 	public final Column<LayoutPageTemplateCollectionTable, Date>
 		lastPublishDate = createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionWrapper.java
@@ -56,6 +56,10 @@ public class LayoutPageTemplateCollectionWrapper
 			getLayoutPageTemplateCollectionKey());
 		attributes.put("name", getName());
 		attributes.put("description", getDescription());
+		attributes.put(
+			"parentLayoutPageTemplateCollectionId",
+			getParentLayoutPageTemplateCollectionId());
+		attributes.put("type", getType());
 		attributes.put("lastPublishDate", getLastPublishDate());
 
 		return attributes;
@@ -141,6 +145,20 @@ public class LayoutPageTemplateCollectionWrapper
 
 		if (description != null) {
 			setDescription(description);
+		}
+
+		Long parentLayoutPageTemplateCollectionId = (Long)attributes.get(
+			"parentLayoutPageTemplateCollectionId");
+
+		if (parentLayoutPageTemplateCollectionId != null) {
+			setParentLayoutPageTemplateCollectionId(
+				parentLayoutPageTemplateCollectionId);
+		}
+
+		Integer type = (Integer)attributes.get("type");
+
+		if (type != null) {
+			setType(type);
 		}
 
 		Date lastPublishDate = (Date)attributes.get("lastPublishDate");
@@ -266,6 +284,16 @@ public class LayoutPageTemplateCollectionWrapper
 	}
 
 	/**
+	 * Returns the parent layout page template collection ID of this layout page template collection.
+	 *
+	 * @return the parent layout page template collection ID of this layout page template collection
+	 */
+	@Override
+	public long getParentLayoutPageTemplateCollectionId() {
+		return model.getParentLayoutPageTemplateCollectionId();
+	}
+
+	/**
 	 * Returns the primary key of this layout page template collection.
 	 *
 	 * @return the primary key of this layout page template collection
@@ -273,6 +301,16 @@ public class LayoutPageTemplateCollectionWrapper
 	@Override
 	public long getPrimaryKey() {
 		return model.getPrimaryKey();
+	}
+
+	/**
+	 * Returns the type of this layout page template collection.
+	 *
+	 * @return the type of this layout page template collection
+	 */
+	@Override
+	public int getType() {
+		return model.getType();
 	}
 
 	/**
@@ -436,6 +474,19 @@ public class LayoutPageTemplateCollectionWrapper
 	}
 
 	/**
+	 * Sets the parent layout page template collection ID of this layout page template collection.
+	 *
+	 * @param parentLayoutPageTemplateCollectionId the parent layout page template collection ID of this layout page template collection
+	 */
+	@Override
+	public void setParentLayoutPageTemplateCollectionId(
+		long parentLayoutPageTemplateCollectionId) {
+
+		model.setParentLayoutPageTemplateCollectionId(
+			parentLayoutPageTemplateCollectionId);
+	}
+
+	/**
 	 * Sets the primary key of this layout page template collection.
 	 *
 	 * @param primaryKey the primary key of this layout page template collection
@@ -443,6 +494,16 @@ public class LayoutPageTemplateCollectionWrapper
 	@Override
 	public void setPrimaryKey(long primaryKey) {
 		model.setPrimaryKey(primaryKey);
+	}
+
+	/**
+	 * Sets the type of this layout page template collection.
+	 *
+	 * @param type the type of this layout page template collection
+	 */
+	@Override
+	public void setType(int type) {
+		model.setType(type);
 	}
 
 	/**

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalService.java
@@ -80,6 +80,12 @@ public interface LayoutPageTemplateCollectionLocalService
 
 	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long userId, long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long userId, long groupId, String name, String description,
 			ServiceContext serviceContext)
 		throws PortalException;
 

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceUtil.java
@@ -55,6 +55,17 @@ public class LayoutPageTemplateCollectionLocalServiceUtil {
 
 	public static LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long userId, long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addLayoutPageTemplateCollection(
+			userId, groupId, name, description,
+			parentLayoutPageTemplateCollection, serviceContext);
+	}
+
+	public static LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long userId, long groupId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceWrapper.java
@@ -55,6 +55,19 @@ public class LayoutPageTemplateCollectionLocalServiceWrapper
 	@Override
 	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long userId, long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutPageTemplateCollectionLocalService.
+			addLayoutPageTemplateCollection(
+				userId, groupId, name, description,
+				parentLayoutPageTemplateCollection, serviceContext);
+	}
+
+	@Override
+	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long userId, long groupId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionService.java
@@ -48,6 +48,12 @@ public interface LayoutPageTemplateCollectionService extends BaseService {
 	 */
 	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long groupId, String name, String description,
 			ServiceContext serviceContext)
 		throws PortalException;
 

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceUtil.java
@@ -32,6 +32,17 @@ public class LayoutPageTemplateCollectionServiceUtil {
 	 */
 	public static LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addLayoutPageTemplateCollection(
+			groupId, name, description, parentLayoutPageTemplateCollection,
+			serviceContext);
+	}
+
+	public static LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long groupId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceWrapper.java
@@ -34,6 +34,19 @@ public class LayoutPageTemplateCollectionServiceWrapper
 	@Override
 	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutPageTemplateCollectionService.
+			addLayoutPageTemplateCollection(
+				groupId, name, description, parentLayoutPageTemplateCollection,
+				serviceContext);
+	}
+
+	@Override
+	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long groupId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalService.java
@@ -91,14 +91,16 @@ public interface LayoutPageTemplateEntryLocalService
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
 			long previewFileEntryId, boolean defaultTemplate,
-			long layoutPrototypeId, long plid, long masterLayoutPlid,
-			int status, ServiceContext serviceContext)
+			long layoutPrototypeId, long parentLayoutPageTemplateCollectionId,
+			long plid, long masterLayoutPlid, int status,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
-			long masterLayoutPlid, int status, ServiceContext serviceContext)
+			long masterLayoutPlid, long parentLayoutPageTemplateCollectionId,
+			int status, ServiceContext serviceContext)
 		throws PortalException;
 
 	public LayoutPageTemplateEntry addLayoutPageTemplateEntry(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceUtil.java
@@ -69,27 +69,30 @@ public class LayoutPageTemplateEntryLocalServiceUtil {
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
 			long previewFileEntryId, boolean defaultTemplate,
-			long layoutPrototypeId, long plid, long masterLayoutPlid,
-			int status,
+			long layoutPrototypeId, long parentLayoutPageTemplateCollectionId,
+			long plid, long masterLayoutPlid, int status,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addLayoutPageTemplateEntry(
 			userId, groupId, layoutPageTemplateCollectionId, classNameId,
 			classTypeId, name, type, previewFileEntryId, defaultTemplate,
-			layoutPrototypeId, plid, masterLayoutPlid, status, serviceContext);
+			layoutPrototypeId, parentLayoutPageTemplateCollectionId, plid,
+			masterLayoutPlid, status, serviceContext);
 	}
 
 	public static LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
-			long masterLayoutPlid, int status,
+			long masterLayoutPlid, long parentLayoutPageTemplateCollectionId,
+			int status,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addLayoutPageTemplateEntry(
 			userId, groupId, layoutPageTemplateCollectionId, classNameId,
-			classTypeId, name, type, masterLayoutPlid, status, serviceContext);
+			classTypeId, name, type, masterLayoutPlid,
+			parentLayoutPageTemplateCollectionId, status, serviceContext);
 	}
 
 	public static LayoutPageTemplateEntry addLayoutPageTemplateEntry(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceWrapper.java
@@ -75,28 +75,31 @@ public class LayoutPageTemplateEntryLocalServiceWrapper
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
 			long previewFileEntryId, boolean defaultTemplate,
-			long layoutPrototypeId, long plid, long masterLayoutPlid,
-			int status,
+			long layoutPrototypeId, long parentLayoutPageTemplateCollectionId,
+			long plid, long masterLayoutPlid, int status,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
 			userId, groupId, layoutPageTemplateCollectionId, classNameId,
 			classTypeId, name, type, previewFileEntryId, defaultTemplate,
-			layoutPrototypeId, plid, masterLayoutPlid, status, serviceContext);
+			layoutPrototypeId, parentLayoutPageTemplateCollectionId, plid,
+			masterLayoutPlid, status, serviceContext);
 	}
 
 	@Override
 	public LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
-			long masterLayoutPlid, int status,
+			long masterLayoutPlid, long parentLayoutPageTemplateCollectionId,
+			int status,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
 			userId, groupId, layoutPageTemplateCollectionId, classNameId,
-			classTypeId, name, type, masterLayoutPlid, status, serviceContext);
+			classTypeId, name, type, masterLayoutPlid,
+			parentLayoutPageTemplateCollectionId, status, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryService.java
@@ -49,7 +49,8 @@ public interface LayoutPageTemplateEntryService extends BaseService {
 	 */
 	public LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long groupId, long layoutPageTemplateCollectionId, long classNameId,
-			long classTypeId, String name, long masterLayoutPlid, int status,
+			long classTypeId, String name, long masterLayoutPlid,
+			long parentLayoutPageTemplateCollectionId, int status,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -98,22 +99,25 @@ public interface LayoutPageTemplateEntryService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 		long groupId, int type, int start, int end,
+		long parentLayoutPageTemplateCollectionId,
 		OrderByComparator<Object> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-		long groupId, long layoutPageTemplateCollectionId, int type, int start,
-		int end, OrderByComparator<Object> orderByComparator);
+		long groupId, long layoutPageTemplateCollectionId,
+		long parentLayoutPageTemplateCollectionId, int type, int start, int end,
+		OrderByComparator<Object> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 		long groupId, long layoutPageTemplateCollectionId, String name,
-		int type, int start, int end,
+		long parentLayoutPageTemplateCollectionId, int type, int start, int end,
 		OrderByComparator<Object> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-		long groupId, String name, int type, int start, int end,
+		long groupId, String name, long parentLayoutPageTemplateCollectionId,
+		int type, int start, int end,
 		OrderByComparator<Object> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -127,7 +131,7 @@ public interface LayoutPageTemplateEntryService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 		long groupId, long layoutPageTemplateCollectionId, String name,
-		int type);
+		long parentLayoutPageTemplateCollectionId, int type);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryService.java
@@ -102,12 +102,32 @@ public interface LayoutPageTemplateEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+		long groupId, long layoutPageTemplateCollectionId, int type, int start,
+		int end, OrderByComparator<Object> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+		long groupId, long layoutPageTemplateCollectionId, String name,
+		int type, int start, int end,
+		OrderByComparator<Object> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 		long groupId, String name, int type, int start, int end,
 		OrderByComparator<Object> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 		long groupId, int type);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, long layoutPageTemplateCollectionId, int type);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, long layoutPageTemplateCollectionId, String name,
+		int type);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceUtil.java
@@ -134,6 +134,29 @@ public class LayoutPageTemplateEntryServiceUtil {
 
 	public static List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			long groupId, long layoutPageTemplateCollectionId, int type,
+			int start, int end, OrderByComparator<Object> orderByComparator) {
+
+		return getService().
+			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+				groupId, layoutPageTemplateCollectionId, type, start, end,
+				orderByComparator);
+	}
+
+	public static List<Object>
+		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			long groupId, long layoutPageTemplateCollectionId, String name,
+			int type, int start, int end,
+			OrderByComparator<Object> orderByComparator) {
+
+		return getService().
+			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+				groupId, layoutPageTemplateCollectionId, name, type, start, end,
+				orderByComparator);
+	}
+
+	public static List<Object>
+		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			long groupId, String name, int type, int start, int end,
 			OrderByComparator<Object> orderByComparator) {
 
@@ -148,6 +171,23 @@ public class LayoutPageTemplateEntryServiceUtil {
 		return getService().
 			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 				groupId, type);
+	}
+
+	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, long layoutPageTemplateCollectionId, int type) {
+
+		return getService().
+			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+				groupId, layoutPageTemplateCollectionId, type);
+	}
+
+	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, long layoutPageTemplateCollectionId, String name,
+		int type) {
+
+		return getService().
+			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+				groupId, layoutPageTemplateCollectionId, name, type);
 	}
 
 	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceUtil.java
@@ -32,13 +32,15 @@ public class LayoutPageTemplateEntryServiceUtil {
 	 */
 	public static LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long groupId, long layoutPageTemplateCollectionId, long classNameId,
-			long classTypeId, String name, long masterLayoutPlid, int status,
+			long classTypeId, String name, long masterLayoutPlid,
+			long parentLayoutPageTemplateCollectionId, int status,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addLayoutPageTemplateEntry(
 			groupId, layoutPageTemplateCollectionId, classNameId, classTypeId,
-			name, masterLayoutPlid, status, serviceContext);
+			name, masterLayoutPlid, parentLayoutPageTemplateCollectionId,
+			status, serviceContext);
 	}
 
 	public static LayoutPageTemplateEntry addLayoutPageTemplateEntry(
@@ -125,44 +127,51 @@ public class LayoutPageTemplateEntryServiceUtil {
 	public static List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			long groupId, int type, int start, int end,
+			long parentLayoutPageTemplateCollectionId,
 			OrderByComparator<Object> orderByComparator) {
 
 		return getService().
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, type, start, end, orderByComparator);
+				groupId, type, start, end, parentLayoutPageTemplateCollectionId,
+				orderByComparator);
 	}
 
 	public static List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			long groupId, long layoutPageTemplateCollectionId, int type,
-			int start, int end, OrderByComparator<Object> orderByComparator) {
+			long groupId, long layoutPageTemplateCollectionId,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end, OrderByComparator<Object> orderByComparator) {
 
 		return getService().
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, layoutPageTemplateCollectionId, type, start, end,
+				groupId, layoutPageTemplateCollectionId,
+				parentLayoutPageTemplateCollectionId, type, start, end,
 				orderByComparator);
 	}
 
 	public static List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			long groupId, long layoutPageTemplateCollectionId, String name,
-			int type, int start, int end,
-			OrderByComparator<Object> orderByComparator) {
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end, OrderByComparator<Object> orderByComparator) {
 
 		return getService().
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, layoutPageTemplateCollectionId, name, type, start, end,
+				groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type, start, end,
 				orderByComparator);
 	}
 
 	public static List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			long groupId, String name, int type, int start, int end,
-			OrderByComparator<Object> orderByComparator) {
+			long groupId, String name,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end, OrderByComparator<Object> orderByComparator) {
 
 		return getService().
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, name, type, start, end, orderByComparator);
+				groupId, name, parentLayoutPageTemplateCollectionId, type,
+				start, end, orderByComparator);
 	}
 
 	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
@@ -183,11 +192,12 @@ public class LayoutPageTemplateEntryServiceUtil {
 
 	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 		long groupId, long layoutPageTemplateCollectionId, String name,
-		int type) {
+		long parentLayoutPageTemplateCollectionId, int type) {
 
 		return getService().
 			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
-				groupId, layoutPageTemplateCollectionId, name, type);
+				groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type);
 	}
 
 	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceWrapper.java
@@ -32,13 +32,15 @@ public class LayoutPageTemplateEntryServiceWrapper
 	@Override
 	public LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long groupId, long layoutPageTemplateCollectionId, long classNameId,
-			long classTypeId, String name, long masterLayoutPlid, int status,
+			long classTypeId, String name, long masterLayoutPlid,
+			long parentLayoutPageTemplateCollectionId, int status,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
 			groupId, layoutPageTemplateCollectionId, classNameId, classTypeId,
-			name, masterLayoutPlid, status, serviceContext);
+			name, masterLayoutPlid, parentLayoutPageTemplateCollectionId,
+			status, serviceContext);
 	}
 
 	@Override
@@ -135,25 +137,29 @@ public class LayoutPageTemplateEntryServiceWrapper
 	public java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			long groupId, int type, int start, int end,
+			long parentLayoutPageTemplateCollectionId,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
 		return _layoutPageTemplateEntryService.
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, type, start, end, orderByComparator);
+				groupId, type, start, end, parentLayoutPageTemplateCollectionId,
+				orderByComparator);
 	}
 
 	@Override
 	public java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			long groupId, long layoutPageTemplateCollectionId, int type,
-			int start, int end,
+			long groupId, long layoutPageTemplateCollectionId,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
 		return _layoutPageTemplateEntryService.
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, layoutPageTemplateCollectionId, type, start, end,
+				groupId, layoutPageTemplateCollectionId,
+				parentLayoutPageTemplateCollectionId, type, start, end,
 				orderByComparator);
 	}
 
@@ -161,26 +167,31 @@ public class LayoutPageTemplateEntryServiceWrapper
 	public java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			long groupId, long layoutPageTemplateCollectionId, String name,
-			int type, int start, int end,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
 		return _layoutPageTemplateEntryService.
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, layoutPageTemplateCollectionId, name, type, start, end,
+				groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type, start, end,
 				orderByComparator);
 	}
 
 	@Override
 	public java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			long groupId, String name, int type, int start, int end,
+			long groupId, String name,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
 		return _layoutPageTemplateEntryService.
 			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-				groupId, name, type, start, end, orderByComparator);
+				groupId, name, parentLayoutPageTemplateCollectionId, type,
+				start, end, orderByComparator);
 	}
 
 	@Override
@@ -204,11 +215,12 @@ public class LayoutPageTemplateEntryServiceWrapper
 	@Override
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 		long groupId, long layoutPageTemplateCollectionId, String name,
-		int type) {
+		long parentLayoutPageTemplateCollectionId, int type) {
 
 		return _layoutPageTemplateEntryService.
 			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
-				groupId, layoutPageTemplateCollectionId, name, type);
+				groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryServiceWrapper.java
@@ -146,6 +146,34 @@ public class LayoutPageTemplateEntryServiceWrapper
 	@Override
 	public java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			long groupId, long layoutPageTemplateCollectionId, int type,
+			int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator<Object>
+				orderByComparator) {
+
+		return _layoutPageTemplateEntryService.
+			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+				groupId, layoutPageTemplateCollectionId, type, start, end,
+				orderByComparator);
+	}
+
+	@Override
+	public java.util.List<Object>
+		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			long groupId, long layoutPageTemplateCollectionId, String name,
+			int type, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator<Object>
+				orderByComparator) {
+
+		return _layoutPageTemplateEntryService.
+			getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+				groupId, layoutPageTemplateCollectionId, name, type, start, end,
+				orderByComparator);
+	}
+
+	@Override
+	public java.util.List<Object>
+		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			long groupId, String name, int type, int start, int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
@@ -162,6 +190,25 @@ public class LayoutPageTemplateEntryServiceWrapper
 		return _layoutPageTemplateEntryService.
 			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 				groupId, type);
+	}
+
+	@Override
+	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, long layoutPageTemplateCollectionId, int type) {
+
+		return _layoutPageTemplateEntryService.
+			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+				groupId, layoutPageTemplateCollectionId, type);
+	}
+
+	@Override
+	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, long layoutPageTemplateCollectionId, String name,
+		int type) {
+
+		return _layoutPageTemplateEntryService.
+			getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+				groupId, layoutPageTemplateCollectionId, name, type);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/model/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/model/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.2.0
+version 7.0.0

--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.2.0
+Liferay-Require-SchemaVersion: 5.3.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -26,6 +26,8 @@
 		<column db-name="lptCollectionKey" name="layoutPageTemplateCollectionKey" type="String" />
 		<column name="name" type="String" />
 		<column name="description" type="String" />
+		<column db-name="parentLPTCollectionId" name="parentLayoutPageTemplateCollectionId" type="long" />
+		<column name="type" type="int" />
 		<column name="lastPublishDate" type="Date" />
 
 		<!-- Order -->

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -189,6 +189,15 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 				"LayoutPageTemplateStructure", "classPK", "plid LONG"),
 			UpgradeProcessFactory.dropColumns(
 				"LayoutPageTemplateStructure", "classNameId"));
+
+		registry.register(
+			"5.2.0", "5.3.0",
+			UpgradeProcessFactory.addColumns(
+				"LayoutPageTemplateCollection",
+				"type_ INTEGER default 0 NOT NULL"),
+			UpgradeProcessFactory.addColumns(
+				"LayoutPageTemplateCollection",
+				"parentLPTCollectionId LONG default 0 NOT NULL"));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateCollectionCacheModel.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateCollectionCacheModel.java
@@ -73,7 +73,7 @@ public class LayoutPageTemplateCollectionCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(29);
+		StringBundler sb = new StringBundler(33);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -101,6 +101,10 @@ public class LayoutPageTemplateCollectionCacheModel
 		sb.append(name);
 		sb.append(", description=");
 		sb.append(description);
+		sb.append(", parentLayoutPageTemplateCollectionId=");
+		sb.append(parentLayoutPageTemplateCollectionId);
+		sb.append(", type=");
+		sb.append(type);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
 		sb.append("}");
@@ -175,6 +179,11 @@ public class LayoutPageTemplateCollectionCacheModel
 			layoutPageTemplateCollectionImpl.setDescription(description);
 		}
 
+		layoutPageTemplateCollectionImpl.
+			setParentLayoutPageTemplateCollectionId(
+				parentLayoutPageTemplateCollectionId);
+		layoutPageTemplateCollectionImpl.setType(type);
+
 		if (lastPublishDate == Long.MIN_VALUE) {
 			layoutPageTemplateCollectionImpl.setLastPublishDate(null);
 		}
@@ -208,6 +217,10 @@ public class LayoutPageTemplateCollectionCacheModel
 		layoutPageTemplateCollectionKey = objectInput.readUTF();
 		name = objectInput.readUTF();
 		description = objectInput.readUTF();
+
+		parentLayoutPageTemplateCollectionId = objectInput.readLong();
+
+		type = objectInput.readInt();
 		lastPublishDate = objectInput.readLong();
 	}
 
@@ -263,6 +276,9 @@ public class LayoutPageTemplateCollectionCacheModel
 			objectOutput.writeUTF(description);
 		}
 
+		objectOutput.writeLong(parentLayoutPageTemplateCollectionId);
+
+		objectOutput.writeInt(type);
 		objectOutput.writeLong(lastPublishDate);
 	}
 
@@ -279,6 +295,8 @@ public class LayoutPageTemplateCollectionCacheModel
 	public String layoutPageTemplateCollectionKey;
 	public String name;
 	public String description;
+	public long parentLayoutPageTemplateCollectionId;
+	public int type;
 	public long lastPublishDate;
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateCollectionModelImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateCollectionModelImpl.java
@@ -72,7 +72,8 @@ public class LayoutPageTemplateCollectionModelImpl
 		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
 		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
 		{"lptCollectionKey", Types.VARCHAR}, {"name", Types.VARCHAR},
-		{"description", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP}
+		{"description", Types.VARCHAR}, {"parentLPTCollectionId", Types.BIGINT},
+		{"type_", Types.INTEGER}, {"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -92,11 +93,13 @@ public class LayoutPageTemplateCollectionModelImpl
 		TABLE_COLUMNS_MAP.put("lptCollectionKey", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("parentLPTCollectionId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table LayoutPageTemplateCollection (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,layoutPageTemplateCollectionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,lptCollectionKey VARCHAR(75) null,name VARCHAR(75) null,description STRING null,lastPublishDate DATE null,primary key (layoutPageTemplateCollectionId, ctCollectionId))";
+		"create table LayoutPageTemplateCollection (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,layoutPageTemplateCollectionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,lptCollectionKey VARCHAR(75) null,name VARCHAR(75) null,description STRING null,parentLPTCollectionId LONG,type_ INTEGER,lastPublishDate DATE null,primary key (layoutPageTemplateCollectionId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table LayoutPageTemplateCollection";
@@ -290,6 +293,12 @@ public class LayoutPageTemplateCollectionModelImpl
 			attributeGetterFunctions.put(
 				"description", LayoutPageTemplateCollection::getDescription);
 			attributeGetterFunctions.put(
+				"parentLayoutPageTemplateCollectionId",
+				LayoutPageTemplateCollection::
+					getParentLayoutPageTemplateCollectionId);
+			attributeGetterFunctions.put(
+				"type", LayoutPageTemplateCollection::getType);
+			attributeGetterFunctions.put(
 				"lastPublishDate",
 				LayoutPageTemplateCollection::getLastPublishDate);
 
@@ -365,6 +374,15 @@ public class LayoutPageTemplateCollectionModelImpl
 				"description",
 				(BiConsumer<LayoutPageTemplateCollection, String>)
 					LayoutPageTemplateCollection::setDescription);
+			attributeSetterBiConsumers.put(
+				"parentLayoutPageTemplateCollectionId",
+				(BiConsumer<LayoutPageTemplateCollection, Long>)
+					LayoutPageTemplateCollection::
+						setParentLayoutPageTemplateCollectionId);
+			attributeSetterBiConsumers.put(
+				"type",
+				(BiConsumer<LayoutPageTemplateCollection, Integer>)
+					LayoutPageTemplateCollection::setType);
 			attributeSetterBiConsumers.put(
 				"lastPublishDate",
 				(BiConsumer<LayoutPageTemplateCollection, Date>)
@@ -670,6 +688,39 @@ public class LayoutPageTemplateCollectionModelImpl
 
 	@JSON
 	@Override
+	public long getParentLayoutPageTemplateCollectionId() {
+		return _parentLayoutPageTemplateCollectionId;
+	}
+
+	@Override
+	public void setParentLayoutPageTemplateCollectionId(
+		long parentLayoutPageTemplateCollectionId) {
+
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_parentLayoutPageTemplateCollectionId =
+			parentLayoutPageTemplateCollectionId;
+	}
+
+	@JSON
+	@Override
+	public int getType() {
+		return _type;
+	}
+
+	@Override
+	public void setType(int type) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_type = type;
+	}
+
+	@JSON
+	@Override
 	public Date getLastPublishDate() {
 		return _lastPublishDate;
 	}
@@ -763,6 +814,10 @@ public class LayoutPageTemplateCollectionModelImpl
 			getLayoutPageTemplateCollectionKey());
 		layoutPageTemplateCollectionImpl.setName(getName());
 		layoutPageTemplateCollectionImpl.setDescription(getDescription());
+		layoutPageTemplateCollectionImpl.
+			setParentLayoutPageTemplateCollectionId(
+				getParentLayoutPageTemplateCollectionId());
+		layoutPageTemplateCollectionImpl.setType(getType());
 		layoutPageTemplateCollectionImpl.setLastPublishDate(
 			getLastPublishDate());
 
@@ -803,6 +858,11 @@ public class LayoutPageTemplateCollectionModelImpl
 			this.<String>getColumnOriginalValue("name"));
 		layoutPageTemplateCollectionImpl.setDescription(
 			this.<String>getColumnOriginalValue("description"));
+		layoutPageTemplateCollectionImpl.
+			setParentLayoutPageTemplateCollectionId(
+				this.<Long>getColumnOriginalValue("parentLPTCollectionId"));
+		layoutPageTemplateCollectionImpl.setType(
+			this.<Integer>getColumnOriginalValue("type_"));
 		layoutPageTemplateCollectionImpl.setLastPublishDate(
 			this.<Date>getColumnOriginalValue("lastPublishDate"));
 
@@ -966,6 +1026,12 @@ public class LayoutPageTemplateCollectionModelImpl
 			layoutPageTemplateCollectionCacheModel.description = null;
 		}
 
+		layoutPageTemplateCollectionCacheModel.
+			parentLayoutPageTemplateCollectionId =
+				getParentLayoutPageTemplateCollectionId();
+
+		layoutPageTemplateCollectionCacheModel.type = getType();
+
 		Date lastPublishDate = getLastPublishDate();
 
 		if (lastPublishDate != null) {
@@ -1054,6 +1120,8 @@ public class LayoutPageTemplateCollectionModelImpl
 	private String _layoutPageTemplateCollectionKey;
 	private String _name;
 	private String _description;
+	private long _parentLayoutPageTemplateCollectionId;
+	private int _type;
 	private Date _lastPublishDate;
 
 	public <T> T getColumnValue(String columnName) {
@@ -1101,6 +1169,9 @@ public class LayoutPageTemplateCollectionModelImpl
 			"lptCollectionKey", _layoutPageTemplateCollectionKey);
 		_columnOriginalValues.put("name", _name);
 		_columnOriginalValues.put("description", _description);
+		_columnOriginalValues.put(
+			"parentLPTCollectionId", _parentLayoutPageTemplateCollectionId);
+		_columnOriginalValues.put("type_", _type);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
 	}
 
@@ -1112,6 +1183,9 @@ public class LayoutPageTemplateCollectionModelImpl
 		attributeNames.put("uuid_", "uuid");
 		attributeNames.put(
 			"lptCollectionKey", "layoutPageTemplateCollectionKey");
+		attributeNames.put(
+			"parentLPTCollectionId", "parentLayoutPageTemplateCollectionId");
+		attributeNames.put("type_", "type");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
@@ -1153,7 +1227,11 @@ public class LayoutPageTemplateCollectionModelImpl
 
 		columnBitmasks.put("description", 4096L);
 
-		columnBitmasks.put("lastPublishDate", 8192L);
+		columnBitmasks.put("parentLPTCollectionId", 8192L);
+
+		columnBitmasks.put("type_", 16384L);
+
+		columnBitmasks.put("lastPublishDate", 32768L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/base/LayoutPageTemplateCollectionLocalServiceBaseImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/base/LayoutPageTemplateCollectionLocalServiceBaseImpl.java
@@ -112,6 +112,15 @@ public abstract class LayoutPageTemplateCollectionLocalServiceBaseImpl
 			layoutPageTemplateCollectionId);
 	}
 
+	@Override
+	@Transactional(enabled = false)
+	public LayoutPageTemplateCollection createLayoutPageTemplateCollection(
+		long parentLayoutPageTemplateCollectionId, long layoutPageTemplateCollectionId) {
+
+		return layoutPageTemplateCollectionPersistence.create(
+			layoutPageTemplateCollectionId);
+	}
+
 	/**
 	 * Deletes the layout page template collection with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/base/LayoutPageTemplateCollectionLocalServiceBaseImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/base/LayoutPageTemplateCollectionLocalServiceBaseImpl.java
@@ -112,15 +112,6 @@ public abstract class LayoutPageTemplateCollectionLocalServiceBaseImpl
 			layoutPageTemplateCollectionId);
 	}
 
-	@Override
-	@Transactional(enabled = false)
-	public LayoutPageTemplateCollection createLayoutPageTemplateCollection(
-		long parentLayoutPageTemplateCollectionId, long layoutPageTemplateCollectionId) {
-
-		return layoutPageTemplateCollectionPersistence.create(
-			layoutPageTemplateCollectionId);
-	}
-
 	/**
 	 * Deletes the layout page template collection with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateCollectionServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateCollectionServiceHttp.java
@@ -45,7 +45,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 		com.liferay.layout.page.template.model.LayoutPageTemplateCollection
 				addLayoutPageTemplateCollection(
 					HttpPrincipal httpPrincipal, long groupId, String name,
-					String description,
+					String description, long parentLayoutPageTemplateCollection,
 					com.liferay.portal.kernel.service.ServiceContext
 						serviceContext)
 			throws com.liferay.portal.kernel.exception.PortalException {
@@ -55,6 +55,54 @@ public class LayoutPageTemplateCollectionServiceHttp {
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"addLayoutPageTemplateCollection",
 				_addLayoutPageTemplateCollectionParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, name, description,
+				parentLayoutPageTemplateCollection, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.layout.page.template.model.
+				LayoutPageTemplateCollection)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static
+		com.liferay.layout.page.template.model.LayoutPageTemplateCollection
+				addLayoutPageTemplateCollection(
+					HttpPrincipal httpPrincipal, long groupId, String name,
+					String description,
+					com.liferay.portal.kernel.service.ServiceContext
+						serviceContext)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateCollectionServiceUtil.class,
+				"addLayoutPageTemplateCollection",
+				_addLayoutPageTemplateCollectionParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, description, serviceContext);
@@ -99,7 +147,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"deleteLayoutPageTemplateCollection",
-				_deleteLayoutPageTemplateCollectionParameterTypes1);
+				_deleteLayoutPageTemplateCollectionParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateCollectionId);
@@ -141,7 +189,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"deleteLayoutPageTemplateCollections",
-				_deleteLayoutPageTemplateCollectionsParameterTypes2);
+				_deleteLayoutPageTemplateCollectionsParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateCollectionIds);
@@ -181,7 +229,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"fetchLayoutPageTemplateCollection",
-				_fetchLayoutPageTemplateCollectionParameterTypes3);
+				_fetchLayoutPageTemplateCollectionParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateCollectionId);
@@ -224,7 +272,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"getLayoutPageTemplateCollections",
-				_getLayoutPageTemplateCollectionsParameterTypes4);
+				_getLayoutPageTemplateCollectionsParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -260,7 +308,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"getLayoutPageTemplateCollections",
-				_getLayoutPageTemplateCollectionsParameterTypes5);
+				_getLayoutPageTemplateCollectionsParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end);
@@ -300,7 +348,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"getLayoutPageTemplateCollections",
-				_getLayoutPageTemplateCollectionsParameterTypes6);
+				_getLayoutPageTemplateCollectionsParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end, orderByComparator);
@@ -341,7 +389,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"getLayoutPageTemplateCollections",
-				_getLayoutPageTemplateCollectionsParameterTypes7);
+				_getLayoutPageTemplateCollectionsParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, start, end, orderByComparator);
@@ -376,7 +424,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"getLayoutPageTemplateCollectionsCount",
-				_getLayoutPageTemplateCollectionsCountParameterTypes8);
+				_getLayoutPageTemplateCollectionsCountParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -408,7 +456,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"getLayoutPageTemplateCollectionsCount",
-				_getLayoutPageTemplateCollectionsCountParameterTypes9);
+				_getLayoutPageTemplateCollectionsCountParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name);
@@ -446,7 +494,7 @@ public class LayoutPageTemplateCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateCollectionServiceUtil.class,
 				"updateLayoutPageTemplateCollection",
-				_updateLayoutPageTemplateCollectionParameterTypes10);
+				_updateLayoutPageTemplateCollectionParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateCollectionId, name, description);
@@ -485,49 +533,54 @@ public class LayoutPageTemplateCollectionServiceHttp {
 
 	private static final Class<?>[]
 		_addLayoutPageTemplateCollectionParameterTypes0 = new Class[] {
+			long.class, String.class, String.class, long.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[]
+		_addLayoutPageTemplateCollectionParameterTypes1 = new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_deleteLayoutPageTemplateCollectionParameterTypes1 = new Class[] {
+		_deleteLayoutPageTemplateCollectionParameterTypes2 = new Class[] {
 			long.class
 		};
 	private static final Class<?>[]
-		_deleteLayoutPageTemplateCollectionsParameterTypes2 = new Class[] {
+		_deleteLayoutPageTemplateCollectionsParameterTypes3 = new Class[] {
 			long[].class
 		};
 	private static final Class<?>[]
-		_fetchLayoutPageTemplateCollectionParameterTypes3 = new Class[] {
-			long.class
-		};
-	private static final Class<?>[]
-		_getLayoutPageTemplateCollectionsParameterTypes4 = new Class[] {
+		_fetchLayoutPageTemplateCollectionParameterTypes4 = new Class[] {
 			long.class
 		};
 	private static final Class<?>[]
 		_getLayoutPageTemplateCollectionsParameterTypes5 = new Class[] {
-			long.class, int.class, int.class
+			long.class
 		};
 	private static final Class<?>[]
 		_getLayoutPageTemplateCollectionsParameterTypes6 = new Class[] {
+			long.class, int.class, int.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateCollectionsParameterTypes7 = new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateCollectionsParameterTypes7 = new Class[] {
+		_getLayoutPageTemplateCollectionsParameterTypes8 = new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateCollectionsCountParameterTypes8 = new Class[] {
+		_getLayoutPageTemplateCollectionsCountParameterTypes9 = new Class[] {
 			long.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateCollectionsCountParameterTypes9 = new Class[] {
+		_getLayoutPageTemplateCollectionsCountParameterTypes10 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateCollectionParameterTypes10 = new Class[] {
+		_updateLayoutPageTemplateCollectionParameterTypes11 = new Class[] {
 			long.class, String.class, String.class
 		};
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateEntryServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateEntryServiceHttp.java
@@ -492,6 +492,83 @@ public class LayoutPageTemplateEntryServiceHttp {
 
 	public static java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			HttpPrincipal httpPrincipal, long groupId,
+			long layoutPageTemplateCollectionId, int type, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator<Object>
+				orderByComparator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageCollectionsAndLayoutPageTemplateEntries",
+				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes11);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, layoutPageTemplateCollectionId, type, start,
+				end, orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<Object>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List<Object>
+		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			HttpPrincipal httpPrincipal, long groupId,
+			long layoutPageTemplateCollectionId, String name, int type,
+			int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator<Object>
+				orderByComparator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageCollectionsAndLayoutPageTemplateEntries",
+				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes12);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, layoutPageTemplateCollectionId, name, type,
+				start, end, orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<Object>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List<Object>
+		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			HttpPrincipal httpPrincipal, long groupId, String name, int type,
 			int start, int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
@@ -501,7 +578,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageCollectionsAndLayoutPageTemplateEntries",
-				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes11);
+				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type, start, end, orderByComparator);
@@ -534,10 +611,78 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount",
-				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes12);
+				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		HttpPrincipal httpPrincipal, long groupId,
+		long layoutPageTemplateCollectionId, int type) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount",
+				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes15);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, layoutPageTemplateCollectionId, type);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		HttpPrincipal httpPrincipal, long groupId,
+		long layoutPageTemplateCollectionId, String name, int type) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateEntryServiceUtil.class,
+				"getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount",
+				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes16);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, layoutPageTemplateCollectionId, name, type);
 
 			Object returnObj = null;
 
@@ -567,7 +712,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount",
-				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes13);
+				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type);
@@ -606,7 +751,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes14);
+				_getLayoutPageTemplateEntriesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type, status, start, end,
@@ -648,7 +793,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes15);
+				_getLayoutPageTemplateEntriesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type, start, end, orderByComparator);
@@ -689,7 +834,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes16);
+				_getLayoutPageTemplateEntriesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, types, status, start, end,
@@ -731,7 +876,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes17);
+				_getLayoutPageTemplateEntriesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, types, start, end, orderByComparator);
@@ -769,7 +914,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes18);
+				_getLayoutPageTemplateEntriesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, type, defaultTemplate);
@@ -807,7 +952,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes19);
+				_getLayoutPageTemplateEntriesParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, start, end);
@@ -846,7 +991,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes20);
+				_getLayoutPageTemplateEntriesParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, status,
@@ -889,7 +1034,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes21);
+				_getLayoutPageTemplateEntriesParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, status,
@@ -931,7 +1076,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes22);
+				_getLayoutPageTemplateEntriesParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, start, end,
@@ -970,7 +1115,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes23);
+				_getLayoutPageTemplateEntriesParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type);
@@ -1008,7 +1153,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes24);
+				_getLayoutPageTemplateEntriesParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type, status);
@@ -1049,7 +1194,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes25);
+				_getLayoutPageTemplateEntriesParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type, status,
@@ -1091,7 +1236,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes26);
+				_getLayoutPageTemplateEntriesParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type, start, end,
@@ -1134,7 +1279,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes27);
+				_getLayoutPageTemplateEntriesParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, name, type,
@@ -1176,7 +1321,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes28);
+				_getLayoutPageTemplateEntriesParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, name, type, start,
@@ -1219,7 +1364,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes29);
+				_getLayoutPageTemplateEntriesParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, name,
@@ -1262,7 +1407,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes30);
+				_getLayoutPageTemplateEntriesParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, name, start,
@@ -1304,7 +1449,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes31);
+				_getLayoutPageTemplateEntriesParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type, status, start, end,
@@ -1346,7 +1491,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes32);
+				_getLayoutPageTemplateEntriesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type, start, end, orderByComparator);
@@ -1387,7 +1532,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes33);
+				_getLayoutPageTemplateEntriesParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, types, status, start, end,
@@ -1429,7 +1574,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntries",
-				_getLayoutPageTemplateEntriesParameterTypes34);
+				_getLayoutPageTemplateEntriesParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, types, start, end, orderByComparator);
@@ -1471,7 +1616,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesByType",
-				_getLayoutPageTemplateEntriesByTypeParameterTypes35);
+				_getLayoutPageTemplateEntriesByTypeParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, type, start,
@@ -1507,7 +1652,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes36);
+				_getLayoutPageTemplateEntriesCountParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type);
@@ -1540,7 +1685,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes37);
+				_getLayoutPageTemplateEntriesCountParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type, status);
@@ -1573,7 +1718,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes38);
+				_getLayoutPageTemplateEntriesCountParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, types);
@@ -1606,7 +1751,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes39);
+				_getLayoutPageTemplateEntriesCountParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, types, status);
@@ -1640,7 +1785,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes40);
+				_getLayoutPageTemplateEntriesCountParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId);
@@ -1674,7 +1819,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes41);
+				_getLayoutPageTemplateEntriesCountParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, status);
@@ -1708,7 +1853,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes42);
+				_getLayoutPageTemplateEntriesCountParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type);
@@ -1742,7 +1887,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes43);
+				_getLayoutPageTemplateEntriesCountParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, type, status);
@@ -1776,7 +1921,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes44);
+				_getLayoutPageTemplateEntriesCountParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, name, type);
@@ -1810,7 +1955,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes45);
+				_getLayoutPageTemplateEntriesCountParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classTypeId, name, type,
@@ -1845,7 +1990,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes46);
+				_getLayoutPageTemplateEntriesCountParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, name);
@@ -1879,7 +2024,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes47);
+				_getLayoutPageTemplateEntriesCountParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, name,
@@ -1913,7 +2058,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes48);
+				_getLayoutPageTemplateEntriesCountParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type);
@@ -1947,7 +2092,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes49);
+				_getLayoutPageTemplateEntriesCountParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, type, status);
@@ -1980,7 +2125,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes50);
+				_getLayoutPageTemplateEntriesCountParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, types);
@@ -2014,7 +2159,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCount",
-				_getLayoutPageTemplateEntriesCountParameterTypes51);
+				_getLayoutPageTemplateEntriesCountParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, types, status);
@@ -2048,7 +2193,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntriesCountByType",
-				_getLayoutPageTemplateEntriesCountByTypeParameterTypes52);
+				_getLayoutPageTemplateEntriesCountByTypeParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, type);
@@ -2084,7 +2229,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"getLayoutPageTemplateEntry",
-				_getLayoutPageTemplateEntryParameterTypes53);
+				_getLayoutPageTemplateEntryParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateEntryKey);
@@ -2128,7 +2273,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"moveLayoutPageTemplateEntry",
-				_moveLayoutPageTemplateEntryParameterTypes54);
+				_moveLayoutPageTemplateEntryParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId,
@@ -2173,7 +2318,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"updateLayoutPageTemplateEntry",
-				_updateLayoutPageTemplateEntryParameterTypes55);
+				_updateLayoutPageTemplateEntryParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, defaultTemplate);
@@ -2217,7 +2362,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"updateLayoutPageTemplateEntry",
-				_updateLayoutPageTemplateEntryParameterTypes56);
+				_updateLayoutPageTemplateEntryParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, previewFileEntryId);
@@ -2261,7 +2406,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class,
 				"updateLayoutPageTemplateEntry",
-				_updateLayoutPageTemplateEntryParameterTypes57);
+				_updateLayoutPageTemplateEntryParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, name);
@@ -2304,7 +2449,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutPageTemplateEntryServiceUtil.class, "updateStatus",
-				_updateStatusParameterTypes58);
+				_updateStatusParameterTypes62);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, layoutPageTemplateEntryId, status);
@@ -2393,212 +2538,231 @@ public class LayoutPageTemplateEntryServiceHttp {
 	private static final Class<?>[]
 		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes11 =
 			new Class[] {
+				long.class, long.class, int.class, int.class, int.class,
+				com.liferay.portal.kernel.util.OrderByComparator.class
+			};
+	private static final Class<?>[]
+		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes12 =
+			new Class[] {
+				long.class, long.class, String.class, int.class, int.class,
+				int.class,
+				com.liferay.portal.kernel.util.OrderByComparator.class
+			};
+	private static final Class<?>[]
+		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes13 =
+			new Class[] {
 				long.class, String.class, int.class, int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
-		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes12 =
+		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes14 =
 			new Class[] {long.class, int.class};
 	private static final Class<?>[]
-		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes13 =
+		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes15 =
+			new Class[] {long.class, long.class, int.class};
+	private static final Class<?>[]
+		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes16 =
+			new Class[] {long.class, long.class, String.class, int.class};
+	private static final Class<?>[]
+		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes17 =
 			new Class[] {long.class, String.class, int.class};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes14 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes18 = new Class[] {
 			long.class, int.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes15 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes19 = new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes16 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes20 = new Class[] {
 			long.class, int[].class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes17 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes21 = new Class[] {
 			long.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes18 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes22 = new Class[] {
 			long.class, long.class, int.class, boolean.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes19 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes23 = new Class[] {
 			long.class, long.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes20 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes24 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes21 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes25 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes22 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes26 = new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes23 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes27 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes24 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes28 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes25 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes29 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes26 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes30 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes27 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes31 = new Class[] {
 			long.class, long.class, long.class, String.class, int.class,
 			int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes28 = new Class[] {
+		_getLayoutPageTemplateEntriesParameterTypes32 = new Class[] {
 			long.class, long.class, long.class, String.class, int.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes29 = new Class[] {
-			long.class, long.class, String.class, int.class, int.class,
-			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes30 = new Class[] {
-			long.class, long.class, String.class, int.class, int.class,
-			com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes31 = new Class[] {
-			long.class, String.class, int.class, int.class, int.class,
-			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesParameterTypes32 = new Class[] {
-			long.class, String.class, int.class, int.class, int.class,
-			com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[]
 		_getLayoutPageTemplateEntriesParameterTypes33 = new Class[] {
-			long.class, String.class, int[].class, int.class, int.class,
+			long.class, long.class, String.class, int.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
 		_getLayoutPageTemplateEntriesParameterTypes34 = new Class[] {
+			long.class, long.class, String.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesParameterTypes35 = new Class[] {
+			long.class, String.class, int.class, int.class, int.class,
+			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesParameterTypes36 = new Class[] {
+			long.class, String.class, int.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesParameterTypes37 = new Class[] {
+			long.class, String.class, int[].class, int.class, int.class,
+			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[]
+		_getLayoutPageTemplateEntriesParameterTypes38 = new Class[] {
 			long.class, String.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesByTypeParameterTypes35 = new Class[] {
+		_getLayoutPageTemplateEntriesByTypeParameterTypes39 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes36 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes40 = new Class[] {
 			long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes37 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes41 = new Class[] {
 			long.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes38 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes42 = new Class[] {
 			long.class, int[].class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes39 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes43 = new Class[] {
 			long.class, int[].class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes40 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes44 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes41 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes45 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes42 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes46 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes43 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes47 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes44 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes48 = new Class[] {
 			long.class, long.class, long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes45 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes49 = new Class[] {
 			long.class, long.class, long.class, String.class, int.class,
 			int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes46 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes50 = new Class[] {
 			long.class, long.class, String.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes47 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes51 = new Class[] {
 			long.class, long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes48 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes52 = new Class[] {
 			long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes49 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes53 = new Class[] {
 			long.class, String.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes50 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes54 = new Class[] {
 			long.class, String.class, int[].class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountParameterTypes51 = new Class[] {
+		_getLayoutPageTemplateEntriesCountParameterTypes55 = new Class[] {
 			long.class, String.class, int[].class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntriesCountByTypeParameterTypes52 = new Class[] {
+		_getLayoutPageTemplateEntriesCountByTypeParameterTypes56 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getLayoutPageTemplateEntryParameterTypes53 = new Class[] {
+		_getLayoutPageTemplateEntryParameterTypes57 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_moveLayoutPageTemplateEntryParameterTypes54 = new Class[] {
+		_moveLayoutPageTemplateEntryParameterTypes58 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateEntryParameterTypes55 = new Class[] {
+		_updateLayoutPageTemplateEntryParameterTypes59 = new Class[] {
 			long.class, boolean.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateEntryParameterTypes56 = new Class[] {
+		_updateLayoutPageTemplateEntryParameterTypes60 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_updateLayoutPageTemplateEntryParameterTypes57 = new Class[] {
+		_updateLayoutPageTemplateEntryParameterTypes61 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _updateStatusParameterTypes58 =
+	private static final Class<?>[] _updateStatusParameterTypes62 =
 		new Class[] {long.class, int.class};
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateEntryServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateEntryServiceHttp.java
@@ -46,7 +46,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 				HttpPrincipal httpPrincipal, long groupId,
 				long layoutPageTemplateCollectionId, long classNameId,
 				long classTypeId, String name, long masterLayoutPlid,
-				int status,
+				long parentLayoutPageTemplateCollectionId, int status,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -58,7 +58,8 @@ public class LayoutPageTemplateEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutPageTemplateCollectionId, classNameId,
-				classTypeId, name, masterLayoutPlid, status, serviceContext);
+				classTypeId, name, masterLayoutPlid,
+				parentLayoutPageTemplateCollectionId, status, serviceContext);
 
 			Object returnObj = null;
 
@@ -456,7 +457,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 	public static java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			HttpPrincipal httpPrincipal, long groupId, int type, int start,
-			int end,
+			int end, long parentLayoutPageTemplateCollectionId,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
@@ -467,7 +468,8 @@ public class LayoutPageTemplateEntryServiceHttp {
 				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, type, start, end, orderByComparator);
+				methodKey, groupId, type, start, end,
+				parentLayoutPageTemplateCollectionId, orderByComparator);
 
 			Object returnObj = null;
 
@@ -493,7 +495,9 @@ public class LayoutPageTemplateEntryServiceHttp {
 	public static java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			HttpPrincipal httpPrincipal, long groupId,
-			long layoutPageTemplateCollectionId, int type, int start, int end,
+			long layoutPageTemplateCollectionId,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
@@ -504,8 +508,9 @@ public class LayoutPageTemplateEntryServiceHttp {
 				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, layoutPageTemplateCollectionId, type, start,
-				end, orderByComparator);
+				methodKey, groupId, layoutPageTemplateCollectionId,
+				parentLayoutPageTemplateCollectionId, type, start, end,
+				orderByComparator);
 
 			Object returnObj = null;
 
@@ -531,8 +536,9 @@ public class LayoutPageTemplateEntryServiceHttp {
 	public static java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 			HttpPrincipal httpPrincipal, long groupId,
-			long layoutPageTemplateCollectionId, String name, int type,
-			int start, int end,
+			long layoutPageTemplateCollectionId, String name,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
@@ -543,8 +549,9 @@ public class LayoutPageTemplateEntryServiceHttp {
 				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, layoutPageTemplateCollectionId, name, type,
-				start, end, orderByComparator);
+				methodKey, groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type, start, end,
+				orderByComparator);
 
 			Object returnObj = null;
 
@@ -569,8 +576,9 @@ public class LayoutPageTemplateEntryServiceHttp {
 
 	public static java.util.List<Object>
 		getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			HttpPrincipal httpPrincipal, long groupId, String name, int type,
-			int start, int end,
+			HttpPrincipal httpPrincipal, long groupId, String name,
+			long parentLayoutPageTemplateCollectionId, int type, int start,
+			int end,
 			com.liferay.portal.kernel.util.OrderByComparator<Object>
 				orderByComparator) {
 
@@ -581,7 +589,8 @@ public class LayoutPageTemplateEntryServiceHttp {
 				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, name, type, start, end, orderByComparator);
+				methodKey, groupId, name, parentLayoutPageTemplateCollectionId,
+				type, start, end, orderByComparator);
 
 			Object returnObj = null;
 
@@ -673,7 +682,8 @@ public class LayoutPageTemplateEntryServiceHttp {
 
 	public static int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 		HttpPrincipal httpPrincipal, long groupId,
-		long layoutPageTemplateCollectionId, String name, int type) {
+		long layoutPageTemplateCollectionId, String name,
+		long parentLayoutPageTemplateCollectionId, int type) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
@@ -682,7 +692,8 @@ public class LayoutPageTemplateEntryServiceHttp {
 				_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, layoutPageTemplateCollectionId, name, type);
+				methodKey, groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type);
 
 			Object returnObj = null;
 
@@ -2489,7 +2500,7 @@ public class LayoutPageTemplateEntryServiceHttp {
 	private static final Class<?>[] _addLayoutPageTemplateEntryParameterTypes0 =
 		new Class[] {
 			long.class, long.class, long.class, long.class, String.class,
-			long.class, int.class,
+			long.class, long.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addLayoutPageTemplateEntryParameterTypes1 =
@@ -2532,26 +2543,28 @@ public class LayoutPageTemplateEntryServiceHttp {
 	private static final Class<?>[]
 		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes10 =
 			new Class[] {
-				long.class, int.class, int.class, int.class,
+				long.class, int.class, int.class, int.class, long.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
 		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes11 =
 			new Class[] {
-				long.class, long.class, int.class, int.class, int.class,
+				long.class, long.class, long.class, int.class, int.class,
+				int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
 		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes12 =
 			new Class[] {
-				long.class, long.class, String.class, int.class, int.class,
-				int.class,
+				long.class, long.class, String.class, long.class, int.class,
+				int.class, int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
 		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesParameterTypes13 =
 			new Class[] {
-				long.class, String.class, int.class, int.class, int.class,
+				long.class, String.class, long.class, int.class, int.class,
+				int.class,
 				com.liferay.portal.kernel.util.OrderByComparator.class
 			};
 	private static final Class<?>[]
@@ -2562,7 +2575,9 @@ public class LayoutPageTemplateEntryServiceHttp {
 			new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[]
 		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes16 =
-			new Class[] {long.class, long.class, String.class, int.class};
+			new Class[] {
+				long.class, long.class, String.class, long.class, int.class
+			};
 	private static final Class<?>[]
 		_getLayoutPageCollectionsAndLayoutPageTemplateEntriesCountParameterTypes17 =
 			new Class[] {long.class, String.class, int.class};

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
@@ -48,6 +48,7 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 	@Override
 	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long userId, long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -76,6 +77,8 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 			_generateLayoutPageTemplateCollectionKey(groupId, name));
 		layoutPageTemplateCollection.setName(name);
 		layoutPageTemplateCollection.setDescription(description);
+		layoutPageTemplateCollection.setParentLayoutPageTemplateCollectionId(
+			parentLayoutPageTemplateCollection);
 
 		layoutPageTemplateCollection =
 			layoutPageTemplateCollectionPersistence.update(
@@ -87,6 +90,16 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 			layoutPageTemplateCollection, serviceContext);
 
 		return layoutPageTemplateCollection;
+	}
+
+	@Override
+	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long userId, long groupId, String name, String description,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return addLayoutPageTemplateCollection(
+			userId, groupId, name, description, 0, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionServiceImpl.java
@@ -40,6 +40,23 @@ public class LayoutPageTemplateCollectionServiceImpl
 	@Override
 	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
 			long groupId, String name, String description,
+			long parentLayoutPageTemplateCollection,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), groupId,
+			LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION);
+
+		return layoutPageTemplateCollectionLocalService.
+			addLayoutPageTemplateCollection(
+				getUserId(), groupId, name, description,
+				parentLayoutPageTemplateCollection, serviceContext);
+	}
+
+	@Override
+	public LayoutPageTemplateCollection addLayoutPageTemplateCollection(
+			long groupId, String name, String description,
 			ServiceContext serviceContext)
 		throws PortalException {
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -226,8 +226,9 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			addLayoutPageTemplateEntry(
 				userId, groupId, layoutPageTemplateCollectionId, classNameId,
-				classTypeId, name, type, 0, false, 0, 0, masterLayoutPlid,
-				status, serviceContext);
+				classTypeId, name, type, 0, false, 0, 0,
+				parentLayoutPageTemplateCollectionId, masterLayoutPlid, status,
+				serviceContext);
 
 		// Dynamic data mapping structure link
 
@@ -249,7 +250,7 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 
 		return addLayoutPageTemplateEntry(
 			userId, groupId, layoutPageTemplateCollectionId, 0, 0, name, type,
-			0, false, 0, 0, masterLayoutPlid, status, serviceContext);
+			0, false, 0, 0, -1, masterLayoutPlid, status, serviceContext);
 	}
 
 	@Override
@@ -282,7 +283,7 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 				sourceLayoutPageTemplateEntry.getClassNameId(),
 				sourceLayoutPageTemplateEntry.getClassTypeId(), name,
 				sourceLayoutPageTemplateEntry.getType(), 0, false,
-				sourceLayoutPageTemplateEntry.getLayoutPrototypeId(), 0,
+				sourceLayoutPageTemplateEntry.getLayoutPrototypeId(), 0, -1,
 				masterLayoutPlid, sourceLayoutPageTemplateEntry.getStatus(),
 				serviceContext);
 
@@ -837,7 +838,7 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 		return addLayoutPageTemplateEntry(
 			layoutPrototype.getUserId(), groupId, 0, 0, 0,
 			nameMap.get(defaultLocale),
-			LayoutPageTemplateEntryTypeConstants.TYPE_WIDGET_PAGE, 0, false,
+			LayoutPageTemplateEntryTypeConstants.TYPE_WIDGET_PAGE, 0, false, -1,
 			layoutPrototype.getLayoutPrototypeId(), layout.getPlid(), 0, status,
 			new ServiceContext());
 	}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -114,8 +114,9 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
 			long previewFileEntryId, boolean defaultTemplate,
-			long layoutPrototypeId, long plid, long masterLayoutPlid,
-			int status, ServiceContext serviceContext)
+			long layoutPrototypeId, long parentLayoutPageTemplateCollectionId,
+			long plid, long masterLayoutPlid, int status,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Layout page template entry
@@ -141,6 +142,8 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			serviceContext.getModifiedDate(new Date()));
 		layoutPageTemplateEntry.setLayoutPageTemplateCollectionId(
 			layoutPageTemplateCollectionId);
+		layoutPageTemplateEntry.setLayoutPageTemplateCollectionId(
+			parentLayoutPageTemplateCollectionId);
 		layoutPageTemplateEntry.setLayoutPageTemplateEntryKey(
 			_generateLayoutPageTemplateEntryKey(groupId, name));
 		layoutPageTemplateEntry.setClassNameId(classNameId);
@@ -212,7 +215,8 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 	public LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long userId, long groupId, long layoutPageTemplateCollectionId,
 			long classNameId, long classTypeId, String name, int type,
-			long masterLayoutPlid, int status, ServiceContext serviceContext)
+			long masterLayoutPlid, long parentLayoutPageTemplateCollectionId,
+			int status, ServiceContext serviceContext)
 		throws PortalException {
 
 		// Layout page template entry

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -70,7 +70,8 @@ public class LayoutPageTemplateEntryServiceImpl
 			getUserId(), groupId, layoutPageTemplateCollectionId, classNameId,
 			classTypeId, name,
 			LayoutPageTemplateEntryTypeConstants.TYPE_DISPLAY_PAGE,
-			masterLayoutPlid, status, serviceContext);
+			masterLayoutPlid, parentLayoutPageTemplateCollectionId, status,
+			serviceContext);
 	}
 
 	@Override
@@ -130,7 +131,7 @@ public class LayoutPageTemplateEntryServiceImpl
 				targetLayoutPageTemplateCollection.
 					getLayoutPageTemplateCollectionId(),
 				0, 0, name, LayoutPageTemplateEntryTypeConstants.TYPE_BASIC, 0,
-				false, 0, 0, sourceLayout.getMasterLayoutPlid(),
+				false, 0, 0, -1, sourceLayout.getMasterLayoutPlid(),
 				WorkflowConstants.STATUS_DRAFT, serviceContext);
 
 		Layout layout = _layoutLocalService.getLayout(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -57,7 +57,8 @@ public class LayoutPageTemplateEntryServiceImpl
 	@Override
 	public LayoutPageTemplateEntry addLayoutPageTemplateEntry(
 			long groupId, long layoutPageTemplateCollectionId, long classNameId,
-			long classTypeId, String name, long masterLayoutPlid, int status,
+			long classTypeId, String name, long masterLayoutPlid,
+			long parentLayoutPageTemplateCollectionId, int status,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -927,7 +928,7 @@ public class LayoutPageTemplateEntryServiceImpl
 					if (parentLayoutPageTemplateCollectionId != -1) {
 						return LayoutPageTemplateEntryTable.INSTANCE.
 							layoutPageTemplateCollectionId.eq(
-							parentLayoutPageTemplateCollectionId);
+								parentLayoutPageTemplateCollectionId);
 					}
 
 					return null;
@@ -937,7 +938,7 @@ public class LayoutPageTemplateEntryServiceImpl
 					if (layoutPageTemplateCollectionId != -1) {
 						return LayoutPageTemplateEntryTable.INSTANCE.
 							layoutPageTemplateCollectionId.eq(
-							layoutPageTemplateCollectionId);
+								layoutPageTemplateCollectionId);
 					}
 
 					return null;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -237,7 +237,17 @@ public class LayoutPageTemplateEntryServiceImpl
 
 	@Override
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-		long groupId, String name, int type, int start, int end,
+		long groupId, long layoutPageTemplateCollectionId, int type, int start,
+		int end, OrderByComparator<Object> orderByComparator) {
+
+		return getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			groupId, null, type, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+		long groupId, long layoutPageTemplateCollectionId, String name,
+		int type, int start, int end,
 		OrderByComparator<Object> orderByComparator) {
 
 		Table<?> tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntry =
@@ -258,6 +268,15 @@ public class LayoutPageTemplateEntryServiceImpl
 	}
 
 	@Override
+	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+		long groupId, String name, int type, int start, int end,
+		OrderByComparator<Object> orderByComparator) {
+
+		return getLayoutPageCollectionsAndLayoutPageTemplateEntries(
+			groupId, -1, name, type, start, end, orderByComparator);
+	}
+
+	@Override
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 		long groupId, int type) {
 
@@ -267,7 +286,16 @@ public class LayoutPageTemplateEntryServiceImpl
 
 	@Override
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
-		long groupId, String name, int type) {
+		long groupId, long layoutPageTemplateCollectionId, int type) {
+
+		return getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+			groupId, null, type);
+	}
+
+	@Override
+	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, long layoutPageTemplateCollectionId, String name,
+		int type) {
 
 		Table<?> tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntry =
 			_getTempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable(
@@ -280,6 +308,14 @@ public class LayoutPageTemplateEntryServiceImpl
 			).from(
 				tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntry
 			));
+	}
+
+	@Override
+	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+		long groupId, String name, int type) {
+
+		return getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
+			groupId, -1, name, type);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -241,7 +241,8 @@ public class LayoutPageTemplateEntryServiceImpl
 		int end, OrderByComparator<Object> orderByComparator) {
 
 		return getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			groupId, null, type, start, end, orderByComparator);
+			groupId, layoutPageTemplateCollectionId, null, type, start, end,
+			orderByComparator);
 	}
 
 	@Override
@@ -252,7 +253,7 @@ public class LayoutPageTemplateEntryServiceImpl
 
 		Table<?> tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntry =
 			_getTempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable(
-				groupId, name, type);
+				groupId, layoutPageTemplateCollectionId, name, type);
 
 		return _getLayoutPageTemplateCollectionAndLayoutPageTemplateEntries(
 			DSLQueryFactoryUtil.select(
@@ -289,7 +290,7 @@ public class LayoutPageTemplateEntryServiceImpl
 		long groupId, long layoutPageTemplateCollectionId, int type) {
 
 		return getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
-			groupId, null, type);
+			groupId, layoutPageTemplateCollectionId, null, type);
 	}
 
 	@Override
@@ -299,7 +300,7 @@ public class LayoutPageTemplateEntryServiceImpl
 
 		Table<?> tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntry =
 			_getTempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable(
-				groupId, name, type);
+				groupId, layoutPageTemplateCollectionId, name, type);
 
 		return layoutPageTemplateEntryPersistence.dslQueryCount(
 			DSLQueryFactoryUtil.countDistinct(
@@ -898,7 +899,8 @@ public class LayoutPageTemplateEntryServiceImpl
 
 	private Table<?>
 		_getTempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable(
-			long groupId, String name, int type) {
+			long groupId, long layoutPageTemplateCollectionId, String name,
+			int type) {
 
 		return DSLQueryFactoryUtil.select(
 			LayoutPageTemplateEntryTable.INSTANCE.layoutPageTemplateEntryId,
@@ -912,6 +914,16 @@ public class LayoutPageTemplateEntryServiceImpl
 		).where(
 			LayoutPageTemplateEntryTable.INSTANCE.groupId.eq(
 				groupId
+			).and(
+				() -> {
+					if (layoutPageTemplateCollectionId != -1) {
+						return LayoutPageTemplateEntryTable.INSTANCE.
+							layoutPageTemplateCollectionId.eq(
+								layoutPageTemplateCollectionId);
+					}
+
+					return null;
+				}
 			).and(
 				() -> {
 					if (Validator.isNotNull(name)) {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -229,31 +229,36 @@ public class LayoutPageTemplateEntryServiceImpl
 	@Override
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 		long groupId, int type, int start, int end,
+		long parentLayoutPageTemplateCollectionId,
 		OrderByComparator<Object> orderByComparator) {
 
 		return getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			groupId, null, type, start, end, orderByComparator);
+			groupId, null, parentLayoutPageTemplateCollectionId, type, start,
+			end, orderByComparator);
 	}
 
 	@Override
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-		long groupId, long layoutPageTemplateCollectionId, int type, int start,
-		int end, OrderByComparator<Object> orderByComparator) {
+		long groupId, long layoutPageTemplateCollectionId,
+		long parentLayoutPageTemplateCollectionId, int type, int start, int end,
+		OrderByComparator<Object> orderByComparator) {
 
 		return getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			groupId, layoutPageTemplateCollectionId, null, type, start, end,
+			groupId, layoutPageTemplateCollectionId, null,
+			parentLayoutPageTemplateCollectionId, type, start, end,
 			orderByComparator);
 	}
 
 	@Override
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
 		long groupId, long layoutPageTemplateCollectionId, String name,
-		int type, int start, int end,
+		long parentLayoutPageTemplateCollectionId, int type, int start, int end,
 		OrderByComparator<Object> orderByComparator) {
 
 		Table<?> tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntry =
 			_getTempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable(
-				groupId, layoutPageTemplateCollectionId, name, type);
+				groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type);
 
 		return _getLayoutPageTemplateCollectionAndLayoutPageTemplateEntries(
 			DSLQueryFactoryUtil.select(
@@ -270,11 +275,13 @@ public class LayoutPageTemplateEntryServiceImpl
 
 	@Override
 	public List<Object> getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-		long groupId, String name, int type, int start, int end,
+		long groupId, String name, long parentLayoutPageTemplateCollectionId,
+		int type, int start, int end,
 		OrderByComparator<Object> orderByComparator) {
 
 		return getLayoutPageCollectionsAndLayoutPageTemplateEntries(
-			groupId, -1, name, type, start, end, orderByComparator);
+			groupId, -1, name, parentLayoutPageTemplateCollectionId, type,
+			start, end, orderByComparator);
 	}
 
 	@Override
@@ -290,17 +297,18 @@ public class LayoutPageTemplateEntryServiceImpl
 		long groupId, long layoutPageTemplateCollectionId, int type) {
 
 		return getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
-			groupId, layoutPageTemplateCollectionId, null, type);
+			groupId, layoutPageTemplateCollectionId, null, -1, type);
 	}
 
 	@Override
 	public int getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
 		long groupId, long layoutPageTemplateCollectionId, String name,
-		int type) {
+		long parentLayoutPageTemplateCollectionId, int type) {
 
 		Table<?> tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntry =
 			_getTempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable(
-				groupId, layoutPageTemplateCollectionId, name, type);
+				groupId, layoutPageTemplateCollectionId, name,
+				parentLayoutPageTemplateCollectionId, type);
 
 		return layoutPageTemplateEntryPersistence.dslQueryCount(
 			DSLQueryFactoryUtil.countDistinct(
@@ -316,7 +324,7 @@ public class LayoutPageTemplateEntryServiceImpl
 		long groupId, String name, int type) {
 
 		return getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount(
-			groupId, -1, name, type);
+			groupId, -1, name, -1, type);
 	}
 
 	@Override
@@ -900,7 +908,7 @@ public class LayoutPageTemplateEntryServiceImpl
 	private Table<?>
 		_getTempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable(
 			long groupId, long layoutPageTemplateCollectionId, String name,
-			int type) {
+			long parentLayoutPageTemplateCollectionId, int type) {
 
 		return DSLQueryFactoryUtil.select(
 			LayoutPageTemplateEntryTable.INSTANCE.layoutPageTemplateEntryId,
@@ -916,10 +924,20 @@ public class LayoutPageTemplateEntryServiceImpl
 				groupId
 			).and(
 				() -> {
+					if (parentLayoutPageTemplateCollectionId != -1) {
+						return LayoutPageTemplateEntryTable.INSTANCE.
+							layoutPageTemplateCollectionId.eq(
+							parentLayoutPageTemplateCollectionId);
+					}
+
+					return null;
+				}
+			).and(
+				() -> {
 					if (layoutPageTemplateCollectionId != -1) {
 						return LayoutPageTemplateEntryTable.INSTANCE.
 							layoutPageTemplateCollectionId.eq(
-								layoutPageTemplateCollectionId);
+							layoutPageTemplateCollectionId);
 					}
 
 					return null;
@@ -948,7 +966,19 @@ public class LayoutPageTemplateEntryServiceImpl
 			).from(
 				LayoutPageTemplateCollectionTable.INSTANCE
 			).where(
-				LayoutPageTemplateCollectionTable.INSTANCE.groupId.eq(groupId)
+				LayoutPageTemplateCollectionTable.INSTANCE.groupId.eq(
+					groupId
+				).and(
+					() -> {
+						if (parentLayoutPageTemplateCollectionId != -1) {
+							return LayoutPageTemplateCollectionTable.INSTANCE.
+								parentLayoutPageTemplateCollectionId.eq(
+									parentLayoutPageTemplateCollectionId);
+						}
+
+						return null;
+					}
+				)
 			)
 		).as(
 			"tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable"

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateCollectionPersistenceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateCollectionPersistenceImpl.java
@@ -4084,6 +4084,9 @@ public class LayoutPageTemplateCollectionPersistenceImpl
 		dbColumnNames.put("uuid", "uuid_");
 		dbColumnNames.put(
 			"layoutPageTemplateCollectionKey", "lptCollectionKey");
+		dbColumnNames.put(
+			"parentLayoutPageTemplateCollectionId", "parentLPTCollectionId");
+		dbColumnNames.put("type", "type_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -4961,6 +4964,8 @@ public class LayoutPageTemplateCollectionPersistenceImpl
 		ctStrictColumnNames.add("lptCollectionKey");
 		ctStrictColumnNames.add("name");
 		ctStrictColumnNames.add("description");
+		ctStrictColumnNames.add("parentLPTCollectionId");
+		ctStrictColumnNames.add("type_");
 		ctStrictColumnNames.add("lastPublishDate");
 
 		_ctColumnNamesMap.put(
@@ -5199,7 +5204,10 @@ public class LayoutPageTemplateCollectionPersistenceImpl
 		LayoutPageTemplateCollectionPersistenceImpl.class);
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid", "layoutPageTemplateCollectionKey"});
+		new String[] {
+			"uuid", "layoutPageTemplateCollectionKey",
+			"parentLayoutPageTemplateCollectionId", "type"
+		});
 
 	@Override
 	protected FinderCache getFinderCache() {

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/module-hbm.xml
@@ -22,6 +22,8 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="lptCollectionKey" name="layoutPageTemplateCollectionKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="parentLPTCollectionId" name="parentLayoutPageTemplateCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="type_" name="type" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="lastPublishDate" type="org.hibernate.type.TimestampType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryImpl" table="LayoutPageTemplateEntry">

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -19,6 +19,8 @@
 		<field name="description" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>
+		<field name="parentLayoutPageTemplateCollectionId" type="long" />
+		<field name="type" type="int" />
 		<field name="lastPublishDate" type="Date" />
 	</model>
 	<model name="com.liferay.layout.page.template.model.LayoutPageTemplateEntry">

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
@@ -12,6 +12,8 @@ create table LayoutPageTemplateCollection (
 	lptCollectionKey VARCHAR(75) null,
 	name VARCHAR(75) null,
 	description STRING null,
+	parentLPTCollectionId LONG,
+	type_ INTEGER,
 	lastPublishDate DATE null,
 	primary key (layoutPageTemplateCollectionId, ctCollectionId)
 );

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateCollectionPersistenceTest.java
@@ -152,6 +152,11 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 		newLayoutPageTemplateCollection.setDescription(
 			RandomTestUtil.randomString());
 
+		newLayoutPageTemplateCollection.setParentLayoutPageTemplateCollectionId(
+			RandomTestUtil.nextLong());
+
+		newLayoutPageTemplateCollection.setType(RandomTestUtil.nextInt());
+
 		newLayoutPageTemplateCollection.setLastPublishDate(
 			RandomTestUtil.nextDate());
 
@@ -209,6 +214,14 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 		Assert.assertEquals(
 			existingLayoutPageTemplateCollection.getDescription(),
 			newLayoutPageTemplateCollection.getDescription());
+		Assert.assertEquals(
+			existingLayoutPageTemplateCollection.
+				getParentLayoutPageTemplateCollectionId(),
+			newLayoutPageTemplateCollection.
+				getParentLayoutPageTemplateCollectionId());
+		Assert.assertEquals(
+			existingLayoutPageTemplateCollection.getType(),
+			newLayoutPageTemplateCollection.getType());
 		Assert.assertEquals(
 			Time.getShortTimestamp(
 				existingLayoutPageTemplateCollection.getLastPublishDate()),
@@ -319,7 +332,9 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 			"layoutPageTemplateCollectionId", true, "groupId", true,
 			"companyId", true, "userId", true, "userName", true, "createDate",
 			true, "modifiedDate", true, "layoutPageTemplateCollectionKey", true,
-			"name", true, "description", true, "lastPublishDate", true);
+			"name", true, "description", true,
+			"parentLayoutPageTemplateCollectionId", true, "type", true,
+			"lastPublishDate", true);
 	}
 
 	@Test
@@ -695,6 +710,11 @@ public class LayoutPageTemplateCollectionPersistenceTest {
 
 		layoutPageTemplateCollection.setDescription(
 			RandomTestUtil.randomString());
+
+		layoutPageTemplateCollection.setParentLayoutPageTemplateCollectionId(
+			RandomTestUtil.nextLong());
+
+		layoutPageTemplateCollection.setType(RandomTestUtil.nextInt());
 
 		layoutPageTemplateCollection.setLastPublishDate(
 			RandomTestUtil.nextDate());


### PR DESCRIPTION
- LPS-193763 Create href to navigate to each available layoutPageTemplateCollection
- LPS-193763 Modify getLayoutPageCollectionsAndLayoutPageTemplateEntries and getLayoutPageCollectionsAndLayoutPageTemplateEntriesCount params to be able to filter by layoutPageTemplateCollectionId
- LPS-194345 buildService
- LPS-193763 Modify method to retrieve items related only to the current layoutPageTemplateCollectionId
- LPS-194345 Add parentLayoutPageTemplateCollectionId and type fields to LayoutPageTemplateCollection
- LPS-194345 Adding parentLayoutPageTemplateCollectionId as param in addLayoutPageTemplateCollection methods
- LPS-194345 buildService
- LPS-194345 Create layoutPageTemplateCollections filling the parentLayoutPageTemplateCollectionId so we will be able of subfoldering
- LPS-194345 Add parentLayoutPageTemplateCollectionId param to the add dropdown item url
- LPS-194345 Retrieve LayoutPageTemplateCollections and LayoutPageTemplateEntries only related to the specified parentLayoutPageTemplateCollectionId
- LPS-194345 Add parentLayoutPageTemplateCollectionId in LayoutPageTemplateEntries addition
- LPS-194345 buildService
- LPS-194345 Adjusting calls to methods with new params
- LPS-194345 Add parentLayoutPageTemplateCollectionId with default value when clicking Display Page Templates tab
-  LPS-194345 Upgrade layoutPageTemplateCollection table with type and parentLayoutPageTemplateCollectionId fields
- LPS-194345 wip
