### PR TITLE
LPD-88576 Add poshi-shrink skill

### DIFF
--- a/.claude/skills/poshi-consolidate/SKILL.md
+++ b/.claude/skills/poshi-consolidate/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: poshi-consolidate
+description: Triage and consolidate Poshi .testcase files for a given Liferay @component-name before migrating to Playwright, Java integration, or unit tests. Enumerates tests by component, groups by testray.main.component.name, identifies overlapping tests within a file, and drives the consolidation via reviewable per-merge commits. Use when the user asks to migrate, consolidate, merge, triage, or reduce Poshi tests for their team's component.
+---
+
+# Poshi Test Consolidation
+
+A playbook for shrinking a Liferay component's Poshi test suite before migrating tests to Playwright, Java integration, or unit layer. Typical outcome: a file with ~27 tests ends up with ~8, in ~24 small reviewable commits.
+
+## Inputs required from the user
+
+Before doing anything, confirm:
+
+- **`@component-name`**: the annotation at the top of `.testcase` files (e.g., `portal-analytics-cloud`, `portal-knowledge-base`, `portal-commerce`). Check the first line of any `.testcase` file if unsure.
+- **LPD ticket prefix**: for commit messages (e.g., `LPD-87004`). Use `LPD-X` if none yet.
+
+If either is not in the skill args, ask. Do not guess.
+
+## Workflow
+
+### Step 1 — Triage all tests for the component
+
+From `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, list every `.testcase` file tagged with the component, its `testray.main.component.name`, and its test count. Sort ascending by component, then by test count, so small files (easy migration wins) surface first.
+
+```bash
+cd portal-web/test/functional/com/liferay/portalweb/tests/enduser
+find . -name "*.testcase" | while read f; do
+  if grep -q '@component-name = "<COMPONENT>"' "$f"; then
+    component=$(grep -oE 'testray\.main\.component\.name = "[^"]*"' "$f" | head -1 | sed -E 's/.*= "([^"]*)"/\1/')
+    count=$(grep -cE '^[[:space:]]*test [A-Za-z0-9_]+ \{' "$f")
+    printf "%s\t%s\t%d\n" "${f#./}" "${component:-(none)}" "$count"
+  fi
+done | sort -t$'\t' -k2,2 -k3,3n
+```
+
+Save a triage doc at repo root (`<component>-test-triage.md`) with:
+- Totals by `testray.main.component.name` (files + tests).
+- Full table of files, component, test count.
+- "Quick-win candidates" section: files with 1–2 tests.
+
+### Step 2 — Optional bucket-classification per test
+
+For each test, look up its LPS/LPD ticket from `@description` in `git log` and see what files the ticket actually changed. Helps decide the target layer later.
+
+| Bucket | Signal |
+|--------|--------|
+| `integration-java` | Ticket changed Java in service/validator/permission layer |
+| `rest-integration` | Ticket changed Java in `*-rest-impl` |
+| `playwright` | Ticket changed only JSP/JS/CSS/fragment files |
+| `needs-review` | Ticket only added the Poshi test, or only language keys |
+| `inconclusive` | Ticket not in the repo's git log |
+| `no-ticket` | No LPS/LPD reference in the description |
+
+This step is useful but not required for the consolidation itself.
+
+### Step 3 — Pick a file and find merge groups
+
+Start with files showing visually obvious overlap — classic signals from Liferay test names:
+
+- Multiple `AuthorNotShowIn<Context>` tests — usually one per panel-context is enough.
+- Multiple `MetricsIconVisibleIn<Context>` + `PanelInformationIn<Context>` — the first checks title+traffic, the second title+URL+language; huge overlap.
+- `CheckAllInfo*` or similar catch-all tests that duplicate specific-field tests.
+- Tests that share the full `setUp` + first N tasks (navigate, create blog, open panel) and differ only in the final assertion.
+
+Avoid files with 40+ tests on the first pass — practice on smaller ones first.
+
+#### Merge signals — DO
+
+- Same setup + same UI surface + different assertion → one test with N assertion tasks.
+- Tests differing only in asset type (blog vs document vs web content) when the panel behaviour being asserted is identical — often fully redundant; propose deletion rather than merge.
+- Tests where the source's assertion is already fully covered in the target — commit still happens, it just deletes the source.
+
+#### Merge signals — DON'T
+
+- Tests with test-level property overrides that differ: `property portal.upstream = "quarantine"`, `property test.liferay.virtual.instance = "false"`, `property test.run.type = "single"` (when not inherited).
+- Tests with special setup (localized URLs, fragment translations, system settings changes, extra page creation).
+- Tests with `@ignore` / `@skip` annotations.
+
+### Step 4 — Plan and get approval
+
+Never start editing before the user has seen and approved the consolidation plan. Present it clearly:
+
+> **Group A — <Context name>** (N → 1):
+> - Rename `<Keeper>` → `<FinalName>` (commit 1)
+> - Merge `<Source2>` → adds `<assertion>` (commit 2)
+> - Merge `<Source3>` → adds `<assertion>` (commit 3)
+> - ... etc
+
+Pick the **keeper**: the test with the most comprehensive assertions, or the clearest name. The **final name** is usually descriptive of the combined behaviour (e.g., `ContentPerformancePanelInBlogDisplayPage`, `LanguageDropdownInContentPage`), typically different from the keeper's original name.
+
+### Step 5 — Execute with one commit per operation
+
+For each group, make one commit per source test. Message conventions:
+
+- `<TICKET> Rename test <Keeper> to <FinalName>` — pure rename; first commit of the group; no logic change.
+- `<TICKET> Merge test <Source> into <FinalName>` — delete the source test block; add its unique assertions as new `task` blocks in the target.
+
+If a source's assertions are already fully covered by the target, still make the "Merge" commit (it simply deletes the source — documents the consolidation).
+
+Do **not** squash, bundle, or batch these commits. The per-merge granularity is exactly what makes the diff reviewable.
+
+After each commit:
+```bash
+git add <path>
+git commit -m "<TICKET> Merge test <Source> into <FinalName>"
+```
+
+### Step 6 — Optional cleanup
+
+- If the file convention keeps tests alphabetical, add a final `<TICKET> Alphabetic order` commit after all merges.
+- If commits come out unsigned despite `commit.gpgsign=true`, the user's SSH signer (1Password, etc.) may have been locked. Re-sign with `git rebase --exec 'git commit --amend --no-edit -S' <base>` — user must approve in their signer.
+
+## Anti-patterns to avoid
+
+- **Never start editing without an approved plan.** Always present the grouping first.
+- **Never rewrite history on pushed/shared branches** unless the user explicitly asks.
+- **Don't trust the LPS ticket to identify the fix location blindly** — sometimes the ticket only added the Poshi test and the real fix is elsewhere.
+- **Don't drop strong assertions when merging.** When one test uses `AssertTextEquals.assertPartialText("web/<site-path>")` and another uses a weak `AssertVisible value1="http://"`, keep the strong one.
+- **Don't merge tests across different property/setup profiles.** Those properties exist for a reason (flaky environment, quarantined, virtual-instance-specific).
+- **Don't guess the ticket prefix.** Ask if not provided.
+
+## Heuristics learned from prior runs
+
+- Identical panel assertions across four asset-type variants (blog / document / widget / content page) are usually overengineered — **one representative often suffices**; propose deletion for the rest instead of merging four tests into four tests.
+- The *keeper* does not have to keep its name. Pick the most comprehensive test as the starting point, then rename it.
+- When a merge target already has an assertion the source also has, the merge commit is still a valid "documents-that-this-was-redundant" commit.
+
+## Reference example
+
+Completed run: `portal-analytics-cloud` / `Content Performance` / `ContentPerformance.testcase`.
+
+- Before: 27 tests.
+- After: 8 tests (70% reduction).
+- Commits: 24 (~5 renames + ~18 merges + 1 deletion-of-redundant + 1 alphabetic cleanup).
+- Groups consolidated:
+  - Blog Display Page panel: 5 → 1
+  - Content Page panel: 8 → 1
+  - Document Display Page panel: 4 → 0 (subsumed by Blog Display Page panel — identical assertions, only asset type differed)
+  - Widget Page panel: 3 → 1
+  - Language Dropdown: 3 → 1
+- Kept intact: 4 tests with unique setup (localized URL config, fragment translations, extra page creation).
+
+The triage doc from that run (`analytics-cloud-test-triage.md` at repo root) is a good template for structure.

--- a/.claude/skills/poshi-consolidate/SKILL.md
+++ b/.claude/skills/poshi-consolidate/SKILL.md
@@ -33,10 +33,72 @@ find . -name "*.testcase" | while read f; do
 done | sort -t$'\t' -k2,2 -k3,3n
 ```
 
-Save a triage doc at repo root (`<component>-test-triage.md`) with:
-- Totals by `testray.main.component.name` (files + tests).
-- Full table of files, component, test count.
-- "Quick-win candidates" section: files with 1–2 tests.
+Save a triage doc at repo root (`<component>-test-triage.md`) following this template:
+
+````markdown
+# <Component Title> Test Triage Report
+
+**Scope:** All Poshi tests tagged `@component-name = "<component>"`
+**Date:** YYYY-MM-DD
+**Method:** Enumerated <N> `.testcase` files, parsed <N> test blocks for priority and ticket references, looked up ticket commits in git log, classified buckets by changed file paths.
+
+## Summary
+
+- **Total test blocks:** <N>
+- **Unique tickets referenced:** <N>
+
+### By Bucket
+
+| Bucket | Count | Meaning |
+| --- | --- | --- |
+| integration-java | <N> | Rewrite as Java integration test against service/validator/permission layer |
+| rest-integration | <N> | Rewrite as REST-layer integration test in `*-rest-test` |
+| playwright | <N> | Keep as functional; migrate to Playwright (not Java-replaceable) |
+| needs-review | <N> | Git log alone not conclusive; must read the test body |
+| inconclusive | <N> | Ticket not in this repo's git history (often LPD-internal) |
+| no-ticket | <N> | Test description has no LPS/LPD reference; must read the test body |
+
+### By Priority
+
+| Priority | Count |
+| --- | --- |
+| 5 | <N> |
+| 4 | <N> |
+| 3 | <N> |
+| 2 | <N> |
+| 1 | <N> |
+
+## Test Details
+
+| File | Test | Priority | Ticket | Bucket | Notes |
+| --- | --- | --- | --- | --- | --- |
+| <file> | <test> | <priority> | <ticket> | <bucket> | <notes> |
+
+## Files by Component & Test Count
+
+Classification based on `property testray.main.component.name` in each `.testcase`. Sorted ascending by test count within each component so small files (easy migration wins) appear first.
+
+### Totals by Component
+
+| Component | Files | Tests |
+| --- | --- | --- |
+| <component> | <N> | <N> |
+| **Total** | **<N>** | **<N>** |
+
+### Quick-win candidates (1–2 tests, <N> files)
+
+| Component | File | Tests |
+| --- | --- | --- |
+| <component> | <file> | <N> |
+
+### <Component Name> (<N> files, <N> tests)
+
+| File | Tests |
+| --- | --- |
+| <file> | <N> |
+````
+
+Sort the **Test Details** rows by bucket order (`integration-java`, `rest-integration`, `playwright`, `needs-review`, `inconclusive`, `no-ticket`), then priority descending, then file path and test name. Leave the **Ticket** cell blank when there is none. **Notes** is a short reason taken from the bucket lookup, for example "service/validator/permission impl" or "UI/JSP/frontend fix". The bucket and **Test Details** content is filled in after Step 2; Step 1 alone produces the **Files by Component & Test Count** section and the test enumeration.
 
 ### Step 2 — Optional bucket-classification per test
 
@@ -124,20 +186,3 @@ git commit -m "<TICKET> Merge test <Source> into <FinalName>"
 - Identical panel assertions across four asset-type variants (blog / document / widget / content page) are usually overengineered — **one representative often suffices**; propose deletion for the rest instead of merging four tests into four tests.
 - The *keeper* does not have to keep its name. Pick the most comprehensive test as the starting point, then rename it.
 - When a merge target already has an assertion the source also has, the merge commit is still a valid "documents-that-this-was-redundant" commit.
-
-## Reference example
-
-Completed run: `portal-analytics-cloud` / `Content Performance` / `ContentPerformance.testcase`.
-
-- Before: 27 tests.
-- After: 8 tests (70% reduction).
-- Commits: 24 (~5 renames + ~18 merges + 1 deletion-of-redundant + 1 alphabetic cleanup).
-- Groups consolidated:
-  - Blog Display Page panel: 5 → 1
-  - Content Page panel: 8 → 1
-  - Document Display Page panel: 4 → 0 (subsumed by Blog Display Page panel — identical assertions, only asset type differed)
-  - Widget Page panel: 3 → 1
-  - Language Dropdown: 3 → 1
-- Kept intact: 4 tests with unique setup (localized URL config, fragment translations, extra page creation).
-
-The triage doc from that run (`analytics-cloud-test-triage.md` at repo root) is a good template for structure.

--- a/.claude/skills/poshi-shrink/SKILL.md
+++ b/.claude/skills/poshi-shrink/SKILL.md
@@ -1,9 +1,12 @@
 ---
-name: poshi-consolidate
-description: Triage and consolidate Poshi .testcase files for a given Liferay @component-name before migrating to Playwright, Java integration, or unit tests. Enumerates tests by component, groups by testray.main.component.name, identifies overlapping tests within a file, and drives the consolidation via reviewable per-merge commits. Use when the user asks to migrate, consolidate, merge, triage, or reduce Poshi tests for their team's component.
+
+argument-hint: "<component-name>"
+description: Shrink a Liferay component's Poshi test suite by merging overlapping tests. Use when the user asks to reduce, merge, or clean up Poshi tests for a @component-name.
+name: poshi-shrink
+
 ---
 
-# Poshi Test Consolidation
+# Shrink Poshi Tests
 
 A playbook for shrinking a Liferay component's Poshi test suite before migrating tests to Playwright, Java integration, or unit layer. Typical outcome: a file with ~27 tests ends up with ~8, in ~24 small reviewable commits.
 
@@ -11,7 +14,7 @@ A playbook for shrinking a Liferay component's Poshi test suite before migrating
 
 Before doing anything, confirm:
 
-- **`@component-name`**: the annotation at the top of `.testcase` files (e.g., `portal-analytics-cloud`, `portal-knowledge-base`, `portal-commerce`). Check the first line of any `.testcase` file if unsure.
+- **`@component-name`**: passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-knowledge-base`, `portal-commerce`). Check the first line of any `.testcase` file if unsure.
 - **LPD ticket prefix**: for commit messages (e.g., `LPD-87004`). Use `LPD-X` if none yet.
 
 If either is not in the skill args, ask. Do not guess.
@@ -113,7 +116,7 @@ For each test, look up its LPS/LPD ticket from `@description` in `git log` and s
 | `inconclusive` | Ticket not in the repo's git log |
 | `no-ticket` | No LPS/LPD reference in the description |
 
-This step is useful but not required for the consolidation itself.
+This step is useful but not required for the shrink itself.
 
 ### Step 3 — Pick a file and find merge groups
 
@@ -140,7 +143,7 @@ Avoid files with 40+ tests on the first pass — practice on smaller ones first.
 
 ### Step 4 — Plan and get approval
 
-Never start editing before the user has seen and approved the consolidation plan. Present it clearly:
+Never start editing before the user has seen and approved the shrink plan. Present it clearly:
 
 > **Group A — <Context name>** (N → 1):
 > - Rename `<Keeper>` → `<FinalName>` (commit 1)
@@ -157,7 +160,7 @@ For each group, make one commit per source test. Message conventions:
 - `<TICKET> Rename test <Keeper> to <FinalName>` — pure rename; first commit of the group; no logic change.
 - `<TICKET> Merge test <Source> into <FinalName>` — delete the source test block; add its unique assertions as new `task` blocks in the target.
 
-If a source's assertions are already fully covered by the target, still make the "Merge" commit (it simply deletes the source — documents the consolidation).
+If a source's assertions are already fully covered by the target, still make the "Merge" commit (it simply deletes the source — documents the shrink).
 
 Do **not** squash, bundle, or batch these commits. The per-merge granularity is exactly what makes the diff reviewable.
 

--- a/.claude/skills/poshi-shrink/SKILL.md
+++ b/.claude/skills/poshi-shrink/SKILL.md
@@ -18,7 +18,7 @@ A playbook for shrinking a Liferay component's Poshi test suite before migrating
 
 ### Component Name
 
-The `@component-name` annotation, passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-knowledge-base`, `portal-commerce`). Ask if missing; do not guess.
+The `@component-name` annotation, passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-commerce`, `portal-content-management`). Ask if missing; do not guess.
 
 Verify the component by enumerating, under `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, every `.testcase` whose `@component-name` matches; abort when none does. The same enumeration feeds the **Shrink Plan**: per file, capture the path, the `testray.main.component.name` value, and the test-block count.
 

--- a/.claude/skills/poshi-shrink/SKILL.md
+++ b/.claude/skills/poshi-shrink/SKILL.md
@@ -10,33 +10,38 @@ name: poshi-shrink
 
 A playbook for shrinking a Liferay component's Poshi test suite before migrating tests to Playwright, Java integration, or unit layer. Typical outcome: a file with ~27 tests ends up with ~8, in ~24 small reviewable commits.
 
-## Inputs required from the user
+## Preconditions
 
-Before doing anything, confirm:
+- The working tree is clean. Abort and ask the user to commit or stash first when dirty.
 
-- **`@component-name`**: passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-knowledge-base`, `portal-commerce`). Check the first line of any `.testcase` file if unsure.
-- **LPD ticket prefix**: for commit messages (e.g., `LPD-87004`). Use `LPD-X` if none yet.
+## Input
 
-If either is not in the skill args, ask. Do not guess.
+### Component Name
 
-## Workflow
+The `@component-name` annotation, passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-knowledge-base`, `portal-commerce`). Ask if missing; do not guess.
 
-### Step 1 — Triage all tests for the component
+Verify the component by enumerating, under `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, every `.testcase` whose `@component-name` matches; abort when none does. The same enumeration feeds the **Triage Report**: per file, capture the path, the `testray.main.component.name` value, and the test-block count, sorted by component then by ascending test count.
 
-From `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, list every `.testcase` file tagged with the component, its `testray.main.component.name`, and its test count. Sort ascending by component, then by test count, so small files (easy migration wins) surface first.
+## Expected Output
 
-```bash
-cd portal-web/test/functional/com/liferay/portalweb/tests/enduser
-find . -name "*.testcase" | while read f; do
-  if grep -q '@component-name = "<COMPONENT>"' "$f"; then
-    component=$(grep -oE 'testray\.main\.component\.name = "[^"]*"' "$f" | head -1 | sed -E 's/.*= "([^"]*)"/\1/')
-    count=$(grep -cE '^[[:space:]]*test [A-Za-z0-9_]+ \{' "$f")
-    printf "%s\t%s\t%d\n" "${f#./}" "${component:-(none)}" "$count"
-  fi
-done | sort -t$'\t' -k2,2 -k3,3n
-```
+### Triage Report
 
-Save a triage doc at repo root (`<component>-test-triage.md`) following this template:
+A `<component>-test-triage.md` saved at repo root. Lists every `.testcase` tagged with the component, grouped by `testray.main.component.name`, with optional bucket classification per test.
+
+The bucket signals the most likely target layer for a future migration:
+
+| Bucket | Signal |
+| --- | --- |
+| `integration-java` | Ticket changed Java in service/validator/permission layer |
+| `rest-integration` | Ticket changed Java in `*-rest-impl` |
+| `playwright` | Ticket changed only JSP/JS/CSS/fragment files |
+| `needs-review` | Ticket only added the Poshi test, or only language keys |
+| `inconclusive` | Ticket not in the repo's git log |
+| `no-ticket` | No LPS/LPD reference in the description |
+
+To classify a test, look up its LPS/LPD ticket from `@description` in `git log` and inspect which files that ticket actually changed. Classification is optional; when skipped, leave the **Bucket** column blank in the **Test Details** table and the **By Bucket** counts at zero.
+
+The report follows this template:
 
 ````markdown
 # <Component Title> Test Triage Report
@@ -101,24 +106,20 @@ Classification based on `property testray.main.component.name` in each `.testcas
 | <file> | <N> |
 ````
 
-Sort the **Test Details** rows by bucket order (`integration-java`, `rest-integration`, `playwright`, `needs-review`, `inconclusive`, `no-ticket`), then priority descending, then file path and test name. Leave the **Ticket** cell blank when there is none. **Notes** is a short reason taken from the bucket lookup, for example "service/validator/permission impl" or "UI/JSP/frontend fix". The bucket and **Test Details** content is filled in after Step 2; Step 1 alone produces the **Files by Component & Test Count** section and the test enumeration.
+Sort the **Test Details** rows by bucket order (`integration-java`, `rest-integration`, `playwright`, `needs-review`, `inconclusive`, `no-ticket`), then priority descending, then file path and test name. Leave the **Ticket** cell blank when there is none. **Notes** is a short reason taken from the bucket lookup, for example "service/validator/permission impl" or "UI/JSP/frontend fix".
 
-### Step 2 — Optional bucket-classification per test
+### Merge Plan
 
-For each test, look up its LPS/LPD ticket from `@description` in `git log` and see what files the ticket actually changed. Helps decide the target layer later.
+For the file the user picks to attack, present the grouping clearly and **wait for explicit approval before any edit**:
 
-| Bucket | Signal |
-|--------|--------|
-| `integration-java` | Ticket changed Java in service/validator/permission layer |
-| `rest-integration` | Ticket changed Java in `*-rest-impl` |
-| `playwright` | Ticket changed only JSP/JS/CSS/fragment files |
-| `needs-review` | Ticket only added the Poshi test, or only language keys |
-| `inconclusive` | Ticket not in the repo's git log |
-| `no-ticket` | No LPS/LPD reference in the description |
+> **Group A — <Context name>** (N → 1):
+>
+> - Rename `<Keeper>` → `<FinalName>` (commit 1)
+> - Merge `<Source2>` → adds `<assertion>` (commit 2)
+> - Merge `<Source3>` → adds `<assertion>` (commit 3)
+> - … etc
 
-This step is useful but not required for the shrink itself.
-
-### Step 3 — Pick a file and find merge groups
+Pick the **keeper**: the test with the most comprehensive assertions, or the clearest name. The **final name** is usually descriptive of the combined behaviour (e.g., `ContentPerformancePanelInBlogDisplayPage`, `LanguageDropdownInContentPage`), typically different from the keeper's original name.
 
 Start with files showing visually obvious overlap — classic signals from Liferay test names:
 
@@ -129,62 +130,53 @@ Start with files showing visually obvious overlap — classic signals from Lifer
 
 Avoid files with 40+ tests on the first pass — practice on smaller ones first.
 
-#### Merge signals — DO
+#### Merge Signals — DO
 
 - Same setup + same UI surface + different assertion → one test with N assertion tasks.
 - Tests differing only in asset type (blog vs document vs web content) when the panel behaviour being asserted is identical — often fully redundant; propose deletion rather than merge.
 - Tests where the source's assertion is already fully covered in the target — commit still happens, it just deletes the source.
 
-#### Merge signals — DON'T
+#### Merge Signals — DON'T
 
 - Tests with test-level property overrides that differ: `property portal.upstream = "quarantine"`, `property test.liferay.virtual.instance = "false"`, `property test.run.type = "single"` (when not inherited).
 - Tests with special setup (localized URLs, fragment translations, system settings changes, extra page creation).
 - Tests with `@ignore` / `@skip` annotations.
 
-### Step 4 — Plan and get approval
+### Edited Test Files
 
-Never start editing before the user has seen and approved the shrink plan. Present it clearly:
+After approval, apply each operation in the order it appears in the plan:
 
-> **Group A — <Context name>** (N → 1):
-> - Rename `<Keeper>` → `<FinalName>` (commit 1)
-> - Merge `<Source2>` → adds `<assertion>` (commit 2)
-> - Merge `<Source3>` → adds `<assertion>` (commit 3)
-> - ... etc
+- **Rename** — change the keeper's `test <OldName>` to `test <FinalName>` with no other edits.
+- **Merge** — delete the source's `test <Source> { ... }` block and fold its **unique** assertions into the target as new `task` blocks. When the source's assertions are already fully covered by the target, simply delete the source.
 
-Pick the **keeper**: the test with the most comprehensive assertions, or the clearest name. The **final name** is usually descriptive of the combined behaviour (e.g., `ContentPerformancePanelInBlogDisplayPage`, `LanguageDropdownInContentPage`), typically different from the keeper's original name.
+### Per-Merge Commits
 
-### Step 5 — Execute with one commit per operation
-
-For each group, make one commit per source test. Message conventions:
+One commit per operation — never squash. Use the `/commit` skill. Message templates:
 
 - `<TICKET> Rename test <Keeper> to <FinalName>` — pure rename; first commit of the group; no logic change.
 - `<TICKET> Merge test <Source> into <FinalName>` — delete the source test block; add its unique assertions as new `task` blocks in the target.
 
-If a source's assertions are already fully covered by the target, still make the "Merge" commit (it simply deletes the source — documents the shrink).
+The per-merge granularity is exactly what makes the diff reviewable. Do **not** bundle multiple merges into one commit.
 
-Do **not** squash, bundle, or batch these commits. The per-merge granularity is exactly what makes the diff reviewable.
+When the file convention keeps tests alphabetical, add a final `<TICKET> Alphabetic order` commit after all merges.
 
-After each commit:
-```bash
-git add <path>
-git commit -m "<TICKET> Merge test <Source> into <FinalName>"
-```
+### Summary
 
-### Step 6 — Optional cleanup
+After the file is shrunk, report:
 
-- If the file convention keeps tests alphabetical, add a final `<TICKET> Alphabetic order` commit after all merges.
-- If commits come out unsigned despite `commit.gpgsign=true`, the user's SSH signer (1Password, etc.) may have been locked. Re-sign with `git rebase --exec 'git commit --amend --no-edit -S' <base>` — user must approve in their signer.
+- The file shrunk and its `testray.main.component.name`.
+- Before/after test counts.
+- Total commits made (renames + merges + optional cleanups).
+- Tests kept intact and the reason (special setup, differing properties, `@ignore`).
 
-## Anti-patterns to avoid
+## Anti-Patterns
 
-- **Never start editing without an approved plan.** Always present the grouping first.
 - **Never rewrite history on pushed/shared branches** unless the user explicitly asks.
 - **Don't trust the LPS ticket to identify the fix location blindly** — sometimes the ticket only added the Poshi test and the real fix is elsewhere.
 - **Don't drop strong assertions when merging.** When one test uses `AssertTextEquals.assertPartialText("web/<site-path>")` and another uses a weak `AssertVisible value1="http://"`, keep the strong one.
 - **Don't merge tests across different property/setup profiles.** Those properties exist for a reason (flaky environment, quarantined, virtual-instance-specific).
-- **Don't guess the ticket prefix.** Ask if not provided.
 
-## Heuristics learned from prior runs
+## Heuristics
 
 - Identical panel assertions across four asset-type variants (blog / document / widget / content page) are usually overengineered — **one representative often suffices**; propose deletion for the rest instead of merging four tests into four tests.
 - The *keeper* does not have to keep its name. Pick the most comprehensive test as the starting point, then rename it.

--- a/.claude/skills/poshi-shrink/SKILL.md
+++ b/.claude/skills/poshi-shrink/SKILL.md
@@ -20,97 +20,24 @@ A playbook for shrinking a Liferay component's Poshi test suite before migrating
 
 The `@component-name` annotation, passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-knowledge-base`, `portal-commerce`). Ask if missing; do not guess.
 
-Verify the component by enumerating, under `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, every `.testcase` whose `@component-name` matches; abort when none does. The same enumeration feeds the **Triage Report**: per file, capture the path, the `testray.main.component.name` value, and the test-block count, sorted by component then by ascending test count.
+Verify the component by enumerating, under `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, every `.testcase` whose `@component-name` matches; abort when none does. The same enumeration feeds the **Shrink Plan**: per file, capture the path, the `testray.main.component.name` value, and the test-block count.
 
 ## Expected Output
 
-### Triage Report
+### Shrink Plan
 
-A `<component>-test-triage.md` saved at repo root. Lists every `.testcase` tagged with the component, grouped by `testray.main.component.name`, with optional bucket classification per test.
+Build the plan via plan mode (`EnterPlanMode`) using this format:
 
-The bucket signals the most likely target layer for a future migration:
+```markdown
+## Inventory
 
-| Bucket | Signal |
-| --- | --- |
-| `integration-java` | Ticket changed Java in service/validator/permission layer |
-| `rest-integration` | Ticket changed Java in `*-rest-impl` |
-| `playwright` | Ticket changed only JSP/JS/CSS/fragment files |
-| `needs-review` | Ticket only added the Poshi test, or only language keys |
-| `inconclusive` | Ticket not in the repo's git log |
-| `no-ticket` | No LPS/LPD reference in the description |
-
-To classify a test, look up its LPS/LPD ticket from `@description` in `git log` and inspect which files that ticket actually changed. Classification is optional; when skipped, leave the **Bucket** column blank in the **Test Details** table and the **By Bucket** counts at zero.
-
-The report follows this template:
-
-````markdown
-# <Component Title> Test Triage Report
-
-**Scope:** All Poshi tests tagged `@component-name = "<component>"`
-**Date:** YYYY-MM-DD
-**Method:** Enumerated <N> `.testcase` files, parsed <N> test blocks for priority and ticket references, looked up ticket commits in git log, classified buckets by changed file paths.
-
-## Summary
-
-- **Total test blocks:** <N>
-- **Unique tickets referenced:** <N>
-
-### By Bucket
-
-| Bucket | Count | Meaning |
+| File | Test Count | testray.main.component.name |
 | --- | --- | --- |
-| integration-java | <N> | Rewrite as Java integration test against service/validator/permission layer |
-| rest-integration | <N> | Rewrite as REST-layer integration test in `*-rest-test` |
-| playwright | <N> | Keep as functional; migrate to Playwright (not Java-replaceable) |
-| needs-review | <N> | Git log alone not conclusive; must read the test body |
-| inconclusive | <N> | Ticket not in this repo's git history (often LPD-internal) |
-| no-ticket | <N> | Test description has no LPS/LPD reference; must read the test body |
+| <path> | <N> | <component> |
 
-### By Priority
+## Files to Attack
 
-| Priority | Count |
-| --- | --- |
-| 5 | <N> |
-| 4 | <N> |
-| 3 | <N> |
-| 2 | <N> |
-| 1 | <N> |
-
-## Test Details
-
-| File | Test | Priority | Ticket | Bucket | Notes |
-| --- | --- | --- | --- | --- | --- |
-| <file> | <test> | <priority> | <ticket> | <bucket> | <notes> |
-
-## Files by Component & Test Count
-
-Classification based on `property testray.main.component.name` in each `.testcase`. Sorted ascending by test count within each component so small files (easy migration wins) appear first.
-
-### Totals by Component
-
-| Component | Files | Tests |
-| --- | --- | --- |
-| <component> | <N> | <N> |
-| **Total** | **<N>** | **<N>** |
-
-### Quick-win candidates (1–2 tests, <N> files)
-
-| Component | File | Tests |
-| --- | --- | --- |
-| <component> | <file> | <N> |
-
-### <Component Name> (<N> files, <N> tests)
-
-| File | Tests |
-| --- | --- |
-| <file> | <N> |
-````
-
-Sort the **Test Details** rows by bucket order (`integration-java`, `rest-integration`, `playwright`, `needs-review`, `inconclusive`, `no-ticket`), then priority descending, then file path and test name. Leave the **Ticket** cell blank when there is none. **Notes** is a short reason taken from the bucket lookup, for example "service/validator/permission impl" or "UI/JSP/frontend fix".
-
-### Merge Plan
-
-For the file the user picks to attack, present the grouping clearly and **wait for explicit approval before any edit**:
+### <file path> (N → M)
 
 > **Group A — <Context name>** (N → 1):
 >
@@ -119,16 +46,21 @@ For the file the user picks to attack, present the grouping clearly and **wait f
 > - Merge `<Source3>` → adds `<assertion>` (commit 3)
 > - … etc
 
-Pick the **keeper**: the test with the most comprehensive assertions, or the clearest name. The **final name** is usually descriptive of the combined behaviour (e.g., `ContentPerformancePanelInBlogDisplayPage`, `LanguageDropdownInContentPage`), typically different from the keeper's original name.
+### <next file path> (N → M)
 
-Start with files showing visually obvious overlap — classic signals from Liferay test names:
+…
+```
+
+Sort the inventory ascending by test count so small files (easy wins) surface first. Avoid files with 40+ tests on the first pass.
+
+Pick the **keeper** for each group: the test with the most comprehensive assertions, or the clearest name. The **final name** is usually descriptive of the combined behaviour (e.g., `ContentPerformancePanelInBlogDisplayPage`, `LanguageDropdownInContentPage`), typically different from the keeper's original name.
+
+Common merge-worthy signals — classic patterns from Liferay test names:
 
 - Multiple `AuthorNotShowIn<Context>` tests — usually one per panel-context is enough.
 - Multiple `MetricsIconVisibleIn<Context>` + `PanelInformationIn<Context>` — the first checks title+traffic, the second title+URL+language; huge overlap.
 - `CheckAllInfo*` or similar catch-all tests that duplicate specific-field tests.
 - Tests that share the full `setUp` + first N tasks (navigate, create blog, open panel) and differ only in the final assertion.
-
-Avoid files with 40+ tests on the first pass — practice on smaller ones first.
 
 #### Merge Signals — DO
 
@@ -144,7 +76,7 @@ Avoid files with 40+ tests on the first pass — practice on smaller ones first.
 
 ### Edited Test Files
 
-After approval, apply each operation in the order it appears in the plan:
+After `ExitPlanMode` returns the user's approval, apply each operation in the order it appears in the plan:
 
 - **Rename** — change the keeper's `test <OldName>` to `test <FinalName>` with no other edits.
 - **Merge** — delete the source's `test <Source> { ... }` block and fold its **unique** assertions into the target as new `task` blocks. When the source's assertions are already fully covered by the target, simply delete the source.

--- a/.claude/skills/poshi-shrink/SKILL.md
+++ b/.claude/skills/poshi-shrink/SKILL.md
@@ -74,21 +74,12 @@ Common merge-worthy signals — classic patterns from Liferay test names:
 - Tests with special setup (localized URLs, fragment translations, system settings changes, extra page creation).
 - Tests with `@ignore` / `@skip` annotations.
 
-### Edited Test Files
+### Shrunk Test Files
 
-After `ExitPlanMode` returns the user's approval, apply each operation in the order it appears in the plan:
+After `ExitPlanMode` returns the user's approval, apply each operation in the order it appears in the plan and commit after each one with the `/commit` skill — one commit per operation, never squashed. The per-merge granularity is exactly what makes the diff reviewable.
 
-- **Rename** — change the keeper's `test <OldName>` to `test <FinalName>` with no other edits.
-- **Merge** — delete the source's `test <Source> { ... }` block and fold its **unique** assertions into the target as new `task` blocks. When the source's assertions are already fully covered by the target, simply delete the source.
-
-### Per-Merge Commits
-
-One commit per operation — never squash. Use the `/commit` skill. Message templates:
-
-- `<TICKET> Rename test <Keeper> to <FinalName>` — pure rename; first commit of the group; no logic change.
-- `<TICKET> Merge test <Source> into <FinalName>` — delete the source test block; add its unique assertions as new `task` blocks in the target.
-
-The per-merge granularity is exactly what makes the diff reviewable. Do **not** bundle multiple merges into one commit.
+- **Rename** — change the keeper's `test <OldName>` to `test <FinalName>` with no other edits. Commit message: `<TICKET> Rename test <Keeper> to <FinalName>`.
+- **Merge** — delete the source's `test <Source> { ... }` block and fold its **unique** assertions into the target as new `task` blocks. When the source's assertions are already fully covered by the target, simply delete the source. Commit message: `<TICKET> Merge test <Source> into <FinalName>`.
 
 When the file convention keeps tests alphabetical, add a final `<TICKET> Alphabetic order` commit after all merges.
 

--- a/.claude/skills/poshi-shrink/SKILL.md
+++ b/.claude/skills/poshi-shrink/SKILL.md
@@ -53,7 +53,7 @@ Build the plan via plan mode (`EnterPlanMode`) using this format:
 
 Sort the inventory ascending by test count so small files (easy wins) surface first. Avoid files with 40+ tests on the first pass.
 
-Pick the **keeper** for each group: the test with the most comprehensive assertions, or the clearest name. The **final name** is usually descriptive of the combined behaviour (e.g., `ContentPerformancePanelInBlogDisplayPage`, `LanguageDropdownInContentPage`), typically different from the keeper's original name.
+Pick the **keeper** for each group: the test with the most comprehensive assertions, even when its name is awkward — the keeper does not have to keep its name. The **final name** describes the combined behaviour (e.g., `ContentPerformancePanelInBlogDisplayPage`, `LanguageDropdownInContentPage`) and is typically different from the keeper's original name.
 
 Common merge-worthy signals — classic patterns from Liferay test names:
 
@@ -65,7 +65,7 @@ Common merge-worthy signals — classic patterns from Liferay test names:
 #### Merge Signals — DO
 
 - Same setup + same UI surface + different assertion → one test with N assertion tasks.
-- Tests differing only in asset type (blog vs document vs web content) when the panel behaviour being asserted is identical — often fully redundant; propose deletion rather than merge.
+- Tests differing only in asset type (blog vs document vs widget vs content page) when the panel behaviour being asserted is identical — one representative usually suffices; propose deletion for the rest rather than merging four tests into four.
 - Tests where the source's assertion is already fully covered in the target — commit still happens, it just deletes the source.
 
 #### Merge Signals — DON'T
@@ -79,7 +79,7 @@ Common merge-worthy signals — classic patterns from Liferay test names:
 After `ExitPlanMode` returns the user's approval, apply each operation in the order it appears in the plan and commit after each one with the `/commit` skill — one commit per operation, never squashed. The per-merge granularity is exactly what makes the diff reviewable.
 
 - **Rename** — change the keeper's `test <OldName>` to `test <FinalName>` with no other edits. Commit message: `<TICKET> Rename test <Keeper> to <FinalName>`.
-- **Merge** — delete the source's `test <Source> { ... }` block and fold its **unique** assertions into the target as new `task` blocks. When the source's assertions are already fully covered by the target, simply delete the source. Commit message: `<TICKET> Merge test <Source> into <FinalName>`.
+- **Merge** — delete the source's `test <Source> { ... }` block and fold its **unique** assertions into the target as new `task` blocks. When the source's assertions are already fully covered by the target, simply delete the source. When the same condition is asserted at different strengths (e.g., `AssertTextEquals.assertPartialText("web/<site-path>")` vs the weaker `AssertVisible value1="http://"`), keep the stronger one. Commit message: `<TICKET> Merge test <Source> into <FinalName>`.
 
 When the file convention keeps tests alphabetical, add a final `<TICKET> Alphabetic order` commit after all merges.
 
@@ -91,16 +91,3 @@ After the file is shrunk, report:
 - Before/after test counts.
 - Total commits made (renames + merges + optional cleanups).
 - Tests kept intact and the reason (special setup, differing properties, `@ignore`).
-
-## Anti-Patterns
-
-- **Never rewrite history on pushed/shared branches** unless the user explicitly asks.
-- **Don't trust the LPS ticket to identify the fix location blindly** — sometimes the ticket only added the Poshi test and the real fix is elsewhere.
-- **Don't drop strong assertions when merging.** When one test uses `AssertTextEquals.assertPartialText("web/<site-path>")` and another uses a weak `AssertVisible value1="http://"`, keep the strong one.
-- **Don't merge tests across different property/setup profiles.** Those properties exist for a reason (flaky environment, quarantined, virtual-instance-specific).
-
-## Heuristics
-
-- Identical panel assertions across four asset-type variants (blog / document / widget / content page) are usually overengineered — **one representative often suffices**; propose deletion for the rest instead of merging four tests into four tests.
-- The *keeper* does not have to keep its name. Pick the most comprehensive test as the starting point, then rename it.
-- When a merge target already has an assertion the source also has, the merge commit is still a valid "documents-that-this-was-redundant" commit.

--- a/.claude/skills/poshi-shrink/SKILL.md
+++ b/.claude/skills/poshi-shrink/SKILL.md
@@ -18,7 +18,7 @@ A playbook for shrinking a Liferay component's Poshi test suite before migrating
 
 ### Component Name
 
-The `@component-name` annotation, passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-commerce`, `portal-content-management`). Ask if missing; do not guess.
+The `@component-name` annotation, passed as `${ARGUMENTS}` (e.g., `portal-analytics-cloud`, `portal-commerce`, `portal-content-management`). When `${ARGUMENTS}` is empty, scan `.testcase` files under `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, list the distinct `@component-name` values found, and ask the user to pick one. Do not guess.
 
 Verify the component by enumerating, under `portal-web/test/functional/com/liferay/portalweb/tests/enduser/`, every `.testcase` whose `@component-name` matches; abort when none does. The same enumeration feeds the **Shrink Plan**: per file, capture the path, the `testray.main.component.name` value, and the test-block count.
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88576

## What Is Being Fixed

Liferay's Poshi test suite has accumulated overlapping tests over the years — multiple tests covering the same setup and UI surface, often differing only in the final assertion. Reducing that redundancy is a prerequisite to migrating functional coverage to Playwright, Java integration, or unit layers.

## How It Is Being Fixed

Adds a `poshi-shrink` Claude Code skill that takes a `@component-name`, builds a rename/merge plan in plan mode (gated by `ExitPlanMode`), and applies each operation to the `.testcase` files with one commit per change via `/commit`.

## Why Are There No Tests?

The pull request only changes documentation under `.claude/skills/poshi-shrink/` — the `SKILL.md` playbook plus its frontmatter. There is no executable code to test.