### PR TITLE
LPD-92392 Resolve audience source without parsing its criteria

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-api/bnd.bnd
+++ b/modules/apps/analytics/analytics-cms-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Analytics CMS REST API
 Bundle-SymbolicName: com.liferay.analytics.cms.rest.api
-Bundle-Version: 4.3.5
+Bundle-Version: 4.4.0
 Export-Package:\
 	com.liferay.analytics.cms.rest.dto.v1_0,\
 	com.liferay.analytics.cms.rest.resource.v1_0

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/dto/v1_0/packageinfo
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.6.0
+version 2.7.0

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/resource/v1_0/packageinfo
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/segments/segments-api/bnd.bnd
+++ b/modules/apps/segments/segments-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Segments API
 Bundle-SymbolicName: com.liferay.segments.api
-Bundle-Version: 34.0.1
+Bundle-Version: 34.1.0
 Export-Package:\
 	com.liferay.segments,\
 	com.liferay.segments.configuration,\

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/context/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/context/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
@@ -536,6 +536,10 @@ public class SegmentsEntryLocalServiceImpl
 	}
 
 	private String _getSource(String criteria, String source) {
+		if (SegmentsEntryConstants.SOURCE_AUDIENCE.equals(source)) {
+			return source;
+		}
+
 		if (Validator.isNotNull(criteria)) {
 			Criteria deserializedCriteria = CriteriaSerializer.deserialize(
 				criteria);

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/servlet/test/GetAudiencesServletTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/servlet/test/GetAudiencesServletTest.java
@@ -159,7 +159,7 @@ public class GetAudiencesServletTest {
 		String[] expectedAttributeNames = {
 			"browser_name", "browser_version", "device_type", "geolocation",
 			"ip_geocoder_country", "language", "last_sign_in_date",
-			"local_date", "local_time", "pathname", "referrer_url",
+			"local_date", "local_time", "pathname", "referrer",
 			"request_parameters", "signed_in", "time_zone", "user_agent", "url"
 		};
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92392

## What Is Being Fixed

Adding or updating an audience from the Audiences portlet failed with a JSON syntax error. Audiences persist their raw criteria filter string instead of the serialized Criteria envelope, but the source-resolution logic in SegmentsEntryLocalServiceImpl still tried to deserialize it. The GetAudiencesServlet integration test also expected an outdated "referrer_url" attribute name.

## How It Is Being Fixed

SegmentsEntryLocalServiceImpl now returns the audience source directly without deserializing the criteria, since audiences are never referred. The integration test is updated to expect the current "referrer" attribute mapping. The analytics CMS REST API and segments API bundle versions are bumped as baselines.

## Why Are There No Tests?

The audience-source fix is covered by the existing integration tests UpdateSegmentsEntryMVCCommandTest and GetAudiencesServletTest, which now pass; the remaining changes are a test adaptation and API version baselines.

## PR Check

**pr-check: PASS** — tested on `954925a3dff881954c6fcf933bcdb4e2f32429df`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "954925a3dff881954c6fcf933bcdb4e2f32429df"} -->